### PR TITLE
ci: Add PHPCS workflow with inline PR annotations

### DIFF
--- a/.github/workflows/phpcs.yml
+++ b/.github/workflows/phpcs.yml
@@ -42,7 +42,7 @@ jobs:
           ./vendor/bin/phpcs
           --standard=WordPress-Extra,WordPress-Docs
           --extensions=php
-          --ignore=*/index.php
+          --ignore=*/index.php,plugins/akismet/*,plugins/hello.php
           --report=checkstyle
           plugins/
           | cs2pr


### PR DESCRIPTION
Runs WordPress-Extra and WordPress-Docs rulesets against themes/, plugins/, and mu-plugins/ on all PRs targeting main. Uses cs2pr to surface violations as inline annotations on changed files.
Close #6 