### PR TITLE
fix: validate theme directory exists before activation (#43)

### DIFF
--- a/wordpress-local.sh
+++ b/wordpress-local.sh
@@ -256,6 +256,14 @@ activate_theme() {
         exit 1
     fi
 
+    if [ ! -d "themes/$theme_slug" ]; then
+        print_error "Theme not found: themes/$theme_slug"
+        echo ""
+        echo "Available themes:"
+        ls -1 themes/
+        exit 1
+    fi
+
     print_header "Activating Theme: $theme_slug"
 
     docker-compose exec wordpress wp theme activate "$theme_slug" --allow-root


### PR DESCRIPTION
## Summary
- Adds a directory existence check to `activate_theme()` in `wordpress-local.sh` so mistyped theme slugs produce a clear error before hitting Docker/WP-CLI.
- Lists available themes on failure and uses `print_error` for consistency with the rest of the script.

Closes #43

## Test plan
- [ ] `./wordpress-local.sh activate-theme typo-theme` → prints `Theme not found: themes/typo-theme` and lists available themes, exits 1
- [ ] `./wordpress-local.sh activate-theme` (no arg) → still prints the usage error
- [ ] `./wordpress-local.sh activate-theme <valid-theme>` → activates normally via Docker

🤖 Generated with [Claude Code](https://claude.com/claude-code)