### PR TITLE
test: add unit tests for rgb_to_hex() (#44)

### DIFF
--- a/tests/canva-fse/rgb-to-hex.bats
+++ b/tests/canva-fse/rgb-to-hex.bats
@@ -1,0 +1,41 @@
+#!/usr/bin/env bats
+# Tests for the rgb_to_hex() helper in scripts/canva-fse/parse-canva-export.sh
+# Unit tests — no Docker, no fixtures, no filesystem.
+
+load '../test_helper'
+
+SCRIPT="${PROJECT_ROOT}/scripts/canva-fse/parse-canva-export.sh"
+
+# The source script has a top-level `case` that exits 1 on no args, so plain
+# `source` is not safe here. Extract just rgb_to_hex and eval it.
+eval "$(sed -n '/^rgb_to_hex() {/,/^}/p' "$SCRIPT")"
+
+@test "rgb_to_hex: pure red" {
+    result=$(rgb_to_hex "rgb(255, 0, 0)")
+    [ "$result" = "#ff0000" ]
+}
+
+@test "rgb_to_hex: pure green" {
+    result=$(rgb_to_hex "rgb(0, 255, 0)")
+    [ "$result" = "#00ff00" ]
+}
+
+@test "rgb_to_hex: pure blue" {
+    result=$(rgb_to_hex "rgb(0, 0, 255)")
+    [ "$result" = "#0000ff" ]
+}
+
+@test "rgb_to_hex: black with no spaces" {
+    result=$(rgb_to_hex "rgb(0,0,0)")
+    [ "$result" = "#000000" ]
+}
+
+@test "rgb_to_hex: white" {
+    result=$(rgb_to_hex "rgb(255, 255, 255)")
+    [ "$result" = "#ffffff" ]
+}
+
+@test "rgb_to_hex: mid-gray" {
+    result=$(rgb_to_hex "rgb(128, 128, 128)")
+    [ "$result" = "#808080" ]
+}


### PR DESCRIPTION
## Summary
- Adds `tests/canva-fse/rgb-to-hex.bats` covering the six cases from the issue (pure red/green/blue, black without spaces, white, mid-gray).
- Extracts the function via `sed`/`eval` rather than `source`, because the script's top-level `case` exits 1 when sourced without args. No Docker, fixtures, or filesystem writes needed.

Closes #44

## Test plan
- [ ] `bats tests/canva-fse/rgb-to-hex.bats` passes all 6 tests
- [ ] Tests run without Docker

🤖 Generated with [Claude Code](https://claude.com/claude-code)