### PR TITLE
feat: add remote deployment agent for staging and production

### DIFF
--- a/.claude/CUSTOM-AGENTS-GUIDE.md
+++ b/.claude/CUSTOM-AGENTS-GUIDE.md
@@ -1,7 +1,7 @@
 # Custom Agents Reference Guide
 
-**Last Updated:** 2026-03-25
-**Total Custom Agents:** 49
+**Last Updated:** 2026-05-06
+**Total Custom Agents:** 50
 **Location:** `.claude/agents/`
 
 This guide categorizes all custom agents by relevance to WordPress FSE theme development.
@@ -87,6 +87,12 @@ These agents directly support WordPress block theme development:
 - **Purpose:** WordPress plugin development
 - **Use for:** Custom post types, REST API endpoints, admin pages, Gutenberg blocks, plugin architecture
 - **WordPress relevance:** High - full plugin development lifecycle
+
+### **deployment-agent** (NEW)
+- **Purpose:** Remote deployment of themes and plugins to staging and production
+- **Use for:** SSH/SFTP atomic releases, Git push-to-deploy, remote WP-CLI orchestration, pre-deployment validation, rollback, multi-environment configuration, deploy notifications
+- **WordPress relevance:** Critical - production-grade release workflow with rollback safety
+- **Backed by:** `scripts/remote-deployment/` and `.claude/config/deployment/`
 
 ---
 

--- a/.claude/agents/deployment-agent.md
+++ b/.claude/agents/deployment-agent.md
@@ -1,0 +1,238 @@
+---
+name: deployment-agent
+description: Use this agent to deploy WordPress themes and plugins to remote staging or production environments. Specializes in SSH/SFTP deploys with atomic releases, Git-based push-to-deploy workflows, remote WP-CLI orchestration, pre-deployment validation, automatic rollback, and multi-environment configuration. Examples - <example>Context: User is ready to ship a new theme version. user: 'Deploy the latest theme to staging.' assistant: 'I'll use deployment-agent to run pre-deploy checks and deploy to staging via SSH.' <commentary>Remote deployments require validation, atomic release management, and rollback safety — this agent handles all of it.</commentary></example> <example>Context: A production deploy went wrong. user: 'Roll production back to the previous release.' assistant: 'I'll use deployment-agent to swap the current symlink to the prior release on production.' <commentary>Rollback is destructive on the remote and benefits from the agent's structured logging and notifications.</commentary></example> <example>Context: User wants push-to-deploy. user: 'Set up git-based deploys for our staging host.' assistant: 'I'll use deployment-agent to wire the remote bare repo and run a push.' <commentary>The agent already knows the config schema and can validate before pushing.</commentary></example>
+tools: Read, Write, Bash, Grep, Glob, TodoWrite, TaskOutput, AskUserQuestion
+model: opus
+permissionMode: bypassPermissions
+---
+
+You are a WordPress remote deployment specialist. You move themes, plugins, and
+must-use plugins from this repository onto staging and production hosts using
+the scripts in `scripts/remote-deployment/`. You enforce a non-negotiable
+discipline: pre-deployment checks always run, every deploy is reversible, and
+every action is logged.
+
+## Primary Responsibilities
+
+### 1. Multi-environment configuration
+
+All environment definitions live in `.claude/config/deployment/<env>.yml`.
+Templates for staging and production are checked into the repo as
+`*.example.yml`. Real configs (with SSH keys, webhook URLs, host details) are
+gitignored.
+
+Schema highlights:
+
+| Key | Purpose |
+|---|---|
+| `method` | `ssh`, `git`, or `wpcli` — selects the primary deployment path |
+| `allow_dirty` | production refuses dirty worktrees unless this is `true` |
+| `activate_theme` / `activate_plugins` | post-deploy WP-CLI activation |
+| `keep_releases` | how many SSH release dirs to retain for rollback |
+| `ssh.*`, `remote_root`, `wp_content_path` | SSH/SFTP deployment |
+| `git.remote_url`, `git.remote_branch` | Git push-to-deploy |
+| `wp_cli.ssh`, `wp_cli.path` | remote WP-CLI orchestration |
+| `notify.slack_webhook` / `discord_webhook` / `webhook_url` / `email_to` | notifications |
+
+The full schema reference lives in `.claude/config/deployment/README.md`. When
+asked to set up a new environment, copy the relevant `*.example.yml`, fill it
+in, and verify with `--dry-run`.
+
+### 2. Pre-deployment validation gate
+
+`scripts/remote-deployment/pre-deploy-checks.sh` runs five checks against the
+deployable target before a single byte leaves the local machine:
+
+1. **Structure validation** — `style.css`/`theme.json` for themes; PHP entry
+   file for plugins.
+2. **PHP security scan** — invokes `scripts/wordpress/security-scan.sh` for
+   SQL injection, missing escapes, missing nonces, missing capability checks.
+3. **Coding standards** — runs `scripts/wordpress/check-coding-standards.sh`
+   (PHPCS with WordPress rulesets). Treated as a warning by default; promote
+   to a failure with `--strict`.
+4. **Dependency scan** — runs `scripts/security-audit/scan-dependencies.sh`.
+   Any reported vulnerability blocks the deploy.
+5. **Artifact validation** — refuses to ship `node_modules/`, `.env` files,
+   or bundles over 50 MB.
+
+Any failure exits non-zero and aborts the orchestrator. Never bypass this gate
+on production. Use `--skip-checks` only for emergency hotfixes and explain to
+the user that you have done so.
+
+### 3. Three deployment methods
+
+#### a) SSH/SFTP (`ssh-deploy.sh`) — default
+
+Capistrano-style atomic releases over `rsync -az --delete` with a structured
+exclusion list (no `.git/`, `node_modules/`, `vendor/`, tests, or `.env`).
+
+```
+<remote_root>/
+  releases/
+    <release-id>/        ← uploaded source
+    <previous-id>/       ← retained, used for rollback
+  current -> releases/<release-id>
+```
+
+`wp-content/themes`, `wp-content/plugins`, and `wp-content/mu-plugins` are
+linked to `<remote_root>/current/...` so flipping the symlink swaps the entire
+deployment atomically. Old releases beyond `keep_releases` are pruned.
+
+#### b) Git-based (`git-deploy.sh`)
+
+Pushes the local ref (default `HEAD`) to a bare repo on the remote. The
+remote's `post-receive` hook is responsible for updating the working tree —
+this is the standard Pantheon / WP Engine / DIY pattern. The script refuses to
+push from a dirty worktree so what's deployed always matches a committed sha.
+
+#### c) Remote WP-CLI (`wpcli-deploy.sh`)
+
+Used both as a primary method (when only WP-CLI orchestration is needed —
+e.g. activating a theme that's already on disk) and automatically after SSH/Git
+deploys when `wp_cli.ssh` is configured. It runs `wp theme activate`,
+`wp plugin activate`, `wp core update-db`, `wp cache flush`, and
+`wp rewrite flush --hard` against the remote install via WP-CLI's native
+`--ssh` alias support.
+
+### 4. Rollback (`rollback.sh`)
+
+For SSH deploys, rollback re-points `current` at a previous release — this is
+sub-second and atomic. Without `--to`, the script picks the most recent
+release that isn't the active one. `--list` shows available targets without
+mutating anything.
+
+For Git deploys, rollback force-pushes (`--force-with-lease`) the previous
+remote commit. This is destructive on the remote branch and requires explicit
+user confirmation in any session.
+
+When the orchestrator runs with `--auto-rollback`, a failure in either the
+upload step or the post-deploy WP-CLI step triggers an automatic rollback and
+emits a `rollback` notification.
+
+### 5. Logging and notifications
+
+Every run writes a structured log to `.claude/logs/deployment/<run-id>.log`
+with timestamps, levels, and `EVENT` records that downstream tooling can grep.
+The log path is also printed at the end of every successful deploy.
+
+`notify.sh` fans out to Slack, Discord, generic JSON webhooks, and email. Each
+channel is optional — empty values in the config are skipped. Notifications
+are sent on `started`, `success`, `failed`, and `rollback` so a single deploy
+produces a coherent thread of events in the team's chat.
+
+## Standard Workflows
+
+### A. First-time environment setup
+
+```
+1. Confirm the user's target hostname, SSH user, and key location.
+2. Copy <env>.example.yml to <env>.yml and edit values.
+3. Run a dry-run:
+     ./scripts/remote-deployment/deploy.sh --env <env> --dry-run
+4. Show the user the dry-run output and ask for confirmation.
+5. Run a real deploy of just one theme to validate end-to-end:
+     ./scripts/remote-deployment/deploy.sh --env <env> --target theme:<slug>
+6. Verify the site renders, then deploy the rest if needed.
+```
+
+### B. Routine staging deploy
+
+```
+1. Verify branch state (no production deploys from feature branches).
+2. Run pre-deployment checks explicitly first to surface issues fast:
+     ./scripts/remote-deployment/pre-deploy-checks.sh --target all
+3. Deploy:
+     ./scripts/remote-deployment/deploy.sh --env staging
+4. Capture the printed log path and release id in the conversation.
+5. If user asks for QA, suggest visual-qa-agent against the staging URL.
+```
+
+### C. Production deploy
+
+```
+1. Confirm the source ref is committed AND merged to main (or the deploy
+   branch). Production refuses dirty worktrees by default.
+2. Run a dry-run first; show the user the plan; require explicit go-ahead.
+3. Deploy with auto-rollback on:
+     ./scripts/remote-deployment/deploy.sh --env production --auto-rollback
+4. Watch for the success notification. If it doesn't arrive within the
+   expected window, check the log file before declaring success.
+5. Post the release id to the user.
+```
+
+### D. Rollback after a bad deploy
+
+```
+1. Run with --list first so the user can see the available targets:
+     ./scripts/remote-deployment/rollback.sh --env <env> --list
+2. Confirm the target with the user.
+3. Execute:
+     ./scripts/remote-deployment/rollback.sh --env <env> --to <release-id>
+4. Verify the site is healthy.
+5. Open an issue to track the root cause; do not move on without it.
+```
+
+## Integration
+
+**Invoked by:**
+- Manual user request to deploy, roll back, or set up a new environment.
+- Trigger keywords: "deploy", "ship", "push to staging", "push to production",
+  "rollback", "release", "promote".
+
+**Works with:**
+- `security-audit-agent` — should run a clean dependency scan before any
+  production deploy. The pre-deploy gate already runs this, but for major
+  releases run it directly first to address findings ahead of time.
+- `test-writer-fixer` — verify the test suite passes before promoting a
+  release candidate.
+- `visual-qa-agent` — run against the staging URL after deploying to catch
+  visual regressions before promoting to production.
+- `wp-environment-manager` — for local sanity-checking a theme before any
+  remote deploy.
+- `devops-automator` — for wiring CI/CD pipelines that call
+  `scripts/remote-deployment/deploy.sh` on tag/branch events.
+
+**Outputs:**
+- Per-run log under `.claude/logs/deployment/`
+- Notifications to the channels configured in the env's `notify.*` section
+- A printable release id (timestamp-shortsha) usable in PR comments and
+  incident timelines
+
+## Rules
+
+- **NEVER deploy to production without a clean worktree** unless the config
+  explicitly sets `allow_dirty: true` AND the user has approved that. The
+  orchestrator enforces this; do not work around it.
+- **NEVER skip pre-deployment checks on production.** If the user insists,
+  refuse and explain the risk. For staging, only skip with explicit
+  acknowledgement.
+- **ALWAYS run a dry-run before the first deploy to a new environment.** The
+  dry-run prints the resolved config so misconfigurations surface before any
+  remote action.
+- **ALWAYS show the user the release id and the log file path** at the end of
+  each deploy. They are the primary hooks for rollback and post-mortem.
+- **ALWAYS run `--list` before a rollback** so the user can confirm what is
+  about to be restored. Rollback is fast, but rolling back to the wrong
+  release wastes everyone's time.
+- **ALWAYS prefer `--auto-rollback` for production.** Failure mid-flight on
+  production is exactly when human reaction time is slowest.
+- **NEVER commit a real `*.yml` file to `.claude/config/deployment/`.** They
+  contain SSH keys and webhook URLs. The repository's `.gitignore` enforces
+  this; do not work around it.
+- **ALWAYS use root-level paths.** This project uses `themes/`, `plugins/`,
+  `mu-plugins/` at the project root, not `wp-content/themes/`. The deploy
+  scripts already follow this convention; do not point them elsewhere.
+- **PREFER pnpm over npm** when running any pre-deploy build steps. The
+  global Claude Code preference applies here too.
+
+## Error Recovery
+
+| Symptom | Likely cause | Action |
+|---|---|---|
+| `Required command not found: rsync` | local environment missing tooling | install rsync (or run from a host that has it); deploy will not proceed otherwise |
+| `Configuration not found for environment 'X'` | no `X.yml` in config dir | copy the matching `*.example.yml` and fill it in |
+| `Pre-deployment checks failed` | one of the five gate checks failed | read the log, fix the underlying issue, retry; do not `--skip-checks` to mask it |
+| `WP-CLI cannot reach <ssh>` | bad ssh alias, wrong path, or WP not installed | confirm `wp_cli.ssh` and `wp_cli.path`; try `wp --ssh=<alias> core is-installed` manually |
+| `Working tree has uncommitted changes` (git method) | local edits not yet committed | commit/stash first; never override |
+| Deploy succeeded but site shows old content | OPcache or page cache on remote | run `wpcli-deploy.sh` standalone to flush; check Varnish/CDN |
+| Symlink swap appears successful but site is broken | new release missing files; rsync exclusion too aggressive | rollback first, then investigate locally |

--- a/.claude/config/deployment/README.md
+++ b/.claude/config/deployment/README.md
@@ -1,0 +1,58 @@
+# Deployment Configuration
+
+Per-environment configuration for the remote deployment scripts in
+`scripts/remote-deployment/`. The files in this directory are loaded by
+`scripts/remote-deployment/lib/config-loader.sh`.
+
+## Conventions
+
+- `*.example.yml` — committed templates, safe to share publicly.
+- `*.yml` — real environment configs, **gitignored** (see project root
+  `.gitignore`). Never commit secrets.
+- File name (minus the extension) is the environment name passed via
+  `--env`. So `staging.yml` is selected by `--env staging`.
+
+## Setting up an environment
+
+```bash
+cp .claude/config/deployment/staging.example.yml \
+   .claude/config/deployment/staging.yml
+$EDITOR .claude/config/deployment/staging.yml
+```
+
+Then verify the file parses cleanly with a dry run:
+
+```bash
+./scripts/remote-deployment/deploy.sh --env staging --dry-run
+```
+
+## Schema reference
+
+| Key | Required for | Notes |
+|---|---|---|
+| `method` | all | `ssh`, `git`, or `wpcli` |
+| `allow_dirty` | production safety | default false on production |
+| `activate_theme` | optional | run `wp theme activate` after deploy |
+| `activate_plugins` | optional | comma-separated list |
+| `keep_releases` | ssh | release directories retained for rollback |
+| `ssh.host` / `ssh.user` / `ssh.port` / `ssh.key` | ssh | connection details |
+| `remote_root` | ssh | base directory; releases live under `<root>/releases/` |
+| `wp_content_path` | ssh | absolute path to wp-content on the remote |
+| `git.remote_url` / `git.remote_branch` | git | bare repo + branch deployed |
+| `git.remote_name` | git | local remote alias (default `deploy-<env>`) |
+| `wp_cli.ssh` / `wp_cli.path` | wpcli or post-deploy WP-CLI | WP-CLI `--ssh` alias |
+| `notify.slack_webhook` | optional | incoming webhook URL |
+| `notify.discord_webhook` | optional | webhook URL |
+| `notify.webhook_url` | optional | generic JSON POST endpoint |
+| `notify.email_to` / `notify.email_from` | optional | requires `mail` |
+
+## Secrets
+
+Real environment files contain SSH keys, webhook URLs, and host details that
+must not enter version control. The repository's `.gitignore` excludes any
+`*.yml` file in this directory other than `*.example.yml`. If you fork the
+project, double-check the ignore rule before adding a new config.
+
+For shared team environments, store the production config in a secrets manager
+(1Password, Vault, AWS Secrets Manager) and check it out into this directory
+during deploy bootstrap.

--- a/.claude/config/deployment/production.example.yml
+++ b/.claude/config/deployment/production.example.yml
@@ -1,0 +1,46 @@
+# Example production deployment configuration.
+#
+# Copy this file to `production.yml`. Production has stricter defaults than
+# staging — auto-rollback is recommended and dirty worktrees are refused
+# unless allow_dirty is explicitly true.
+
+method: ssh
+
+# Production refuses to deploy from a dirty worktree by default. Override only
+# if you accept that what's deployed may not match any committed ref.
+allow_dirty: false
+
+activate_theme: my-fse-theme
+
+# Larger production sites usually want a longer rollback window.
+keep_releases: 10
+
+# ─── SSH / SFTP ────────────────────────────────────────────────────────────
+ssh:
+  host: example.com
+  user: deploy
+  port: 22
+  key: ~/.ssh/production_deploy_ed25519
+
+remote_root: /var/www/example.com/deploy
+wp_content_path: /var/www/example.com/htdocs/wp-content
+
+# ─── Git-based deployment ──────────────────────────────────────────────────
+git:
+  remote_url: ssh://deploy@example.com/var/git/site.git
+  remote_branch: production
+  remote_name: deploy-production
+
+# ─── Remote WP-CLI orchestration ───────────────────────────────────────────
+wp_cli:
+  ssh: deploy@example.com:22/var/www/example.com/htdocs
+  path: /var/www/example.com/htdocs
+
+# ─── Notifications ─────────────────────────────────────────────────────────
+# Production deploys should be visible. Wire at least one alert channel.
+notify:
+  slack_webhook: ""
+  discord_webhook: ""
+  webhook_url: ""
+  email_to: ""
+  email_from: ""

--- a/.claude/config/deployment/staging.example.yml
+++ b/.claude/config/deployment/staging.example.yml
@@ -1,0 +1,58 @@
+# Example staging deployment configuration.
+#
+# Copy this file to `staging.yml` and fill in real values. The file is then
+# read by `scripts/remote-deployment/deploy.sh --env staging`.
+#
+# Every key is parsed into DEPLOY_CFG_<UPPER_PATH> at runtime, e.g.
+#   ssh.host  →  DEPLOY_CFG_SSH_HOST
+#   notify.slack_webhook  →  DEPLOY_CFG_NOTIFY_SLACK_WEBHOOK
+
+# Primary deployment method: ssh, git, or wpcli.
+method: ssh
+
+# Production-only safety. Leave false on staging.
+allow_dirty: true
+
+# Optional. Activated automatically after a successful SSH/Git deploy when
+# WP-CLI credentials below are configured.
+activate_theme: my-fse-theme
+# activate_plugins: my-plugin,another-plugin
+
+# How many releases to keep on the remote host (SSH method only).
+keep_releases: 5
+
+# ─── SSH / SFTP ────────────────────────────────────────────────────────────
+ssh:
+  host: staging.example.com
+  user: deploy
+  port: 22
+  # Optional. Falls back to ~/.ssh/id_rsa via the agent if blank.
+  key: ~/.ssh/staging_deploy_ed25519
+
+# Absolute paths on the remote host.
+remote_root: /var/www/staging.example.com/deploy
+wp_content_path: /var/www/staging.example.com/htdocs/wp-content
+
+# ─── Git-based deployment ──────────────────────────────────────────────────
+# Used only when method: git. The remote URL points at a bare repo on the
+# host, with a post-receive hook that updates the working tree.
+git:
+  remote_url: ssh://deploy@staging.example.com/var/git/site.git
+  remote_branch: staging
+  remote_name: deploy-staging
+
+# ─── Remote WP-CLI orchestration ───────────────────────────────────────────
+# Triggered after SSH/Git deploys when set. Uses WP-CLI's --ssh alias format:
+#   user@host[:port][/path]
+wp_cli:
+  ssh: deploy@staging.example.com:22/var/www/staging.example.com/htdocs
+  path: /var/www/staging.example.com/htdocs
+
+# ─── Notifications ─────────────────────────────────────────────────────────
+# Each channel is optional. Empty/missing values are skipped.
+notify:
+  slack_webhook: ""
+  discord_webhook: ""
+  webhook_url: ""
+  email_to: ""
+  email_from: ""

--- a/.gitignore
+++ b/.gitignore
@@ -6,8 +6,16 @@
 !.claude/commands/
 !.claude/hooks/
 !.claude/validation/
+!.claude/config/
 !.claude/*.md
 !.claude/settings.json
+
+# Deployment configs: example templates are tracked; real env files are not.
+.claude/config/deployment/*.yml
+.claude/config/deployment/*.yaml
+!.claude/config/deployment/*.example.yml
+!.claude/config/deployment/*.example.yaml
+!.claude/config/deployment/README.md
 
 # Claude Code temporary/user-specific files (explicitly ignored)
 .claude/logs/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -279,9 +279,9 @@ This project uses a lean, WordPress-optimized plugin configuration with 6 plugin
 
 ---
 
-### Custom Agents (49 Total)
+### Custom Agents (50 Total)
 
-49 specialized agents: 24 WordPress-focused development agents plus 25 generic cross-domain agents (meta/ops, business, marketing/social, engineering). Key WordPress agents include `frontend-developer`, `plugin-developer`, `test-writer-fixer`, `ui-designer`, `figma-fse-converter`, `canva-fse-converter`, `security-audit-agent`. Key generic agents include `agent-expert`, `backend-architect`, `migration-specialist`, `content-creator`, `devops-automator`.
+50 specialized agents: 25 WordPress-focused development agents plus 25 generic cross-domain agents (meta/ops, business, marketing/social, engineering). Key WordPress agents include `frontend-developer`, `plugin-developer`, `test-writer-fixer`, `ui-designer`, `figma-fse-converter`, `canva-fse-converter`, `security-audit-agent`, `deployment-agent`. Key generic agents include `agent-expert`, `backend-architect`, `migration-specialist`, `content-creator`, `devops-automator`.
 
 Agents are invoked automatically based on task context.
 
@@ -463,7 +463,7 @@ Result: themes/[theme-name]/ ready for WordPress
 - All plugins serve WordPress development
 
 **Agent Philosophy:**
-- 49 custom agents available (24 WordPress-focused + 25 generic cross-domain)
+- 50 custom agents available (25 WordPress-focused + 25 generic cross-domain)
 - Agents invoked contextually by Claude Code
 - No action required - automatic selection
 
@@ -537,6 +537,17 @@ gh auth status                # Check authentication
 ./scripts/security-audit/create-issues.sh               # Create GitHub issues for critical findings (stdin)
 ```
 
+**Remote Deployment:**
+```bash
+./scripts/remote-deployment/deploy.sh --env staging --dry-run            # Plan a deploy
+./scripts/remote-deployment/deploy.sh --env staging                      # Deploy to staging
+./scripts/remote-deployment/deploy.sh --env production --auto-rollback   # Production with safety net
+./scripts/remote-deployment/pre-deploy-checks.sh --target all            # Run validation gate only
+./scripts/remote-deployment/rollback.sh --env <env> --list               # List rollback targets
+./scripts/remote-deployment/rollback.sh --env <env> --to <release-id>    # Roll back
+```
+Configs live in `.claude/config/deployment/<env>.yml` (gitignored). Templates: `*.example.yml`.
+
 **Visual QA & Quality Scripts:**
 ```bash
 ./scripts/visual-diff.js [actual] [expected]     # Pixel-level screenshot comparison
@@ -562,5 +573,5 @@ gh auth status                # Check authentication
 
 ---
 
-**Last Updated:** 2026-03-25
-**Architecture Status:** ✅ Lean, WordPress-optimized configuration (6 plugins + 49 agents)
+**Last Updated:** 2026-05-06
+**Architecture Status:** ✅ Lean, WordPress-optimized configuration (6 plugins + 50 agents)

--- a/scripts/remote-deployment/README.md
+++ b/scripts/remote-deployment/README.md
@@ -1,0 +1,63 @@
+# Remote Deployment Scripts
+
+Push WordPress themes and plugins from this repository to staging and
+production hosts. The scripts here are invoked by the `deployment-agent`
+(see `.claude/agents/deployment-agent.md`) but are also safe to call directly.
+
+## Layout
+
+| Script | Purpose |
+|---|---|
+| `deploy.sh` | Orchestrator. Runs pre-checks → deploy → WP-CLI → notifications. |
+| `pre-deploy-checks.sh` | Structure, security, PHPCS, dependency, artifact validation. |
+| `ssh-deploy.sh` | Atomic rsync-over-ssh deploy with capistrano-style release dirs. |
+| `git-deploy.sh` | Push current ref to a remote bare repo (post-receive hook deploys). |
+| `wpcli-deploy.sh` | Runs `wp theme activate`, `core update-db`, cache flush remotely. |
+| `rollback.sh` | Switch `current` symlink back to a prior release, or revert git ref. |
+| `notify.sh` | Slack / Discord / generic webhook / email notifications. |
+| `lib/common.sh` | Shared logging, release-id, run-id helpers. |
+| `lib/config-loader.sh` | YAML config parser (PyYAML preferred, awk fallback). |
+
+## Quick start
+
+1. Copy a config template and fill in your environment values:
+
+   ```bash
+   cp .claude/config/deployment/staging.example.yml \
+      .claude/config/deployment/staging.yml
+   $EDITOR .claude/config/deployment/staging.yml
+   ```
+
+2. Plan the deploy:
+
+   ```bash
+   ./scripts/remote-deployment/deploy.sh --env staging --dry-run
+   ```
+
+3. Ship it:
+
+   ```bash
+   ./scripts/remote-deployment/deploy.sh --env staging
+   ```
+
+4. If something looks wrong, roll back:
+
+   ```bash
+   ./scripts/remote-deployment/rollback.sh --env staging
+   ```
+
+## Logs
+
+Every run writes a structured log to
+`.claude/logs/deployment/<run-id>.log`. The path is also printed at the end of
+each successful deploy so it can be attached to PR comments or incident notes.
+
+## Exit codes
+
+All top-level scripts use the same convention:
+
+| Code | Meaning |
+|---|---|
+| 0 | Success |
+| 1 | Operational failure (check log; rollback may have run) |
+| 2 | Invocation/usage error |

--- a/scripts/remote-deployment/deploy.sh
+++ b/scripts/remote-deployment/deploy.sh
@@ -1,0 +1,196 @@
+#!/usr/bin/env bash
+# Remote deployment orchestrator.
+#
+# This is the entry point used by the deployment-agent and humans alike. It
+# loads an environment config, runs pre-deployment checks, dispatches the
+# requested deploy method, optionally runs remote WP-CLI orchestration, and
+# fans out notifications. On failure it can trigger an automatic rollback
+# when the config asks for it.
+#
+# Usage:
+#   deploy.sh --env <name> [--method ssh|git|wpcli] [--target SPEC]
+#             [--ref REF] [--dry-run] [--skip-checks] [--auto-rollback]
+#             [--release-id ID] [--actor NAME] [--message TEXT]
+#
+#   --env NAME       required. environment config from .claude/config/deployment/
+#   --method MODE    overrides DEPLOY_CFG_METHOD (ssh, git, wpcli)
+#   --target SPEC    theme:<slug>, plugin:<slug>, or all (ssh method only)
+#   --ref REF        git ref to push (git method only; default HEAD)
+#   --dry-run        print plan without executing
+#   --skip-checks    skip pre-deployment validation (NOT recommended)
+#   --auto-rollback  on failure, automatically restore previous release
+#
+# Exit codes:
+#   0 — success
+#   1 — deployment failed (rollback may have run)
+#   2 — invocation error
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/lib/common.sh"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/lib/config-loader.sh"
+
+ENV_NAME=""
+METHOD=""
+TARGET="all"
+REF="HEAD"
+DRY_RUN=false
+SKIP_CHECKS=false
+AUTO_ROLLBACK=false
+RELEASE_ID=""
+ACTOR="${USER:-unknown}"
+MESSAGE=""
+
+usage() {
+  sed -n '4,22p' "$0" | sed 's/^# \{0,1\}//'
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --env) ENV_NAME="$2"; shift 2 ;;
+    --method) METHOD="$2"; shift 2 ;;
+    --target) TARGET="$2"; shift 2 ;;
+    --ref) REF="$2"; shift 2 ;;
+    --dry-run) DRY_RUN=true; shift ;;
+    --skip-checks) SKIP_CHECKS=true; shift ;;
+    --auto-rollback) AUTO_ROLLBACK=true; shift ;;
+    --release-id) RELEASE_ID="$2"; shift 2 ;;
+    --actor) ACTOR="$2"; shift 2 ;;
+    --message) MESSAGE="$2"; shift 2 ;;
+    -h|--help) usage; exit 0 ;;
+    *) log_error "Unknown argument: $1"; usage; exit 2 ;;
+  esac
+done
+
+[[ -n "$ENV_NAME" ]] || { log_error "--env is required"; exit 2; }
+
+load_environment_config "$ENV_NAME"
+METHOD="${METHOD:-${DEPLOY_CFG_METHOD:-ssh}}"
+RELEASE_ID="${RELEASE_ID:-$(generate_release_id)}"
+export DEPLOY_RELEASE_ID="$RELEASE_ID"
+export DEPLOY_ACTOR="$ACTOR"
+
+# Production safety: refuse deploys from a non-clean tree unless explicitly
+# overridden by the config. This prevents shipping uncommitted local hacks.
+if [[ "$ENV_NAME" == "production" ]] && [[ "${DEPLOY_CFG_ALLOW_DIRTY:-false}" != "true" ]]; then
+  if [[ -n "$(git -C "$PROJECT_ROOT" status --porcelain 2>/dev/null)" ]]; then
+    log_error "Refusing to deploy to production with uncommitted changes."
+    log_error "Commit/stash, or set allow_dirty: true in production.yml to override."
+    exit 1
+  fi
+fi
+
+banner "Deploy → $ENV_NAME (method=$METHOD, target=$TARGET, release=$RELEASE_ID)"
+log_event "deploy_plan" "env=$ENV_NAME method=$METHOD target=$TARGET release=$RELEASE_ID actor=$ACTOR"
+
+if $DRY_RUN; then
+  cat <<EOF
+[DRY RUN]
+  environment   : $ENV_NAME
+  config file   : ${DEPLOY_CFG_SOURCE_FILE:-}
+  method        : $METHOD
+  target        : $TARGET
+  ref           : $REF (git only)
+  release id    : $RELEASE_ID
+  log file      : $DEPLOY_LOG_FILE
+  actor         : $ACTOR
+  pre-checks    : $($SKIP_CHECKS && echo skipped || echo enabled)
+  auto-rollback : $AUTO_ROLLBACK
+EOF
+  log_event "deploy_dry_run_complete" "env=$ENV_NAME"
+  exit 0
+fi
+
+# Notify-on-start ------------------------------------------------------------
+"$SCRIPT_DIR/notify.sh" --env "$ENV_NAME" --status started \
+  --release-id "$RELEASE_ID" --actor "$ACTOR" \
+  --message "${MESSAGE:-Deployment in progress}" || true
+
+# 1. Pre-deployment checks ---------------------------------------------------
+if ! $SKIP_CHECKS; then
+  log_step "Running pre-deployment checks"
+  if ! "$SCRIPT_DIR/pre-deploy-checks.sh" --target "$TARGET"; then
+    log_error "Pre-deployment checks failed — aborting"
+    "$SCRIPT_DIR/notify.sh" --env "$ENV_NAME" --status failed \
+      --release-id "$RELEASE_ID" --actor "$ACTOR" \
+      --message "Pre-deployment checks failed" || true
+    exit 1
+  fi
+else
+  log_warn "Skipping pre-deployment checks (--skip-checks)"
+fi
+
+# 2. Dispatch primary deploy method ------------------------------------------
+deploy_failed=0
+case "$METHOD" in
+  ssh)
+    "$SCRIPT_DIR/ssh-deploy.sh" --env "$ENV_NAME" --target "$TARGET" \
+      --release-id "$RELEASE_ID" || deploy_failed=$?
+    ;;
+  git)
+    "$SCRIPT_DIR/git-deploy.sh" --env "$ENV_NAME" --ref "$REF" || deploy_failed=$?
+    ;;
+  wpcli)
+    "$SCRIPT_DIR/wpcli-deploy.sh" --env "$ENV_NAME" \
+      ${DEPLOY_CFG_ACTIVATE_THEME:+--theme "$DEPLOY_CFG_ACTIVATE_THEME"} \
+      || deploy_failed=$?
+    ;;
+  *)
+    log_error "Unsupported method: $METHOD"
+    exit 2
+    ;;
+esac
+
+if [[ $deploy_failed -ne 0 ]]; then
+  log_error "Primary deploy step failed (exit $deploy_failed)"
+  if $AUTO_ROLLBACK; then
+    log_warn "Triggering automatic rollback"
+    "$SCRIPT_DIR/rollback.sh" --env "$ENV_NAME" --method "$METHOD" || true
+    "$SCRIPT_DIR/notify.sh" --env "$ENV_NAME" --status rollback \
+      --release-id "$RELEASE_ID" --actor "$ACTOR" \
+      --message "Auto-rollback after failed deploy" || true
+  fi
+  "$SCRIPT_DIR/notify.sh" --env "$ENV_NAME" --status failed \
+    --release-id "$RELEASE_ID" --actor "$ACTOR" \
+    --message "${MESSAGE:-Deploy failed at $METHOD step}" || true
+  exit 1
+fi
+
+# 3. Optional remote WP-CLI orchestration ------------------------------------
+# Only run when the SSH/Git method was used AND the config provides WP-CLI
+# settings. If the user explicitly chose --method wpcli, that ran above.
+if [[ "$METHOD" != "wpcli" && -n "${DEPLOY_CFG_WP_CLI_SSH:-}" ]]; then
+  log_step "Running post-deploy WP-CLI orchestration"
+  wp_args=(--env "$ENV_NAME")
+  [[ -n "${DEPLOY_CFG_ACTIVATE_THEME:-}" ]] && wp_args+=(--theme "$DEPLOY_CFG_ACTIVATE_THEME")
+  if [[ -n "${DEPLOY_CFG_ACTIVATE_PLUGINS:-}" ]]; then
+    IFS=',' read -ra plist <<< "$DEPLOY_CFG_ACTIVATE_PLUGINS"
+    for p in "${plist[@]}"; do wp_args+=(--plugin "$p"); done
+  fi
+  if ! "$SCRIPT_DIR/wpcli-deploy.sh" "${wp_args[@]}"; then
+    log_error "Post-deploy WP-CLI orchestration failed"
+    if $AUTO_ROLLBACK; then
+      "$SCRIPT_DIR/rollback.sh" --env "$ENV_NAME" --method "$METHOD" || true
+      "$SCRIPT_DIR/notify.sh" --env "$ENV_NAME" --status rollback \
+        --release-id "$RELEASE_ID" --actor "$ACTOR" \
+        --message "Auto-rollback after WP-CLI failure" || true
+    fi
+    "$SCRIPT_DIR/notify.sh" --env "$ENV_NAME" --status failed \
+      --release-id "$RELEASE_ID" --actor "$ACTOR" \
+      --message "WP-CLI post-deploy step failed" || true
+    exit 1
+  fi
+fi
+
+# 4. Success --------------------------------------------------------------------
+log_ok "Deployment complete: $ENV_NAME release=$RELEASE_ID"
+log_event "deploy_ok" "env=$ENV_NAME release=$RELEASE_ID method=$METHOD"
+
+"$SCRIPT_DIR/notify.sh" --env "$ENV_NAME" --status success \
+  --release-id "$RELEASE_ID" --actor "$ACTOR" \
+  --message "${MESSAGE:-Deploy successful}" || true
+
+log_info "Log: $DEPLOY_LOG_FILE"

--- a/scripts/remote-deployment/git-deploy.sh
+++ b/scripts/remote-deployment/git-deploy.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# Git-based deployment.
+#
+# Pushes the current branch (or a named ref) to a remote bare repo. The remote
+# is expected to have a post-receive hook that updates the deployment checkout
+# — this is the standard "git push to deploy" model used by hosts like Pantheon,
+# WP Engine, and many bespoke setups.
+#
+# Usage:
+#   git-deploy.sh --env <name> [--ref <git-ref>]
+#
+# Required config keys:
+#   GIT_REMOTE_URL     — e.g. ssh://deploy@host/var/git/site.git
+#   GIT_REMOTE_BRANCH  — e.g. main, production
+#   GIT_REMOTE_NAME    — local remote alias (default: deploy-<env>)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/lib/common.sh"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/lib/config-loader.sh"
+
+ENV_NAME=""
+REF="HEAD"
+
+usage() {
+  cat <<EOF
+Usage: $(basename "$0") --env <name> [--ref <git-ref>]
+
+  --env NAME    environment config to load
+  --ref REF     local ref to push (default: HEAD)
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --env) ENV_NAME="$2"; shift 2 ;;
+    --ref) REF="$2"; shift 2 ;;
+    -h|--help) usage; exit 0 ;;
+    *) log_error "Unknown argument: $1"; usage; exit 2 ;;
+  esac
+done
+
+[[ -n "$ENV_NAME" ]] || { log_error "--env is required"; exit 2; }
+
+require_cmd git || exit 2
+load_environment_config "$ENV_NAME"
+
+REMOTE_URL="$(require_cfg GIT_REMOTE_URL)" || exit 1
+REMOTE_BRANCH="$(require_cfg GIT_REMOTE_BRANCH)" || exit 1
+REMOTE_NAME="${DEPLOY_CFG_GIT_REMOTE_NAME:-deploy-$ENV_NAME}"
+
+banner "Git deploy → $REMOTE_URL ($REMOTE_BRANCH)"
+log_event "git_deploy_start" "env=$ENV_NAME remote=$REMOTE_URL branch=$REMOTE_BRANCH"
+
+# Configure or refresh the remote alias --------------------------------------
+if git -C "$PROJECT_ROOT" remote get-url "$REMOTE_NAME" >/dev/null 2>&1; then
+  log_step "Updating remote '$REMOTE_NAME'"
+  git -C "$PROJECT_ROOT" remote set-url "$REMOTE_NAME" "$REMOTE_URL"
+else
+  log_step "Adding remote '$REMOTE_NAME'"
+  git -C "$PROJECT_ROOT" remote add "$REMOTE_NAME" "$REMOTE_URL"
+fi
+
+# Reject deploys with a dirty worktree to keep what's deployed in sync with HEAD
+if [[ -n "$(git -C "$PROJECT_ROOT" status --porcelain)" ]]; then
+  log_error "Working tree has uncommitted changes — commit or stash before deploying"
+  log_event "git_deploy_failed" "reason=dirty_worktree env=$ENV_NAME"
+  exit 1
+fi
+
+LOCAL_SHA="$(git -C "$PROJECT_ROOT" rev-parse "$REF")"
+log_info "Deploying $REF ($LOCAL_SHA) → $REMOTE_NAME/$REMOTE_BRANCH"
+
+log_step "Pushing to remote"
+git -C "$PROJECT_ROOT" push --atomic "$REMOTE_NAME" "$REF:refs/heads/$REMOTE_BRANCH"
+
+log_ok "Git deploy complete: $LOCAL_SHA"
+log_event "git_deploy_ok" "env=$ENV_NAME sha=$LOCAL_SHA"
+printf '%s\n' "$LOCAL_SHA"

--- a/scripts/remote-deployment/lib/common.sh
+++ b/scripts/remote-deployment/lib/common.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# Shared helpers for the remote-deployment scripts.
+#
+# Provides:
+#   * Coloured logging that always goes to stderr
+#   * Project-root resolution
+#   * Release-id (timestamp + short git sha) generation
+#   * Run-id correlation across log/notify/rollback steps
+#   * Standard log-file path used by every script in this directory
+
+# Resolve the project root once and cache it. Works regardless of the caller's CWD.
+if [[ -z "${PROJECT_ROOT:-}" ]]; then
+  PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+  export PROJECT_ROOT
+fi
+
+DEPLOY_LOG_DIR="${DEPLOY_LOG_DIR:-$PROJECT_ROOT/.claude/logs/deployment}"
+mkdir -p "$DEPLOY_LOG_DIR"
+
+# Generate a stable run-id once per orchestration. Child scripts inherit it.
+if [[ -z "${DEPLOY_RUN_ID:-}" ]]; then
+  DEPLOY_RUN_ID="$(date -u +"%Y%m%dT%H%M%SZ")-$$"
+  export DEPLOY_RUN_ID
+fi
+
+DEPLOY_LOG_FILE="${DEPLOY_LOG_FILE:-$DEPLOY_LOG_DIR/$DEPLOY_RUN_ID.log}"
+export DEPLOY_LOG_FILE
+
+# ANSI codes are suppressed when stderr is not a TTY (CI logs, file capture).
+if [[ -t 2 ]]; then
+  _C_RESET=$'\033[0m'; _C_RED=$'\033[31m'; _C_YEL=$'\033[33m'
+  _C_GRN=$'\033[32m'; _C_CYAN=$'\033[36m'; _C_DIM=$'\033[2m'
+else
+  _C_RESET=""; _C_RED=""; _C_YEL=""; _C_GRN=""; _C_CYAN=""; _C_DIM=""
+fi
+
+_log_raw() {
+  local level="$1" colour="$2" msg="$3"
+  local ts
+  ts="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+  printf '%s[%s]%s %s%-5s%s %s\n' \
+    "$_C_DIM" "$ts" "$_C_RESET" "$colour" "$level" "$_C_RESET" "$msg" >&2
+  printf '[%s] %-5s %s\n' "$ts" "$level" "$msg" >> "$DEPLOY_LOG_FILE"
+}
+
+log_info()  { _log_raw "INFO"  "$_C_CYAN" "$*"; }
+log_ok()    { _log_raw "OK"    "$_C_GRN"  "$*"; }
+log_warn()  { _log_raw "WARN"  "$_C_YEL"  "$*"; }
+log_error() { _log_raw "ERROR" "$_C_RED"  "$*"; }
+log_step()  { _log_raw "STEP"  "$_C_CYAN" "==> $*"; }
+
+# Emit a single structured event to the log file. Used by notify.sh and the
+# orchestrator so external tooling can tail the log and react to milestones.
+log_event() {
+  local event="$1"; shift
+  local payload="${*:-}"
+  local ts
+  ts="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+  printf '[%s] EVENT %s %s\n' "$ts" "$event" "$payload" >> "$DEPLOY_LOG_FILE"
+}
+
+# Compute a release identifier that combines a timestamp with the short SHA of
+# HEAD. Falls back to "nogit" when the worktree is detached from a repo.
+generate_release_id() {
+  local ts sha
+  ts="$(date -u +"%Y%m%dT%H%M%SZ")"
+  if sha="$(git -C "$PROJECT_ROOT" rev-parse --short=8 HEAD 2>/dev/null)"; then
+    printf '%s-%s' "$ts" "$sha"
+  else
+    printf '%s-nogit' "$ts"
+  fi
+}
+
+require_cmd() {
+  local cmd="$1"
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    log_error "Required command not found: $cmd"
+    return 1
+  fi
+}
+
+# Print a banner around significant phases so the log is scannable.
+banner() {
+  local msg="$*"
+  local line
+  line="$(printf '%*s' "${#msg}" '' | tr ' ' '=')"
+  log_info "$line"
+  log_info "$msg"
+  log_info "$line"
+}

--- a/scripts/remote-deployment/lib/config-loader.sh
+++ b/scripts/remote-deployment/lib/config-loader.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+# Loads a YAML environment configuration file and exports its contents as
+# DEPLOY_CFG_* environment variables for the rest of the deployment pipeline.
+#
+# Configurations live in `.claude/config/deployment/<env>.yml`. See the example
+# files in that directory for the full schema.
+
+# shellcheck source=lib/common.sh
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/common.sh"
+
+PYTHON_BIN=""
+if python3 --version >/dev/null 2>&1; then
+  PYTHON_BIN="python3"
+elif python --version >/dev/null 2>&1; then
+  PYTHON_BIN="python"
+fi
+
+# Locate the config file for the named environment (staging/production/...).
+# Honours $DEPLOY_CONFIG_DIR for non-default locations.
+resolve_config_path() {
+  local env_name="$1"
+  local config_dir="${DEPLOY_CONFIG_DIR:-$PROJECT_ROOT/.claude/config/deployment}"
+  local path="$config_dir/$env_name.yml"
+  if [[ ! -f "$path" ]]; then
+    path="$config_dir/$env_name.yaml"
+  fi
+  if [[ ! -f "$path" ]]; then
+    log_error "Configuration not found for environment '$env_name' in $config_dir"
+    log_error "Copy $config_dir/${env_name}.example.yml to ${env_name}.yml and edit."
+    return 1
+  fi
+  printf '%s' "$path"
+}
+
+# Parse YAML using PyYAML when available, otherwise a shallow native fallback
+# that handles the documented schema (no anchors, no flow-style mappings).
+_parse_yaml_python() {
+  local file="$1"
+  "$PYTHON_BIN" - "$file" <<'PY'
+import os
+import sys
+try:
+    import yaml
+except ImportError:
+    sys.stderr.write("[ERROR] PyYAML not installed; falling back to native parser\n")
+    sys.exit(2)
+
+with open(sys.argv[1], "r", encoding="utf-8") as fh:
+    data = yaml.safe_load(fh) or {}
+
+def emit(prefix, value):
+    if isinstance(value, dict):
+        for key, child in value.items():
+            emit(f"{prefix}_{key.upper()}" if prefix else key.upper(), child)
+    elif isinstance(value, list):
+        joined = ",".join(str(item) for item in value)
+        print(f"DEPLOY_CFG_{prefix}={joined}")
+    else:
+        rendered = "" if value is None else str(value)
+        rendered = rendered.replace("\\", "\\\\").replace('"', '\\"')
+        print(f'DEPLOY_CFG_{prefix}="{rendered}"')
+
+emit("", data)
+PY
+}
+
+# Native fallback: only handles two-space indentation, scalar values, and inline
+# comma lists. Sufficient for the example config schema we ship.
+_parse_yaml_native() {
+  local file="$1"
+  awk '
+    function trim(s) { gsub(/^[ \t\r]+|[ \t\r]+$/, "", s); return s }
+    function emit(key, value) {
+      gsub(/\\/, "\\\\", value)
+      gsub(/"/, "\\\"", value)
+      printf("DEPLOY_CFG_%s=\"%s\"\n", toupper(key), value)
+    }
+    BEGIN { depth = 0 }
+    /^[[:space:]]*#/ { next }
+    /^[[:space:]]*$/ { next }
+    {
+      line = $0
+      sub(/[[:space:]]*#.*$/, "", line)
+      indent = match(line, /[^ ]/) - 1
+      level = int(indent / 2)
+      while (depth > level) { depth--; delete stack[depth] }
+      key = line; sub(/:.*$/, "", key); key = trim(key)
+      value = line; sub(/^[^:]*:/, "", value); value = trim(value)
+      stack[level] = key
+      depth = level + 1
+      if (value == "" || value == "{}" || value == "[]") next
+      gsub(/^"|"$|^'\''|'\''$/, "", value)
+      full = ""
+      for (i = 0; i < depth; i++) {
+        if (full == "") full = stack[i]
+        else full = full "_" stack[i]
+      }
+      emit(full, value)
+    }
+  ' "$file"
+}
+
+# Public entry point. Sources parsed values into the current shell, prefixed
+# with DEPLOY_CFG_<PATH_TO_KEY>.
+load_environment_config() {
+  local env_name="$1"
+  local path
+  path="$(resolve_config_path "$env_name")" || return 1
+
+  log_info "Loading config: $path"
+
+  local rendered=""
+  local mode="native"
+  if [[ -n "$PYTHON_BIN" ]]; then
+    rendered="$(_parse_yaml_python "$path" 2>/dev/null || true)"
+    if [[ -n "$rendered" ]]; then
+      mode="python"
+    fi
+  fi
+  if [[ -z "$rendered" ]]; then
+    rendered="$(_parse_yaml_native "$path")"
+  fi
+
+  log_info "Parsed config using $mode parser"
+
+  while IFS= read -r line; do
+    [[ -z "$line" ]] && continue
+    eval "export $line"
+  done <<< "$rendered"
+
+  export DEPLOY_CFG_ENVIRONMENT="$env_name"
+  export DEPLOY_CFG_SOURCE_FILE="$path"
+}
+
+# Convenience getter that errors out when a required field is missing.
+require_cfg() {
+  local name="$1"
+  local var="DEPLOY_CFG_${name}"
+  if [[ -z "${!var:-}" ]]; then
+    log_error "Required config key missing: $name (env $DEPLOY_CFG_ENVIRONMENT)"
+    return 1
+  fi
+  printf '%s' "${!var}"
+}

--- a/scripts/remote-deployment/notify.sh
+++ b/scripts/remote-deployment/notify.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+# Send deployment notifications to Slack, Discord, generic webhooks, and email.
+#
+# Usage:
+#   notify.sh --env <name> --status (started|success|failed|rollback)
+#             [--message "free text"] [--release-id ID] [--actor NAME]
+#
+# Notification targets are read from the environment config:
+#   NOTIFY_SLACK_WEBHOOK
+#   NOTIFY_DISCORD_WEBHOOK
+#   NOTIFY_WEBHOOK_URL          (generic JSON POST)
+#   NOTIFY_EMAIL_TO             (comma-separated list, requires `mail`)
+#   NOTIFY_EMAIL_FROM
+#
+# Channels with no value configured are silently skipped, so a single config
+# can target one or many integrations.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/lib/common.sh"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/lib/config-loader.sh"
+
+ENV_NAME=""
+STATUS=""
+MESSAGE=""
+RELEASE_ID="${DEPLOY_RELEASE_ID:-}"
+ACTOR="${DEPLOY_ACTOR:-${USER:-unknown}}"
+
+usage() {
+  cat <<EOF
+Usage: $(basename "$0") --env NAME --status STATUS [--message TEXT]
+                        [--release-id ID] [--actor NAME]
+
+  --status   one of: started, success, failed, rollback
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --env) ENV_NAME="$2"; shift 2 ;;
+    --status) STATUS="$2"; shift 2 ;;
+    --message) MESSAGE="$2"; shift 2 ;;
+    --release-id) RELEASE_ID="$2"; shift 2 ;;
+    --actor) ACTOR="$2"; shift 2 ;;
+    -h|--help) usage; exit 0 ;;
+    *) log_error "Unknown argument: $1"; usage; exit 2 ;;
+  esac
+done
+
+[[ -n "$ENV_NAME" && -n "$STATUS" ]] || { usage; exit 2; }
+
+load_environment_config "$ENV_NAME"
+
+case "$STATUS" in
+  started)  EMOJI=":rocket:";        COLOUR="#3aa3e3" ;;
+  success)  EMOJI=":white_check_mark:"; COLOUR="#36a64f" ;;
+  failed)   EMOJI=":x:";              COLOUR="#cc0000" ;;
+  rollback) EMOJI=":rewind:";         COLOUR="#dd9900" ;;
+  *) log_error "Invalid --status: $STATUS"; exit 2 ;;
+esac
+
+TITLE="$EMOJI WordPress deploy [$ENV_NAME] — $STATUS"
+BODY="actor: $ACTOR"
+[[ -n "$RELEASE_ID" ]] && BODY="$BODY"$'\n'"release: $RELEASE_ID"
+[[ -n "$MESSAGE"   ]] && BODY="$BODY"$'\n'"$MESSAGE"
+
+log_step "Sending notifications: $TITLE"
+log_event "notify" "env=$ENV_NAME status=$STATUS release=${RELEASE_ID:-none}"
+
+post_json() {
+  local url="$1" payload="$2"
+  if command -v curl >/dev/null 2>&1; then
+    curl -fsS -m 10 -H 'Content-Type: application/json' -d "$payload" "$url" >/dev/null \
+      || log_warn "Webhook POST failed: $url"
+  else
+    log_warn "curl not installed — skipping webhook"
+  fi
+}
+
+# Slack ----------------------------------------------------------------------
+if [[ -n "${DEPLOY_CFG_NOTIFY_SLACK_WEBHOOK:-}" ]]; then
+  read -r -d '' payload <<JSON || true
+{"attachments":[{"color":"$COLOUR","title":"$TITLE","text":$(printf '%s' "$BODY" | python3 -c 'import json,sys;print(json.dumps(sys.stdin.read()))' 2>/dev/null || printf '"%s"' "${BODY//\"/\\\"}")}]}
+JSON
+  post_json "$DEPLOY_CFG_NOTIFY_SLACK_WEBHOOK" "$payload"
+fi
+
+# Discord --------------------------------------------------------------------
+if [[ -n "${DEPLOY_CFG_NOTIFY_DISCORD_WEBHOOK:-}" ]]; then
+  content="$TITLE"$'\n'"$BODY"
+  payload=$(printf '{"content": %s}' "$(printf '%s' "$content" | python3 -c 'import json,sys;print(json.dumps(sys.stdin.read()))' 2>/dev/null || printf '"%s"' "${content//\"/\\\"}")")
+  post_json "$DEPLOY_CFG_NOTIFY_DISCORD_WEBHOOK" "$payload"
+fi
+
+# Generic webhook ------------------------------------------------------------
+if [[ -n "${DEPLOY_CFG_NOTIFY_WEBHOOK_URL:-}" ]]; then
+  payload=$(python3 -c "
+import json, os
+print(json.dumps({
+  'environment': os.environ['ENV_NAME'],
+  'status': os.environ['STATUS'],
+  'release': os.environ.get('RELEASE_ID') or None,
+  'actor': os.environ['ACTOR'],
+  'message': os.environ.get('MESSAGE') or None,
+}))" 2>/dev/null || printf '{"environment":"%s","status":"%s"}' "$ENV_NAME" "$STATUS")
+  ENV_NAME="$ENV_NAME" STATUS="$STATUS" RELEASE_ID="$RELEASE_ID" ACTOR="$ACTOR" MESSAGE="$MESSAGE" \
+    post_json "$DEPLOY_CFG_NOTIFY_WEBHOOK_URL" "$payload"
+fi
+
+# Email ----------------------------------------------------------------------
+if [[ -n "${DEPLOY_CFG_NOTIFY_EMAIL_TO:-}" ]]; then
+  if command -v mail >/dev/null 2>&1; then
+    printf '%s\n' "$BODY" | mail -s "$TITLE" \
+      ${DEPLOY_CFG_NOTIFY_EMAIL_FROM:+-r "$DEPLOY_CFG_NOTIFY_EMAIL_FROM"} \
+      "$DEPLOY_CFG_NOTIFY_EMAIL_TO" || log_warn "mail send failed"
+  else
+    log_warn "mail command not installed — skipping email notification"
+  fi
+fi
+
+log_ok "Notifications dispatched"

--- a/scripts/remote-deployment/pre-deploy-checks.sh
+++ b/scripts/remote-deployment/pre-deploy-checks.sh
@@ -1,0 +1,199 @@
+#!/usr/bin/env bash
+# Pre-deployment validation gate.
+#
+# Usage:
+#   pre-deploy-checks.sh [--target theme:<name>|plugin:<name>|all] [--strict]
+#
+# Runs:
+#   1. Theme structure validation (style.css, theme.json, required templates)
+#   2. WordPress security scan (PHP code)
+#   3. WordPress coding standards (PHPCS)
+#   4. Dependency vulnerability scan
+#   5. Build artifact validation (no node_modules, no .env, bundle size)
+#
+# Exit codes:
+#   0 — all checks passed
+#   1 — at least one blocking failure
+#   2 — script invocation error
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/lib/common.sh"
+
+TARGET="all"
+STRICT=false
+FAILURES=0
+
+usage() {
+  cat <<EOF
+Usage: $(basename "$0") [--target SPEC] [--strict]
+
+  --target SPEC   theme:<name>, plugin:<name>, or 'all' (default)
+  --strict        treat warnings as failures
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --target) TARGET="$2"; shift 2 ;;
+    --strict) STRICT=true; shift ;;
+    -h|--help) usage; exit 0 ;;
+    *) log_error "Unknown argument: $1"; usage; exit 2 ;;
+  esac
+done
+
+banner "Pre-deployment checks (target=$TARGET strict=$STRICT)"
+
+run_check() {
+  local name="$1"; shift
+  log_step "$name"
+  if "$@"; then
+    log_ok "$name passed"
+  else
+    log_error "$name FAILED"
+    FAILURES=$((FAILURES + 1))
+  fi
+}
+
+run_warn_check() {
+  local name="$1"; shift
+  log_step "$name"
+  if "$@"; then
+    log_ok "$name passed"
+  else
+    log_warn "$name produced warnings"
+    if $STRICT; then FAILURES=$((FAILURES + 1)); fi
+  fi
+}
+
+# Resolve the list of theme/plugin source paths to validate.
+resolve_targets() {
+  local kind="${TARGET%%:*}"
+  local name="${TARGET#*:}"
+  case "$kind" in
+    theme)   printf '%s\n' "$PROJECT_ROOT/themes/$name" ;;
+    plugin)  printf '%s\n' "$PROJECT_ROOT/plugins/$name" ;;
+    all|"")
+      [[ -d "$PROJECT_ROOT/themes" ]]  && find "$PROJECT_ROOT/themes"  -mindepth 1 -maxdepth 1 -type d
+      [[ -d "$PROJECT_ROOT/plugins" ]] && find "$PROJECT_ROOT/plugins" -mindepth 1 -maxdepth 1 -type d
+      ;;
+    *) log_error "Unknown target kind: $kind"; return 2 ;;
+  esac
+}
+
+mapfile -t SOURCE_PATHS < <(resolve_targets)
+
+if [[ ${#SOURCE_PATHS[@]} -eq 0 ]]; then
+  log_warn "No deployable sources found for target '$TARGET'"
+  exit 0
+fi
+
+# 1. Theme/plugin structure validation -----------------------------------------
+check_structure() {
+  local failed=0
+  for src in "${SOURCE_PATHS[@]}"; do
+    [[ -d "$src" ]] || continue
+    local name
+    name="$(basename "$src")"
+    if [[ "$src" == */themes/* ]]; then
+      [[ -f "$src/style.css"  ]] || { log_error "$name: missing style.css"; failed=1; }
+      [[ -f "$src/theme.json" ]] || { log_warn  "$name: missing theme.json (FSE themes require this)"; }
+    elif [[ "$src" == */plugins/* ]]; then
+      if ! ls "$src"/*.php >/dev/null 2>&1; then
+        log_error "$name: no PHP entry file"; failed=1
+      fi
+    fi
+  done
+  return $failed
+}
+
+# 2. PHP security scan ---------------------------------------------------------
+check_security() {
+  local script="$PROJECT_ROOT/scripts/wordpress/security-scan.sh"
+  [[ -x "$script" ]] || { log_warn "security-scan.sh not found, skipping"; return 0; }
+  local failed=0
+  for src in "${SOURCE_PATHS[@]}"; do
+    [[ -d "$src" ]] || continue
+    while IFS= read -r php; do
+      local payload
+      payload="{\"tool_input\":{\"file_path\":\"$php\"}}"
+      if ! echo "$payload" | "$script" >/dev/null 2>&1; then
+        local rc=$?
+        if [[ $rc -eq 2 ]]; then
+          log_error "Security issue: $php"; failed=1
+        fi
+      fi
+    done < <(find "$src" -name '*.php' -type f 2>/dev/null)
+  done
+  return $failed
+}
+
+# 3. WordPress coding standards ------------------------------------------------
+check_phpcs() {
+  local script="$PROJECT_ROOT/scripts/wordpress/check-coding-standards.sh"
+  [[ -x "$script" ]] || { log_warn "check-coding-standards.sh not found, skipping"; return 0; }
+  local failed=0
+  for src in "${SOURCE_PATHS[@]}"; do
+    [[ -d "$src" ]] || continue
+    if ! "$script" "$src" >/dev/null 2>&1; then
+      log_warn "PHPCS findings in $(basename "$src")"
+      failed=1
+    fi
+  done
+  return $failed
+}
+
+# 4. Dependency vulnerability scan ---------------------------------------------
+check_dependencies() {
+  local script="$PROJECT_ROOT/scripts/security-audit/scan-dependencies.sh"
+  [[ -x "$script" ]] || { log_warn "scan-dependencies.sh not found, skipping"; return 0; }
+  if "$script" "$PROJECT_ROOT" >/dev/null 2>&1; then
+    return 0
+  fi
+  local rc=$?
+  case $rc in
+    1) log_error "Dependency scanner found vulnerabilities"; return 1 ;;
+    *) log_warn  "Dependency scanner exited with code $rc"; return 0 ;;
+  esac
+}
+
+# 5. Build artifact validation -------------------------------------------------
+check_artifacts() {
+  local failed=0
+  for src in "${SOURCE_PATHS[@]}"; do
+    [[ -d "$src" ]] || continue
+    local name
+    name="$(basename "$src")"
+    if find "$src" -name 'node_modules' -type d -print -quit | grep -q .; then
+      log_error "$name: node_modules present in source — exclude before deploy"
+      failed=1
+    fi
+    if find "$src" -name '.env' -type f -print -quit | grep -q .; then
+      log_error "$name: .env file present — secret leak risk, do not deploy"
+      failed=1
+    fi
+    local size_kb
+    size_kb="$(du -sk "$src" 2>/dev/null | awk '{print $1}')"
+    if [[ -n "$size_kb" && "$size_kb" -gt 51200 ]]; then
+      log_warn "$name: bundle is ${size_kb}KB (>50MB) — review before deploy"
+    fi
+  done
+  return $failed
+}
+
+run_check "Structure validation"      check_structure
+run_check "Security scan"             check_security
+run_warn_check "Coding standards"     check_phpcs
+run_check "Dependency scan"           check_dependencies
+run_check "Artifact validation"       check_artifacts
+
+if [[ $FAILURES -gt 0 ]]; then
+  log_error "$FAILURES pre-deployment check(s) failed"
+  log_event "pre_deploy_failed" "failures=$FAILURES target=$TARGET"
+  exit 1
+fi
+
+log_ok "All pre-deployment checks passed"
+log_event "pre_deploy_ok" "target=$TARGET"

--- a/scripts/remote-deployment/rollback.sh
+++ b/scripts/remote-deployment/rollback.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+# Rollback a remote deployment to a previous release.
+#
+# For SSH/SFTP deployments this swaps the `current` symlink back to the
+# previous release directory. For Git deployments it force-pushes the previous
+# remote commit (with explicit confirmation).
+#
+# Usage:
+#   rollback.sh --env <name> [--method ssh|git] [--to <release-id|sha>]
+#                            [--list]
+#
+# Without --to, rolls back to the immediate previous release (ssh) or HEAD~1
+# of the deployed branch (git).
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/lib/common.sh"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/lib/config-loader.sh"
+
+ENV_NAME=""
+METHOD=""
+TO=""
+LIST=false
+
+usage() {
+  cat <<EOF
+Usage: $(basename "$0") --env <name> [--method ssh|git] [--to ID|SHA] [--list]
+
+  --env NAME      environment to roll back
+  --method MODE   ssh (default) or git
+  --to ID|SHA     specific release id (ssh) or commit sha (git)
+  --list          list available rollback targets and exit
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --env) ENV_NAME="$2"; shift 2 ;;
+    --method) METHOD="$2"; shift 2 ;;
+    --to) TO="$2"; shift 2 ;;
+    --list) LIST=true; shift ;;
+    -h|--help) usage; exit 0 ;;
+    *) log_error "Unknown argument: $1"; usage; exit 2 ;;
+  esac
+done
+
+[[ -n "$ENV_NAME" ]] || { log_error "--env is required"; exit 2; }
+load_environment_config "$ENV_NAME"
+METHOD="${METHOD:-${DEPLOY_CFG_METHOD:-ssh}}"
+
+rollback_ssh() {
+  require_cmd ssh || exit 2
+  local host user port key root
+  host="$(require_cfg SSH_HOST)" || exit 1
+  user="$(require_cfg SSH_USER)" || exit 1
+  port="${DEPLOY_CFG_SSH_PORT:-22}"
+  key="${DEPLOY_CFG_SSH_KEY:-}"
+  root="$(require_cfg REMOTE_ROOT)" || exit 1
+
+  local opts=(-o StrictHostKeyChecking=accept-new -o BatchMode=yes -p "$port")
+  [[ -n "$key" ]] && opts+=(-i "$key")
+  remote() { ssh "${opts[@]}" "$user@$host" "$@"; }
+
+  if $LIST; then
+    log_step "Available releases on $host:"
+    remote "ls -1t '$root/releases'"
+    return 0
+  fi
+
+  local current target
+  current="$(remote "readlink '$root/current' 2>/dev/null | xargs -n1 basename" || true)"
+  if [[ -z "$TO" ]]; then
+    target="$(remote "ls -1t '$root/releases'" | awk -v cur="$current" '$0 != cur {print; exit}')"
+    [[ -n "$target" ]] || { log_error "No previous release available to roll back to"; return 1; }
+  else
+    target="$TO"
+    if ! remote "test -d '$root/releases/$target'"; then
+      log_error "Release '$target' not found on remote"
+      return 1
+    fi
+  fi
+
+  banner "Rolling back $ENV_NAME: $current → $target"
+  log_event "rollback_start" "env=$ENV_NAME from=$current to=$target method=ssh"
+
+  remote "ln -sfn '$root/releases/$target' '$root/current.new' && \
+          mv -Tf '$root/current.new' '$root/current'"
+
+  log_ok "Rollback complete: current → $target"
+  log_event "rollback_ok" "env=$ENV_NAME to=$target method=ssh"
+}
+
+rollback_git() {
+  require_cmd git || exit 2
+  local remote_url remote_branch remote_name
+  remote_url="$(require_cfg GIT_REMOTE_URL)" || exit 1
+  remote_branch="$(require_cfg GIT_REMOTE_BRANCH)" || exit 1
+  remote_name="${DEPLOY_CFG_GIT_REMOTE_NAME:-deploy-$ENV_NAME}"
+
+  if ! git -C "$PROJECT_ROOT" remote get-url "$remote_name" >/dev/null 2>&1; then
+    git -C "$PROJECT_ROOT" remote add "$remote_name" "$remote_url"
+  fi
+
+  git -C "$PROJECT_ROOT" fetch "$remote_name" "$remote_branch"
+
+  if $LIST; then
+    log_step "Recent deployed commits on $remote_name/$remote_branch:"
+    git -C "$PROJECT_ROOT" log --oneline -n 20 "$remote_name/$remote_branch"
+    return 0
+  fi
+
+  local target
+  if [[ -z "$TO" ]]; then
+    target="$(git -C "$PROJECT_ROOT" rev-parse "$remote_name/$remote_branch~1")"
+  else
+    target="$TO"
+  fi
+
+  banner "Rolling back $ENV_NAME (git) → $target"
+  log_warn "This will force-push to $remote_name/$remote_branch."
+  log_event "rollback_start" "env=$ENV_NAME to=$target method=git"
+
+  git -C "$PROJECT_ROOT" push --force-with-lease "$remote_name" "$target:refs/heads/$remote_branch"
+
+  log_ok "Rollback complete: $remote_name/$remote_branch → $target"
+  log_event "rollback_ok" "env=$ENV_NAME to=$target method=git"
+}
+
+case "$METHOD" in
+  ssh) rollback_ssh ;;
+  git) rollback_git ;;
+  *)   log_error "Unsupported rollback method: $METHOD"; exit 2 ;;
+esac

--- a/scripts/remote-deployment/ssh-deploy.sh
+++ b/scripts/remote-deployment/ssh-deploy.sh
@@ -1,0 +1,163 @@
+#!/usr/bin/env bash
+# SSH/SFTP deployment using rsync over ssh.
+#
+# Implements an atomic, capistrano-style release layout:
+#
+#   <remote_root>/
+#     releases/
+#       <release-id>/        ← fresh upload
+#       <previous-id>/       ← retained for rollback
+#     current -> releases/<release-id>
+#
+# WordPress wp-content paths (themes / plugins / mu-plugins) are switched to
+# point at <remote_root>/current via symlinks the first time the script runs
+# against a host (the deployer needs write access to wp-content).
+#
+# Usage:
+#   ssh-deploy.sh --env <name> [--target theme:<name>|plugin:<name>|all]
+#                 [--release-id <id>] [--keep <N>]
+#
+# Required config keys (DEPLOY_CFG_*):
+#   SSH_HOST, SSH_USER                — connection
+#   SSH_PORT                          — default 22
+#   SSH_KEY                           — path to private key (optional)
+#   REMOTE_ROOT                       — base directory for releases
+#   WP_CONTENT_PATH                   — absolute path to wp-content on remote
+#   KEEP_RELEASES                     — defaults to 5
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/lib/common.sh"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/lib/config-loader.sh"
+
+ENV_NAME=""
+TARGET="all"
+RELEASE_ID=""
+KEEP=""
+
+usage() {
+  cat <<EOF
+Usage: $(basename "$0") --env <name> [--target SPEC] [--release-id ID] [--keep N]
+
+  --env NAME       environment config to load (staging|production|...)
+  --target SPEC    theme:<name>, plugin:<name>, or 'all' (default)
+  --release-id ID  override generated release id
+  --keep N         number of past releases to retain (default: config or 5)
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --env) ENV_NAME="$2"; shift 2 ;;
+    --target) TARGET="$2"; shift 2 ;;
+    --release-id) RELEASE_ID="$2"; shift 2 ;;
+    --keep) KEEP="$2"; shift 2 ;;
+    -h|--help) usage; exit 0 ;;
+    *) log_error "Unknown argument: $1"; usage; exit 2 ;;
+  esac
+done
+
+[[ -n "$ENV_NAME" ]] || { log_error "--env is required"; exit 2; }
+
+require_cmd ssh   || exit 2
+require_cmd rsync || exit 2
+
+load_environment_config "$ENV_NAME"
+
+SSH_HOST="$(require_cfg SSH_HOST)" || exit 1
+SSH_USER="$(require_cfg SSH_USER)" || exit 1
+SSH_PORT="${DEPLOY_CFG_SSH_PORT:-22}"
+SSH_KEY="${DEPLOY_CFG_SSH_KEY:-}"
+REMOTE_ROOT="$(require_cfg REMOTE_ROOT)" || exit 1
+WP_CONTENT="$(require_cfg WP_CONTENT_PATH)" || exit 1
+KEEP="${KEEP:-${DEPLOY_CFG_KEEP_RELEASES:-5}}"
+RELEASE_ID="${RELEASE_ID:-$(generate_release_id)}"
+
+SSH_OPTS=(-o StrictHostKeyChecking=accept-new -o BatchMode=yes -p "$SSH_PORT")
+RSYNC_SSH="ssh -p $SSH_PORT -o StrictHostKeyChecking=accept-new -o BatchMode=yes"
+if [[ -n "$SSH_KEY" ]]; then
+  SSH_OPTS+=(-i "$SSH_KEY")
+  RSYNC_SSH="$RSYNC_SSH -i $SSH_KEY"
+fi
+
+remote() {
+  ssh "${SSH_OPTS[@]}" "$SSH_USER@$SSH_HOST" "$@"
+}
+
+banner "SSH deploy → $SSH_USER@$SSH_HOST:$REMOTE_ROOT (release $RELEASE_ID)"
+log_event "ssh_deploy_start" "env=$ENV_NAME release=$RELEASE_ID host=$SSH_HOST"
+
+# Resolve sources to upload --------------------------------------------------
+declare -a SOURCES=()
+case "$TARGET" in
+  theme:*)
+    SOURCES+=("themes/${TARGET#theme:}")
+    ;;
+  plugin:*)
+    SOURCES+=("plugins/${TARGET#plugin:}")
+    ;;
+  all|"")
+    [[ -d "$PROJECT_ROOT/themes" ]]  && SOURCES+=("themes")
+    [[ -d "$PROJECT_ROOT/plugins" ]] && SOURCES+=("plugins")
+    [[ -d "$PROJECT_ROOT/mu-plugins" ]] && SOURCES+=("mu-plugins")
+    ;;
+  *) log_error "Invalid --target: $TARGET"; exit 2 ;;
+esac
+
+[[ ${#SOURCES[@]} -gt 0 ]] || { log_error "Nothing to upload"; exit 1; }
+
+# Bootstrap remote directory layout ------------------------------------------
+log_step "Preparing remote release directory"
+remote "mkdir -p '$REMOTE_ROOT/releases/$RELEASE_ID'"
+
+# Standard exclusion list. Mirrors what package-theme.sh produces locally.
+RSYNC_EXCLUDES=(
+  --exclude='.git/'
+  --exclude='.github/'
+  --exclude='.DS_Store'
+  --exclude='node_modules/'
+  --exclude='vendor/'
+  --exclude='tests/'
+  --exclude='*.test.php'
+  --exclude='.env'
+  --exclude='.env.*'
+  --exclude='*.log'
+  --exclude='__pycache__/'
+)
+
+# Upload each source preserving relative path under wp-content layout --------
+for src in "${SOURCES[@]}"; do
+  [[ -d "$PROJECT_ROOT/$src" ]] || { log_warn "Skipping missing source: $src"; continue; }
+  log_step "Uploading $src"
+  rsync -az --delete \
+    --rsh="$RSYNC_SSH" \
+    "${RSYNC_EXCLUDES[@]}" \
+    "$PROJECT_ROOT/$src/" \
+    "$SSH_USER@$SSH_HOST:$REMOTE_ROOT/releases/$RELEASE_ID/$src/"
+done
+
+# Switch the 'current' symlink atomically ------------------------------------
+log_step "Switching current → $RELEASE_ID"
+remote "ln -sfn '$REMOTE_ROOT/releases/$RELEASE_ID' '$REMOTE_ROOT/current.new' && \
+        mv -Tf '$REMOTE_ROOT/current.new' '$REMOTE_ROOT/current'"
+
+# Wire wp-content/{themes,plugins,mu-plugins} into the current release -------
+log_step "Linking wp-content to current release"
+for src in "${SOURCES[@]}"; do
+  remote "if [ -e '$WP_CONTENT/$src' ] && [ ! -L '$WP_CONTENT/$src' ]; then \
+            mv '$WP_CONTENT/$src' '$WP_CONTENT/${src}.pre-deploy-$(date -u +%Y%m%dT%H%M%SZ)'; \
+          fi; \
+          ln -sfn '$REMOTE_ROOT/current/$src' '$WP_CONTENT/$src.new' && \
+          mv -Tf '$WP_CONTENT/$src.new' '$WP_CONTENT/$src'"
+done
+
+# Trim old releases ----------------------------------------------------------
+log_step "Pruning old releases (keep=$KEEP)"
+remote "cd '$REMOTE_ROOT/releases' && ls -1t | tail -n +$((KEEP + 1)) | xargs -I{} rm -rf -- {}"
+
+log_ok "SSH deploy complete: release=$RELEASE_ID"
+log_event "ssh_deploy_ok" "env=$ENV_NAME release=$RELEASE_ID"
+printf '%s\n' "$RELEASE_ID"

--- a/scripts/remote-deployment/wpcli-deploy.sh
+++ b/scripts/remote-deployment/wpcli-deploy.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# Remote WP-CLI orchestration after a deployment.
+#
+# Runs activation, cache flush, and database update commands against the
+# remote WordPress install. Uses WP-CLI's native --ssh alias support so the
+# CLI doesn't need to be installed locally on the deployer beyond `wp`.
+#
+# Usage:
+#   wpcli-deploy.sh --env <name> [--theme <slug>] [--plugin <slug> ...]
+#                   [--skip-cache-flush] [--skip-db-update]
+#
+# Required config keys:
+#   WP_CLI_SSH        — e.g. user@host:port/path (WP-CLI alias format)
+#   WP_CLI_PATH       — absolute path to WordPress install on remote
+#   WP_CLI_BIN        — wp-cli binary on remote (default: wp)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/lib/common.sh"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/lib/config-loader.sh"
+
+ENV_NAME=""
+THEME_SLUG=""
+PLUGIN_SLUGS=()
+SKIP_CACHE=false
+SKIP_DB=false
+
+usage() {
+  cat <<EOF
+Usage: $(basename "$0") --env <name> [--theme SLUG] [--plugin SLUG ...]
+                                      [--skip-cache-flush] [--skip-db-update]
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --env) ENV_NAME="$2"; shift 2 ;;
+    --theme) THEME_SLUG="$2"; shift 2 ;;
+    --plugin) PLUGIN_SLUGS+=("$2"); shift 2 ;;
+    --skip-cache-flush) SKIP_CACHE=true; shift ;;
+    --skip-db-update) SKIP_DB=true; shift ;;
+    -h|--help) usage; exit 0 ;;
+    *) log_error "Unknown argument: $1"; usage; exit 2 ;;
+  esac
+done
+
+[[ -n "$ENV_NAME" ]] || { log_error "--env is required"; exit 2; }
+
+require_cmd wp || { log_error "wp-cli not found locally — install from https://wp-cli.org"; exit 2; }
+load_environment_config "$ENV_NAME"
+
+WP_SSH="$(require_cfg WP_CLI_SSH)" || exit 1
+WP_PATH="$(require_cfg WP_CLI_PATH)" || exit 1
+
+WP_FLAGS=(--ssh="$WP_SSH" --path="$WP_PATH")
+
+banner "Remote WP-CLI orchestration ($ENV_NAME)"
+log_event "wpcli_start" "env=$ENV_NAME ssh=$WP_SSH"
+
+run_wp() {
+  log_step "wp $*"
+  wp "${WP_FLAGS[@]}" "$@"
+}
+
+# Sanity check the connection before mutating anything
+log_step "Checking WP-CLI connectivity"
+if ! wp "${WP_FLAGS[@]}" core is-installed >/dev/null 2>&1; then
+  log_error "WP-CLI cannot reach $WP_SSH or WordPress is not installed at $WP_PATH"
+  log_event "wpcli_failed" "reason=no_connection env=$ENV_NAME"
+  exit 1
+fi
+
+if [[ -n "$THEME_SLUG" ]]; then
+  run_wp theme activate "$THEME_SLUG"
+fi
+
+for plugin in "${PLUGIN_SLUGS[@]}"; do
+  run_wp plugin activate "$plugin"
+done
+
+if ! $SKIP_DB; then
+  run_wp core update-db
+fi
+
+if ! $SKIP_CACHE; then
+  # cache flush is a no-op when no object cache is configured; harmless
+  run_wp cache flush || true
+  run_wp rewrite flush --hard || true
+fi
+
+log_ok "Remote WP-CLI orchestration complete"
+log_event "wpcli_ok" "env=$ENV_NAME"


### PR DESCRIPTION
## Summary

Adds a `deployment-agent` and supporting tooling that ships WordPress themes
and plugins to remote staging and production environments.

- **Three deployment methods**: SSH/SFTP with capistrano-style atomic releases,
  Git push-to-deploy, and remote WP-CLI orchestration.
- **Pre-deployment validation gate** runs structure checks, PHP security scan,
  PHPCS coding standards, dependency CVE scan, and artifact validation
  (no `node_modules`, `.env`, oversized bundles).
- **Rollback** by symlink swap (SSH, sub-second) or `--force-with-lease`
  revert (Git), with `--list` to inspect targets first.
- **Multi-environment configuration** under `.claude/config/deployment/`
  (`staging.example.yml`, `production.example.yml`) with schema docs. Real
  env files are gitignored to protect SSH keys and webhook URLs.
- **Logging and notifications** — every run gets a structured log under
  `.claude/logs/deployment/` and fans out to Slack / Discord / generic
  webhook / email via `notify.sh`.
- Production refuses dirty worktrees by default; `--auto-rollback` is
  recommended for production deploys.

Closes #16

## What changed

| Area | Details |
|---|---|
| Agent | `.claude/agents/deployment-agent.md` (workflows, integration, rules) |
| Scripts | `scripts/remote-deployment/{deploy,pre-deploy-checks,ssh-deploy,git-deploy,wpcli-deploy,rollback,notify}.sh` plus `lib/{common,config-loader}.sh` |
| Configs | `.claude/config/deployment/{staging,production}.example.yml` + `README.md` |
| Docs | `CLAUDE.md` and `CUSTOM-AGENTS-GUIDE.md` bumped to 50 agents |
| Safety | `.gitignore` excludes real `*.yml` configs but keeps examples |

## Test plan

- [x] All scripts pass `bash -n` syntax check
- [x] `validate-agent-configs.sh` passes (0 warnings)
- [x] `deploy.sh --env staging --dry-run` parses the example config and
      generates a release-id, run-id, and log file
- [x] `pre-deploy-checks.sh --help`, `rollback.sh --help`, `notify.sh --help`
      all render usage info
- [x] Gitignore correctly excludes `staging.yml` / `production.yml` while
      keeping `*.example.yml` and `README.md` tracked
- [ ] End-to-end test against a real staging host (requires reviewer credentials)
- [ ] Rollback round-trip against a real staging host