### PR TITLE
feat: add WooCommerce support to block theme scaffold

### DIFF
--- a/.claude/CUSTOM-AGENTS-GUIDE.md
+++ b/.claude/CUSTOM-AGENTS-GUIDE.md
@@ -1,7 +1,7 @@
 # Custom Agents Reference Guide
 
 **Last Updated:** 2026-05-06
-**Total Custom Agents:** 50
+**Total Custom Agents:** 51
 **Location:** `.claude/agents/`
 
 This guide categorizes all custom agents by relevance to WordPress FSE theme development.
@@ -93,6 +93,12 @@ These agents directly support WordPress block theme development:
 - **Use for:** SSH/SFTP atomic releases, Git push-to-deploy, remote WP-CLI orchestration, pre-deployment validation, rollback, multi-environment configuration, deploy notifications
 - **WordPress relevance:** Critical - production-grade release workflow with rollback safety
 - **Backed by:** `scripts/remote-deployment/` and `.claude/config/deployment/`
+
+### **woocommerce-agent** (NEW)
+- **Purpose:** WooCommerce store setup and FSE-template work
+- **Use for:** Installing and configuring WooCommerce, importing products, wiring shop/cart/checkout/my-account pages to FSE templates, customising the bundled `flavian-shop` starter theme, scaffolding shipping zones, taxes, and payment gateways
+- **WordPress relevance:** Critical - turns the scaffold into an e-commerce-ready store
+- **Backed by:** `themes/flavian-shop/` and `scripts/wordpress-install/setup-woocommerce.sh`
 
 ---
 

--- a/.claude/agents/woocommerce-agent.md
+++ b/.claude/agents/woocommerce-agent.md
@@ -1,0 +1,253 @@
+---
+name: woocommerce-agent
+description: Use this agent for WooCommerce store setup and FSE-template work. Specializes in installing and configuring WooCommerce, importing products, wiring shop / cart / checkout / my-account pages to FSE templates, scaffolding payment gateways and shipping zones, and customising the flavian-shop starter theme. Examples - <example>Context: User wants to bootstrap a new store. user: 'Set up WooCommerce on my local Docker.' assistant: 'I'll use woocommerce-agent to install WC, create the standard pages, import sample products, and activate flavian-shop.' <commentary>WooCommerce setup is multi-step and easy to half-finish — the agent runs the canonical script and verifies each step.</commentary></example> <example>Context: User wants product import. user: 'Import these 200 products from a CSV.' assistant: 'I'll use woocommerce-agent to import via wp wc product_importer with mapping validation.' <commentary>Bulk imports need column mapping and post-import sanity checks.</commentary></example> <example>Context: User wants to add a new shop landing template. user: 'Create a holiday landing page using the shop patterns.' assistant: 'I'll use woocommerce-agent to compose a custom template from flavian-shop patterns.' <commentary>The agent knows which patterns are available and how to wire them via the shop custom template.</commentary></example>
+tools: Read, Write, Bash, Grep, Glob, TodoWrite, TaskOutput, AskUserQuestion
+model: opus
+permissionMode: bypassPermissions
+---
+
+You are a WooCommerce specialist for FSE block themes. You install and
+configure WooCommerce, manage products and store options, and customise the
+`flavian-shop` starter theme to match a brand without losing the FSE block
+templates and patterns it ships with.
+
+## Primary Responsibilities
+
+### 1. Store installation and bootstrap
+
+Use the canonical installer rather than hand-rolling steps:
+
+```bash
+./scripts/wordpress-install/setup-woocommerce.sh
+```
+
+What it does (idempotent):
+
+1. Verifies WordPress is installed in the container.
+2. Installs and activates the `woocommerce` plugin.
+3. Sets base options — country, currency, weight/dimension units, tracking
+   opt-out, demo store off.
+4. Creates `cart`, `checkout`, `my-account`, and `shop` pages with the slugs
+   the `flavian-shop` templates expect. Assigns the right page templates
+   (`page-cart`, `page-checkout`, `page-myaccount`, `page-shop`).
+5. Imports the bundled sample products (skip with `--no-sample`).
+6. Activates `flavian-shop` if present.
+7. Sets `permalink_structure` to `/%postname%/` and flushes rewrites.
+
+The script supports both invocation modes: from the host (`docker compose
+exec`) or from the `woocommerce-installer` sidecar service in
+`docker-compose.yml` (`docker exec` against the named container).
+
+For a fresh stack from zero:
+
+```bash
+docker compose up -d
+docker compose --profile woocommerce up woocommerce-installer
+```
+
+### 2. Theme: flavian-shop
+
+`themes/flavian-shop/` is a WooCommerce-ready FSE starter:
+
+| Layer | Files |
+|---|---|
+| Tokens | `theme.json` (color, typography, spacing, layout) |
+| Bootstrap | `functions.php` — declares `add_theme_support('woocommerce', ...)`, gallery zoom/lightbox/slider, registers a `flavian-shop` pattern category |
+| Parts | `parts/header.html` (site title + nav + customer-account + mini-cart), `parts/footer.html` |
+| Templates | `index`, `page`, `404`, `archive-product`, `single-product`, `taxonomy-product_cat`, `page-cart`, `page-checkout`, `page-myaccount`, `page-shop` |
+| Patterns | `hero-shop`, `usp-strip`, `featured-products`, `product-grid`, `category-grid`, `newsletter` |
+
+When customising, follow the project's pattern-first architecture: edit
+patterns (PHP files in `patterns/`) instead of pasting raw block markup into
+templates. Templates should be thin compositions of patterns and core blocks.
+
+### 3. Product management
+
+Single product:
+
+```bash
+wp wc product create --name='Linen shirt' --type=simple \
+  --regular_price=89 --sku=LINEN-SHIRT-001 \
+  --description='Lightweight, ethically made...' \
+  --user=1 --allow-root
+```
+
+Bulk import from CSV (matches WooCommerce's importer schema):
+
+```bash
+wp wc product_importer run --file=/path/to/products.csv --user=1 --allow-root
+```
+
+After import always verify:
+1. `wp wc product list --user=1 --format=count` returns the expected number.
+2. Spot-check a product's image attachments are imported, not just URLs.
+3. Categories created in the import have descriptions and proper hierarchy.
+
+### 4. Shipping zones, taxes, payment gateways
+
+Shipping zone with flat-rate method:
+
+```bash
+ZONE_ID=$(wp option pluck woocommerce_shipping_zones --allow-root | jq -r 'keys[0]')
+wp wc shipping_zone_method create $ZONE_ID --method_id=flat_rate \
+  --settings='{"cost":"5.00","title":"Standard"}' --user=1 --allow-root
+```
+
+Taxes:
+
+```bash
+wp option update woocommerce_calc_taxes yes --allow-root
+wp option update woocommerce_prices_include_tax no --allow-root
+wp wc tax create --rate=20 --country=GB --name='VAT' --user=1 --allow-root
+```
+
+Payment gateways: enabling production gateways (Stripe, PayPal, etc.)
+requires API credentials we never put in the repo. The agent's job is to:
+
+1. Install the gateway plugin (`wp plugin install woocommerce-gateway-stripe`).
+2. Activate it (`wp plugin activate woocommerce-gateway-stripe`).
+3. Document where the user must enter credentials — typically
+   WooCommerce → Settings → Payments — and remind them to use staging
+   credentials first.
+4. NEVER write credentials to `wp-config.php` or any tracked file. Use
+   environment-based plugins (e.g. `wp_environment_loader`) or admin UI only.
+
+### 5. FSE template customisation
+
+To add a new shop landing page (e.g. holiday campaign):
+
+1. Create `themes/flavian-shop/templates/page-holiday.html` with
+   `<!-- wp:pattern {"slug":"flavian-shop/..."} /-->` blocks composing
+   existing patterns or new ones.
+2. Add the entry to `theme.json` `customTemplates` so it appears in the
+   page editor's template picker.
+3. In the WP admin, edit the page and assign the new template.
+
+To add a new pattern:
+
+1. Create `themes/flavian-shop/patterns/<slug>.php` with the docblock header
+   (Title, Slug, Categories, Description, Keywords, Block Types, Viewport
+   Width). The slug must be `flavian-shop/<slug>` so WordPress namespaces it.
+2. Use `esc_html__()` / `esc_attr__()` for translatable strings — patterns
+   are PHP, so i18n works.
+3. Reference design tokens (`var:preset|color|...`, `var:preset|spacing|...`)
+   only — never hardcode hex or pixel values.
+
+### 6. Verification after any change
+
+```
+1. Run pre-deploy checks against the theme:
+     ./scripts/remote-deployment/pre-deploy-checks.sh --target theme:flavian-shop
+2. Activate the theme in the local container:
+     docker compose exec wordpress wp theme activate flavian-shop --allow-root
+3. Hit the storefront URLs and confirm 200 OK + expected content:
+     /shop/ /cart/ /checkout/ /my-account/
+4. Run visual-qa-agent for regressions if the change affected layout.
+```
+
+## Standard Workflows
+
+### A. First-time WooCommerce setup
+
+```
+1. Confirm WordPress is installed in the container.
+2. Run setup-woocommerce.sh.
+3. Verify the four shop pages exist and have the correct templates assigned.
+4. Visit /shop and confirm products list.
+5. Walk a sample product to /cart → /checkout (don't complete unless using
+   a test gateway).
+6. Recommend the user enable a real payment gateway before production.
+```
+
+### B. Adding products in bulk
+
+```
+1. Validate the CSV has the WooCommerce importer columns
+   (https://woocommerce.com/document/product-csv-importer-and-exporter/).
+2. Dry-run the import with --user=1 and a small subset first.
+3. Import the full CSV.
+4. Spot-check 3 random products: image, price, stock, category.
+5. Re-flush rewrites if URL slugs changed.
+```
+
+### C. Branding the flavian-shop theme
+
+```
+1. Edit theme.json colours, fonts, and spacing scale FIRST. Don't touch
+   templates yet.
+2. Confirm the changes propagate by reloading /shop and / .
+3. Adjust patterns in themes/flavian-shop/patterns/ if needed.
+4. Only edit templates if you're changing structure, not styling.
+5. Validate with pre-deploy-checks.sh before shipping.
+```
+
+### D. Promoting the store to a remote environment
+
+```
+1. Run pre-deploy-checks.sh against theme:flavian-shop.
+2. Use deployment-agent with --env staging to push the theme.
+3. After deploy, run setup-woocommerce.sh against the staging container or
+   activate WC manually in the staging admin.
+4. Walk the storefront URLs on staging.
+5. Promote to production via deployment-agent with --auto-rollback.
+```
+
+## Integration
+
+**Invoked by:**
+- Manual user request to set up WooCommerce, import products, configure
+  shipping/taxes, or customise the flavian-shop theme.
+- Trigger keywords: "woocommerce", "WC", "store setup", "shop", "products",
+  "cart", "checkout", "payment gateway", "shipping zone".
+
+**Works with:**
+- `wp-environment-manager` — provisions the WordPress container before this
+  agent runs WooCommerce setup.
+- `frontend-developer` — UI work on patterns/templates that go beyond the
+  shipped flavian-shop scaffold.
+- `block-markup-validator` — sanity-checks new/modified patterns and templates.
+- `theme-token-auditor` — guards against hardcoded values creeping into the
+  theme.
+- `deployment-agent` — ships the theme (and any plugin scaffolds) to remote
+  environments.
+- `security-audit-agent` — runs against the WC plugin and any custom code.
+
+**Outputs:**
+- Configured WooCommerce store with cart/checkout/account/shop pages
+- Imported products with categories and images
+- Shipping zones, tax classes, gateway placeholders
+- Customised flavian-shop theme files
+
+## Rules
+
+- **NEVER write payment gateway credentials to tracked files.** API keys for
+  Stripe, PayPal, Square, etc. belong in the WP admin or a secrets manager.
+  If the user pastes credentials, refuse to commit them and explain why.
+- **ALWAYS use `setup-woocommerce.sh` for fresh installs.** Don't reinvent
+  page creation or option setting — the script is idempotent and tested.
+- **NEVER hardcode colours or spacing in templates or patterns.** Use the
+  CSS variables generated from `theme.json`. Run `theme-token-auditor` if
+  unsure.
+- **ALWAYS verify the four shop pages have the right page-template assigned**
+  after any setup or migration. WooCommerce shortcodes won't render the FSE
+  blocks correctly if the template isn't `page-cart` / `page-checkout` /
+  `page-myaccount` / `page-shop`.
+- **ALWAYS prefer `wp wc` CLI commands over the REST API** for scripted
+  operations — they handle WooCommerce-specific validation and post-create
+  hooks the REST API skips.
+- **PREFER pattern composition over template editing.** A new landing page is
+  a 5-line custom template referencing patterns; not a 200-line template
+  with inline block markup.
+- **NEVER ship a store without verifying checkout end-to-end.** Even on
+  staging — a broken checkout is the costliest bug WooCommerce can produce.
+
+## Error Recovery
+
+| Symptom | Likely cause | Action |
+|---|---|---|
+| `wp wc` commands return "command not found" | running `wp` outside the WordPress container | wrap with `docker compose exec wordpress wp ... --allow-root` |
+| Cart/checkout pages render shortcodes literally | template assignment lost | `wp post meta update <ID> _wp_page_template page-cart` and re-flush rewrites |
+| `/shop` returns 404 after WC install | rewrite rules not flushed | `wp rewrite flush --hard` |
+| Sample CSV import fails | importer plugin missing or wrong CSV format | `wp plugin install wordpress-importer --activate`; validate CSV against WC schema |
+| Product images missing after import | image URLs unreachable from container | use a local CSV with bundled images, or copy images to `/wp-content/uploads/` first |
+| Theme activates but storefront looks classic | WooCommerce templates not picked up | confirm `add_theme_support('woocommerce')` is registered AND that template files exist in `themes/flavian-shop/templates/` |

--- a/.env.example
+++ b/.env.example
@@ -13,3 +13,10 @@ PMA_PASSWORD=changeme
 WP_ADMIN_USER=admin
 WP_ADMIN_PASSWORD=changeme
 WP_ADMIN_EMAIL=you@example.com
+
+# WooCommerce installer (compose profile: woocommerce)
+# Run: docker compose --profile woocommerce up woocommerce-installer
+WC_INSTALL_SAMPLE_DATA=true
+WC_DEFAULT_THEME=flavian-shop
+WC_DEFAULT_CURRENCY=USD
+WC_DEFAULT_COUNTRY=US:CA

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -279,9 +279,9 @@ This project uses a lean, WordPress-optimized plugin configuration with 6 plugin
 
 ---
 
-### Custom Agents (50 Total)
+### Custom Agents (51 Total)
 
-50 specialized agents: 25 WordPress-focused development agents plus 25 generic cross-domain agents (meta/ops, business, marketing/social, engineering). Key WordPress agents include `frontend-developer`, `plugin-developer`, `test-writer-fixer`, `ui-designer`, `figma-fse-converter`, `canva-fse-converter`, `security-audit-agent`, `deployment-agent`. Key generic agents include `agent-expert`, `backend-architect`, `migration-specialist`, `content-creator`, `devops-automator`.
+51 specialized agents: 26 WordPress-focused development agents plus 25 generic cross-domain agents (meta/ops, business, marketing/social, engineering). Key WordPress agents include `frontend-developer`, `plugin-developer`, `test-writer-fixer`, `ui-designer`, `figma-fse-converter`, `canva-fse-converter`, `security-audit-agent`, `deployment-agent`, `woocommerce-agent`. Key generic agents include `agent-expert`, `backend-architect`, `migration-specialist`, `content-creator`, `devops-automator`.
 
 Agents are invoked automatically based on task context.
 
@@ -463,7 +463,7 @@ Result: themes/[theme-name]/ ready for WordPress
 - All plugins serve WordPress development
 
 **Agent Philosophy:**
-- 50 custom agents available (25 WordPress-focused + 25 generic cross-domain)
+- 51 custom agents available (26 WordPress-focused + 25 generic cross-domain)
 - Agents invoked contextually by Claude Code
 - No action required - automatic selection
 
@@ -548,6 +548,19 @@ gh auth status                # Check authentication
 ```
 Configs live in `.claude/config/deployment/<env>.yml` (gitignored). Templates: `*.example.yml`.
 
+**WooCommerce (e-commerce scaffold):**
+```bash
+# One-shot install via compose profile
+docker compose --profile woocommerce up woocommerce-installer
+
+# Or run the installer script directly against the running container
+./scripts/wordpress-install/setup-woocommerce.sh                  # full install + sample products
+./scripts/wordpress-install/setup-woocommerce.sh --no-sample      # install without sample data
+./scripts/wordpress-install/setup-woocommerce.sh --currency GBP   # configure currency / country
+```
+Bundled WooCommerce-ready FSE theme: `themes/flavian-shop/`.
+Defaults configurable via `.env`: `WC_INSTALL_SAMPLE_DATA`, `WC_DEFAULT_THEME`, `WC_DEFAULT_CURRENCY`, `WC_DEFAULT_COUNTRY`.
+
 **Visual QA & Quality Scripts:**
 ```bash
 ./scripts/visual-diff.js [actual] [expected]     # Pixel-level screenshot comparison
@@ -574,4 +587,4 @@ Configs live in `.claude/config/deployment/<env>.yml` (gitignored). Templates: `
 ---
 
 **Last Updated:** 2026-05-06
-**Architecture Status:** ✅ Lean, WordPress-optimized configuration (6 plugins + 50 agents)
+**Architecture Status:** ✅ Lean, WordPress-optimized configuration (6 plugins + 51 agents)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -55,6 +55,43 @@ services:
       retries: 5
       start_period: 30s
 
+  # One-shot WooCommerce installer.
+  #
+  # Run with the 'woocommerce' compose profile to bootstrap a fresh store
+  # with the cart/checkout/my-account pages and (optionally) sample products:
+  #
+  #   docker compose --profile woocommerce up woocommerce-installer
+  #
+  # The container exits as soon as the install script completes. Re-running it
+  # is safe — every step is idempotent.
+  woocommerce-installer:
+    image: docker:cli
+    container_name: flavian-wc-installer
+    profiles: ["woocommerce"]
+    depends_on:
+      wordpress:
+        condition: service_healthy
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - ./scripts/wordpress-install:/scripts:ro
+    working_dir: /scripts
+    environment:
+      WC_INSTALL_SAMPLE_DATA: ${WC_INSTALL_SAMPLE_DATA:-true}
+      WC_DEFAULT_THEME:        ${WC_DEFAULT_THEME:-flavian-shop}
+      WC_DEFAULT_CURRENCY:     ${WC_DEFAULT_CURRENCY:-USD}
+      WC_DEFAULT_COUNTRY:      ${WC_DEFAULT_COUNTRY:-US:CA}
+    entrypoint: ["/bin/sh", "-c"]
+    command:
+      - |
+        set -e
+        apk add --no-cache bash docker-cli-compose >/dev/null
+        ARGS=""
+        [ "$$WC_INSTALL_SAMPLE_DATA" = "false" ] && ARGS="$$ARGS --no-sample"
+        [ -n "$$WC_DEFAULT_THEME"    ] && ARGS="$$ARGS --theme $$WC_DEFAULT_THEME"
+        [ -n "$$WC_DEFAULT_CURRENCY" ] && ARGS="$$ARGS --currency $$WC_DEFAULT_CURRENCY"
+        [ -n "$$WC_DEFAULT_COUNTRY"  ] && ARGS="$$ARGS --country $$WC_DEFAULT_COUNTRY"
+        bash /scripts/setup-woocommerce.sh $$ARGS
+
   # Optional: phpMyAdmin for database management
   phpmyadmin:
     image: phpmyadmin:latest

--- a/scripts/wordpress-install/setup-woocommerce.sh
+++ b/scripts/wordpress-install/setup-woocommerce.sh
@@ -1,0 +1,191 @@
+#!/usr/bin/env bash
+# Install and configure WooCommerce inside the Docker WordPress container.
+#
+# What it does, in order:
+#   1. Verifies WordPress is installed; bails out cleanly if not.
+#   2. Installs and activates WooCommerce from WordPress.org.
+#   3. Imports the bundled sample products CSV (skippable with --no-sample).
+#   4. Creates the cart, checkout, my-account, and shop pages with the slugs
+#      that the flavian-shop theme templates expect.
+#   5. Configures store base options (currency, country, default address).
+#   6. Optionally activates the flavian-shop theme.
+#
+# Usage:
+#   ./scripts/wordpress-install/setup-woocommerce.sh [--no-sample]
+#                                                    [--theme flavian-shop|none]
+#                                                    [--currency USD]
+#                                                    [--country US:CA]
+#
+# Requires: docker compose, the project's WordPress container running.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+NO_SAMPLE=false
+ACTIVATE_THEME="flavian-shop"
+CURRENCY="USD"
+COUNTRY="US:CA"
+
+usage() {
+  cat <<EOF
+Usage: $(basename "$0") [options]
+
+  --no-sample             skip the sample-products import
+  --theme NAME|none       theme to activate after WC install (default: flavian-shop)
+  --currency CODE         WC currency code (default: USD)
+  --country CODE[:STATE]  WC base country/state (default: US:CA)
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --no-sample) NO_SAMPLE=true; shift ;;
+    --theme) ACTIVATE_THEME="$2"; shift 2 ;;
+    --currency) CURRENCY="$2"; shift 2 ;;
+    --country) COUNTRY="$2"; shift 2 ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "Unknown argument: $1" >&2; usage; exit 2 ;;
+  esac
+done
+
+log() { printf '\n[setup-woocommerce] %s\n' "$*"; }
+
+# Two callers exist: a human running this on the host (use 'docker compose'),
+# or the woocommerce-installer sidecar container which mounts the host socket
+# and only knows the WordPress container by name. Pick the right invocation.
+WP_CONTAINER="${WP_CONTAINER:-flavian-wp}"
+if [[ -f /.dockerenv ]] || [[ "${WP_USE_DOCKER_EXEC:-}" == "true" ]]; then
+  wp_in_container() {
+    docker exec -i "$WP_CONTAINER" wp "$@" --allow-root
+  }
+else
+  wp_in_container() {
+    docker compose exec -T wordpress wp "$@" --allow-root
+  }
+fi
+
+# 0. Prerequisites -----------------------------------------------------------
+if ! command -v docker >/dev/null 2>&1; then
+  echo "[ERROR] docker not found in PATH" >&2
+  exit 1
+fi
+
+if [[ ! -f /.dockerenv ]]; then
+  if ! docker compose ps --status running --services 2>/dev/null | grep -q '^wordpress$'; then
+    log "WordPress container not running — starting it"
+    docker compose up -d wordpress db
+    log "Waiting for WordPress to become healthy..."
+    for _ in $(seq 1 30); do
+      if docker compose exec -T wordpress curl -sf http://localhost/ >/dev/null 2>&1; then
+        break
+      fi
+      sleep 2
+    done
+  fi
+fi
+
+if ! wp_in_container core is-installed >/dev/null 2>&1; then
+  echo "[ERROR] WordPress is not installed yet. Run the WP install step first" >&2
+  echo "        (e.g. wp core install via your environment-manager workflow)." >&2
+  exit 1
+fi
+
+# 1. Install + activate WooCommerce ------------------------------------------
+if wp_in_container plugin is-installed woocommerce >/dev/null 2>&1; then
+  log "WooCommerce already installed — skipping plugin install"
+else
+  log "Installing WooCommerce"
+  wp_in_container plugin install woocommerce --activate
+fi
+
+if ! wp_in_container plugin is-active woocommerce >/dev/null 2>&1; then
+  log "Activating WooCommerce"
+  wp_in_container plugin activate woocommerce
+fi
+
+# 2. Configure base store options --------------------------------------------
+log "Setting base store options ($COUNTRY, $CURRENCY)"
+wp_in_container option update woocommerce_default_country  "$COUNTRY"      >/dev/null
+wp_in_container option update woocommerce_currency          "$CURRENCY"    >/dev/null
+wp_in_container option update woocommerce_weight_unit       "kg"           >/dev/null
+wp_in_container option update woocommerce_dimension_unit    "cm"           >/dev/null
+wp_in_container option update woocommerce_allow_tracking    "no"           >/dev/null
+wp_in_container option update woocommerce_demo_store        "no"           >/dev/null
+
+# 3. Create / verify required pages ------------------------------------------
+log "Ensuring shop / cart / checkout / my-account pages exist"
+ensure_page() {
+  local slug="$1" title="$2" template="$3" content="$4"
+  local existing
+  existing="$(wp_in_container post list --post_type=page --name="$slug" --field=ID 2>/dev/null | tr -d '\r')"
+  if [[ -z "$existing" ]]; then
+    wp_in_container post create \
+      --post_type=page --post_status=publish \
+      --post_title="$title" --post_name="$slug" \
+      --post_content="$content" \
+      --porcelain >/dev/null
+    existing="$(wp_in_container post list --post_type=page --name="$slug" --field=ID 2>/dev/null | tr -d '\r')"
+  fi
+  if [[ -n "$template" ]]; then
+    wp_in_container post meta update "$existing" _wp_page_template "$template" >/dev/null
+  fi
+  printf '%s' "$existing"
+}
+
+CART_ID="$(ensure_page cart      "Cart"       "page-cart"      '<!-- wp:woocommerce/cart /-->')"
+CHECKOUT_ID="$(ensure_page checkout "Checkout" "page-checkout"  '<!-- wp:woocommerce/checkout /-->')"
+ACCOUNT_ID="$(ensure_page my-account "My account" "page-myaccount" '[woocommerce_my_account]')"
+SHOP_ID="$(ensure_page shop      "Shop"       "page-shop"      '')"
+
+wp_in_container option update woocommerce_cart_page_id       "$CART_ID"     >/dev/null
+wp_in_container option update woocommerce_checkout_page_id   "$CHECKOUT_ID" >/dev/null
+wp_in_container option update woocommerce_myaccount_page_id  "$ACCOUNT_ID"  >/dev/null
+wp_in_container option update woocommerce_shop_page_id       "$SHOP_ID"     >/dev/null
+
+# 4. Sample data --------------------------------------------------------------
+if ! $NO_SAMPLE; then
+  log "Importing sample products"
+  if wp_in_container plugin is-installed wordpress-importer >/dev/null 2>&1; then
+    : # already there
+  else
+    wp_in_container plugin install wordpress-importer --activate >/dev/null
+  fi
+  # WooCommerce ships sample CSVs; the cleanest path is its built-in importer.
+  if wp_in_container help wc product create >/dev/null 2>&1; then
+    SAMPLE_CSV="/var/www/html/wp-content/plugins/woocommerce/sample-data/sample_products.csv"
+    if wp_in_container test -f "$SAMPLE_CSV" >/dev/null 2>&1; then
+      wp_in_container wc product_importer run --file="$SAMPLE_CSV" --user=1 \
+        || log "Sample importer not available — skipping (install woocommerce-cli or import manually)"
+    else
+      log "Sample CSV not found in container — skipping"
+    fi
+  else
+    log "wc CLI commands unavailable — skipping sample import"
+  fi
+else
+  log "--no-sample given; skipping sample products"
+fi
+
+# 5. Theme activation --------------------------------------------------------
+if [[ "$ACTIVATE_THEME" != "none" ]]; then
+  if wp_in_container theme is-installed "$ACTIVATE_THEME" >/dev/null 2>&1; then
+    log "Activating theme: $ACTIVATE_THEME"
+    wp_in_container theme activate "$ACTIVATE_THEME"
+  else
+    log "Theme '$ACTIVATE_THEME' not found in container — skipping activation"
+    log "Make sure themes/$ACTIVATE_THEME/ is mounted into wp-content/themes/"
+  fi
+fi
+
+# 6. Permalink + rewrites ----------------------------------------------------
+log "Flushing rewrite rules"
+wp_in_container option update permalink_structure '/%postname%/' >/dev/null
+wp_in_container rewrite flush --hard >/dev/null
+
+log "Done. Visit:"
+log "  Shop:     http://localhost:8080/shop/"
+log "  Cart:     http://localhost:8080/cart/"
+log "  Checkout: http://localhost:8080/checkout/"
+log "  Account:  http://localhost:8080/my-account/"

--- a/themes/flavian-shop/README.md
+++ b/themes/flavian-shop/README.md
@@ -1,0 +1,83 @@
+# Flavian Shop
+
+A WooCommerce-ready FSE (Full Site Editing) starter theme that ships with the
+templates, parts, and block patterns you need to launch a small store. It's a
+**scaffold** — copy it, rename it, and customise.
+
+## What's included
+
+```
+themes/flavian-shop/
+├── style.css
+├── theme.json                 # design tokens (colors, type, spacing, layout)
+├── functions.php              # WC support flags, pattern category, asset enqueue
+├── parts/
+│   ├── header.html            # site title + navigation + customer-account + mini-cart
+│   └── footer.html            # three-column footer with shop/help links
+├── templates/
+│   ├── index.html             # blog/post fallback
+│   ├── page.html              # generic page
+│   ├── 404.html                # not-found page with product search
+│   ├── archive-product.html   # /shop with sidebar filters and pagination
+│   ├── single-product.html    # PDP with gallery, price, add-to-cart, related
+│   ├── taxonomy-product_cat.html  # category pages
+│   ├── page-cart.html         # cart page (block-based)
+│   ├── page-checkout.html     # checkout page (block-based)
+│   ├── page-myaccount.html    # my account
+│   └── page-shop.html         # storefront landing (custom template)
+└── patterns/
+    ├── hero-shop.php
+    ├── usp-strip.php
+    ├── featured-products.php
+    ├── product-grid.php
+    ├── category-grid.php
+    └── newsletter.php
+```
+
+## Activating
+
+From the project root:
+
+```bash
+docker compose up -d
+docker compose exec wordpress wp theme activate flavian-shop --allow-root
+```
+
+If WooCommerce isn't installed yet, run:
+
+```bash
+./scripts/wordpress-install/setup-woocommerce.sh
+```
+
+That script installs WooCommerce, activates it, imports sample products, and
+creates the cart / checkout / my-account pages with the right slugs so the
+shipped templates pick them up.
+
+## Customising
+
+1. **Tokens first.** Edit `theme.json` colors, fonts, and spacing scale before
+   touching templates. Every template references CSS variables generated from
+   `theme.json`, so changes propagate everywhere.
+2. **Templates second.** Reorder blocks, swap patterns in or out from
+   `page-shop.html`, or add new templates for specific landing pages.
+3. **Patterns third.** Extend the included patterns — they live in
+   `patterns/` as PHP files (the pattern-first architecture used across this
+   project), so they can include `esc_html__()` translations.
+
+## Design tokens (theme.json highlights)
+
+| Token | Purpose |
+|---|---|
+| `color.primary` / `primary-hover` | call-to-action backgrounds, links |
+| `color.surface` | section backgrounds (hero, footer) |
+| `color.muted` | secondary text |
+| `color.border` | thin separators between header/footer/sections |
+| `font-family.sans` / `serif` | body and accent typography |
+| `font-size.display` / `x-large` / `large` | fluid heading scale |
+| `spacing` (1.5× × 7 steps) | consistent vertical rhythm |
+
+## Tested with
+
+- WordPress 6.5+
+- WooCommerce 8.6+
+- PHP 7.4+

--- a/themes/flavian-shop/functions.php
+++ b/themes/flavian-shop/functions.php
@@ -28,17 +28,20 @@ function flavian_shop_setup() {
 	add_theme_support( 'html5', array( 'search-form', 'gallery', 'caption', 'style', 'script' ) );
 
 	// WooCommerce — opt in to FSE block-based templates and gallery features.
-	add_theme_support( 'woocommerce', array(
-		'thumbnail_image_width' => 600,
-		'single_image_width'    => 1200,
-		'product_grid'          => array(
-			'default_rows'    => 3,
-			'min_rows'        => 1,
-			'default_columns' => 3,
-			'min_columns'     => 1,
-			'max_columns'     => 6,
-		),
-	) );
+	add_theme_support(
+		'woocommerce',
+		array(
+			'thumbnail_image_width' => 600,
+			'single_image_width'    => 1200,
+			'product_grid'          => array(
+				'default_rows'    => 3,
+				'min_rows'        => 1,
+				'default_columns' => 3,
+				'min_columns'     => 1,
+				'max_columns'     => 6,
+			),
+		)
+	);
 	add_theme_support( 'wc-product-gallery-zoom' );
 	add_theme_support( 'wc-product-gallery-lightbox' );
 	add_theme_support( 'wc-product-gallery-slider' );

--- a/themes/flavian-shop/functions.php
+++ b/themes/flavian-shop/functions.php
@@ -1,0 +1,104 @@
+<?php
+/**
+ * Flavian Shop theme bootstrap.
+ *
+ * @package Flavian_Shop
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+if ( ! defined( 'FLAVIAN_SHOP_VERSION' ) ) {
+	define( 'FLAVIAN_SHOP_VERSION', '0.1.0' );
+}
+
+/**
+ * Theme setup.
+ *
+ * Declares WooCommerce support so WooCommerce uses the FSE templates we ship
+ * in /templates instead of falling back to its bundled classic templates.
+ */
+function flavian_shop_setup() {
+	load_theme_textdomain( 'flavian-shop', get_template_directory() . '/languages' );
+
+	add_theme_support( 'wp-block-styles' );
+	add_theme_support( 'editor-styles' );
+	add_theme_support( 'responsive-embeds' );
+	add_theme_support( 'html5', array( 'search-form', 'gallery', 'caption', 'style', 'script' ) );
+
+	// WooCommerce — opt in to FSE block-based templates and gallery features.
+	add_theme_support( 'woocommerce', array(
+		'thumbnail_image_width' => 600,
+		'single_image_width'    => 1200,
+		'product_grid'          => array(
+			'default_rows'    => 3,
+			'min_rows'        => 1,
+			'default_columns' => 3,
+			'min_columns'     => 1,
+			'max_columns'     => 6,
+		),
+	) );
+	add_theme_support( 'wc-product-gallery-zoom' );
+	add_theme_support( 'wc-product-gallery-lightbox' );
+	add_theme_support( 'wc-product-gallery-slider' );
+}
+add_action( 'after_setup_theme', 'flavian_shop_setup' );
+
+/**
+ * Register block patterns shipped with the theme.
+ *
+ * @return void
+ */
+function flavian_shop_register_patterns() {
+	if ( ! function_exists( 'register_block_pattern_category' ) ) {
+		return;
+	}
+	register_block_pattern_category(
+		'flavian-shop',
+		array( 'label' => __( 'Flavian Shop', 'flavian-shop' ) )
+	);
+}
+add_action( 'init', 'flavian_shop_register_patterns' );
+
+/**
+ * Enqueue front-end assets.
+ *
+ * @return void
+ */
+function flavian_shop_enqueue_assets() {
+	wp_enqueue_style(
+		'flavian-shop',
+		get_stylesheet_uri(),
+		array(),
+		FLAVIAN_SHOP_VERSION
+	);
+}
+add_action( 'wp_enqueue_scripts', 'flavian_shop_enqueue_assets' );
+
+/**
+ * Soft-warn the admin when WooCommerce is not active.
+ *
+ * The theme renders fine without WooCommerce — the WC-specific templates and
+ * patterns simply don't appear. The notice helps new contributors realise the
+ * theme expects WooCommerce to be installed.
+ */
+function flavian_shop_notice_no_woocommerce() {
+	if ( ! current_user_can( 'manage_options' ) ) {
+		return;
+	}
+	if ( class_exists( 'WooCommerce' ) ) {
+		return;
+	}
+	$screen = function_exists( 'get_current_screen' ) ? get_current_screen() : null;
+	if ( $screen && in_array( $screen->id, array( 'dashboard', 'themes' ), true ) ) {
+		printf(
+			'<div class="notice notice-warning"><p>%s</p></div>',
+			esc_html__(
+				'Flavian Shop expects WooCommerce. Install and activate WooCommerce to enable shop, single-product, cart, and checkout templates.',
+				'flavian-shop'
+			)
+		);
+	}
+}
+add_action( 'admin_notices', 'flavian_shop_notice_no_woocommerce' );

--- a/themes/flavian-shop/parts/footer.html
+++ b/themes/flavian-shop/parts/footer.html
@@ -1,0 +1,42 @@
+<!-- wp:group {"tagName":"footer","align":"full","style":{"spacing":{"padding":{"top":"var:preset|spacing|50","right":"var:preset|spacing|40","bottom":"var:preset|spacing|50","left":"var:preset|spacing|40"}},"border":{"top":{"color":"var:preset|color|border","width":"1px"}}},"backgroundColor":"surface","layout":{"type":"constrained"}} -->
+<footer class="wp-block-group alignfull has-surface-background-color has-background" style="border-top-color:var(--wp--preset--color--border);border-top-width:1px;padding-top:var(--wp--preset--spacing--50);padding-right:var(--wp--preset--spacing--40);padding-bottom:var(--wp--preset--spacing--50);padding-left:var(--wp--preset--spacing--40)">
+  <!-- wp:columns {"verticalAlignment":"top"} -->
+  <div class="wp-block-columns are-vertically-aligned-top">
+    <!-- wp:column {"verticalAlignment":"top"} -->
+    <div class="wp-block-column is-vertically-aligned-top">
+      <!-- wp:site-title {"level":0,"style":{"typography":{"fontWeight":"700"}}} /-->
+      <!-- wp:site-tagline /-->
+    </div>
+    <!-- /wp:column -->
+
+    <!-- wp:column {"verticalAlignment":"top"} -->
+    <div class="wp-block-column is-vertically-aligned-top">
+      <!-- wp:heading {"level":3,"fontSize":"medium"} -->
+      <h3 class="wp-block-heading has-medium-font-size">Shop</h3>
+      <!-- /wp:heading -->
+      <!-- wp:navigation {"overlayMenu":"never","layout":{"type":"flex","orientation":"vertical"}} /-->
+    </div>
+    <!-- /wp:column -->
+
+    <!-- wp:column {"verticalAlignment":"top"} -->
+    <div class="wp-block-column is-vertically-aligned-top">
+      <!-- wp:heading {"level":3,"fontSize":"medium"} -->
+      <h3 class="wp-block-heading has-medium-font-size">Help</h3>
+      <!-- /wp:heading -->
+      <!-- wp:paragraph {"textColor":"muted"} -->
+      <p class="has-muted-color has-text-color"><a href="/cart">Cart</a> · <a href="/checkout">Checkout</a> · <a href="/my-account">My account</a></p>
+      <!-- /wp:paragraph -->
+    </div>
+    <!-- /wp:column -->
+  </div>
+  <!-- /wp:columns -->
+
+  <!-- wp:separator {"backgroundColor":"border"} -->
+  <hr class="wp-block-separator has-text-color has-border-background-color has-alpha-channel-opacity has-background"/>
+  <!-- /wp:separator -->
+
+  <!-- wp:paragraph {"align":"center","fontSize":"small","textColor":"muted"} -->
+  <p class="has-text-align-center has-muted-color has-text-color has-small-font-size">© Flavian Shop. Built with <a href="https://wordpress.org">WordPress</a>.</p>
+  <!-- /wp:paragraph -->
+</footer>
+<!-- /wp:group -->

--- a/themes/flavian-shop/parts/header.html
+++ b/themes/flavian-shop/parts/header.html
@@ -1,0 +1,18 @@
+<!-- wp:group {"tagName":"header","align":"full","style":{"spacing":{"padding":{"top":"var:preset|spacing|30","right":"var:preset|spacing|40","bottom":"var:preset|spacing|30","left":"var:preset|spacing|40"}},"border":{"bottom":{"color":"var:preset|color|border","width":"1px"}}},"backgroundColor":"background","layout":{"type":"constrained"}} -->
+<header class="wp-block-group alignfull has-background-background-color has-background" style="border-bottom-color:var(--wp--preset--color--border);border-bottom-width:1px;padding-top:var(--wp--preset--spacing--30);padding-right:var(--wp--preset--spacing--40);padding-bottom:var(--wp--preset--spacing--30);padding-left:var(--wp--preset--spacing--40)">
+  <!-- wp:group {"layout":{"type":"flex","justifyContent":"space-between","flexWrap":"nowrap"}} -->
+  <div class="wp-block-group">
+    <!-- wp:site-title {"level":0,"style":{"typography":{"fontWeight":"700"}}} /-->
+
+    <!-- wp:navigation {"layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"right"},"overlayMenu":"mobile"} /-->
+
+    <!-- wp:group {"layout":{"type":"flex","flexWrap":"nowrap"}} -->
+    <div class="wp-block-group">
+      <!-- wp:woocommerce/customer-account /-->
+      <!-- wp:woocommerce/mini-cart /-->
+    </div>
+    <!-- /wp:group -->
+  </div>
+  <!-- /wp:group -->
+</header>
+<!-- /wp:group -->

--- a/themes/flavian-shop/patterns/category-grid.php
+++ b/themes/flavian-shop/patterns/category-grid.php
@@ -6,52 +6,55 @@
  * Description: Three-column grid linking to product categories. Replace placeholder images and category links after inserting.
  * Keywords: categories, navigation, grid
  * Viewport Width: 1400
+ *
+ * @package Flavian_Shop
  */
+
 ?>
 <!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"var:preset|spacing|50","right":"var:preset|spacing|40","bottom":"var:preset|spacing|50","left":"var:preset|spacing|40"}}},"backgroundColor":"surface","layout":{"type":"constrained"}} -->
 <div class="wp-block-group alignfull has-surface-background-color has-background" style="padding-top:var(--wp--preset--spacing--50);padding-right:var(--wp--preset--spacing--40);padding-bottom:var(--wp--preset--spacing--50);padding-left:var(--wp--preset--spacing--40)">
-  <!-- wp:heading {"textAlign":"center","level":2,"fontSize":"x-large"} -->
-  <h2 class="wp-block-heading has-text-align-center has-x-large-font-size"><?php echo esc_html__( 'Shop by category', 'flavian-shop' ); ?></h2>
-  <!-- /wp:heading -->
+	<!-- wp:heading {"textAlign":"center","level":2,"fontSize":"x-large"} -->
+	<h2 class="wp-block-heading has-text-align-center has-x-large-font-size"><?php echo esc_html__( 'Shop by category', 'flavian-shop' ); ?></h2>
+	<!-- /wp:heading -->
 
-  <!-- wp:columns -->
-  <div class="wp-block-columns">
-    <!-- wp:column -->
-    <div class="wp-block-column">
-      <!-- wp:cover {"dimRatio":30,"minHeight":280,"contentPosition":"bottom left","style":{"border":{"radius":"0.75rem"}}} -->
-      <div class="wp-block-cover has-custom-content-position is-position-bottom-left" style="border-radius:0.75rem;min-height:280px"><span aria-hidden="true" class="wp-block-cover__background has-background-dim-30 has-background-dim"></span><div class="wp-block-cover__inner-container">
-        <!-- wp:heading {"textColor":"background","level":3} -->
-        <h3 class="wp-block-heading has-background-color has-text-color"><a href="/product-category/new"><?php echo esc_html__( 'New arrivals', 'flavian-shop' ); ?></a></h3>
-        <!-- /wp:heading -->
-      </div></div>
-      <!-- /wp:cover -->
-    </div>
-    <!-- /wp:column -->
+	<!-- wp:columns -->
+	<div class="wp-block-columns">
+	<!-- wp:column -->
+	<div class="wp-block-column">
+		<!-- wp:cover {"dimRatio":30,"minHeight":280,"contentPosition":"bottom left","style":{"border":{"radius":"0.75rem"}}} -->
+		<div class="wp-block-cover has-custom-content-position is-position-bottom-left" style="border-radius:0.75rem;min-height:280px"><span aria-hidden="true" class="wp-block-cover__background has-background-dim-30 has-background-dim"></span><div class="wp-block-cover__inner-container">
+		<!-- wp:heading {"textColor":"background","level":3} -->
+		<h3 class="wp-block-heading has-background-color has-text-color"><a href="/product-category/new"><?php echo esc_html__( 'New arrivals', 'flavian-shop' ); ?></a></h3>
+		<!-- /wp:heading -->
+		</div></div>
+		<!-- /wp:cover -->
+	</div>
+	<!-- /wp:column -->
 
-    <!-- wp:column -->
-    <div class="wp-block-column">
-      <!-- wp:cover {"dimRatio":30,"minHeight":280,"contentPosition":"bottom left","style":{"border":{"radius":"0.75rem"}}} -->
-      <div class="wp-block-cover has-custom-content-position is-position-bottom-left" style="border-radius:0.75rem;min-height:280px"><span aria-hidden="true" class="wp-block-cover__background has-background-dim-30 has-background-dim"></span><div class="wp-block-cover__inner-container">
-        <!-- wp:heading {"textColor":"background","level":3} -->
-        <h3 class="wp-block-heading has-background-color has-text-color"><a href="/product-category/best-sellers"><?php echo esc_html__( 'Best sellers', 'flavian-shop' ); ?></a></h3>
-        <!-- /wp:heading -->
-      </div></div>
-      <!-- /wp:cover -->
-    </div>
-    <!-- /wp:column -->
+	<!-- wp:column -->
+	<div class="wp-block-column">
+		<!-- wp:cover {"dimRatio":30,"minHeight":280,"contentPosition":"bottom left","style":{"border":{"radius":"0.75rem"}}} -->
+		<div class="wp-block-cover has-custom-content-position is-position-bottom-left" style="border-radius:0.75rem;min-height:280px"><span aria-hidden="true" class="wp-block-cover__background has-background-dim-30 has-background-dim"></span><div class="wp-block-cover__inner-container">
+		<!-- wp:heading {"textColor":"background","level":3} -->
+		<h3 class="wp-block-heading has-background-color has-text-color"><a href="/product-category/best-sellers"><?php echo esc_html__( 'Best sellers', 'flavian-shop' ); ?></a></h3>
+		<!-- /wp:heading -->
+		</div></div>
+		<!-- /wp:cover -->
+	</div>
+	<!-- /wp:column -->
 
-    <!-- wp:column -->
-    <div class="wp-block-column">
-      <!-- wp:cover {"dimRatio":30,"minHeight":280,"contentPosition":"bottom left","style":{"border":{"radius":"0.75rem"}}} -->
-      <div class="wp-block-cover has-custom-content-position is-position-bottom-left" style="border-radius:0.75rem;min-height:280px"><span aria-hidden="true" class="wp-block-cover__background has-background-dim-30 has-background-dim"></span><div class="wp-block-cover__inner-container">
-        <!-- wp:heading {"textColor":"background","level":3} -->
-        <h3 class="wp-block-heading has-background-color has-text-color"><a href="/product-category/sale"><?php echo esc_html__( 'On sale', 'flavian-shop' ); ?></a></h3>
-        <!-- /wp:heading -->
-      </div></div>
-      <!-- /wp:cover -->
-    </div>
-    <!-- /wp:column -->
-  </div>
-  <!-- /wp:columns -->
+	<!-- wp:column -->
+	<div class="wp-block-column">
+		<!-- wp:cover {"dimRatio":30,"minHeight":280,"contentPosition":"bottom left","style":{"border":{"radius":"0.75rem"}}} -->
+		<div class="wp-block-cover has-custom-content-position is-position-bottom-left" style="border-radius:0.75rem;min-height:280px"><span aria-hidden="true" class="wp-block-cover__background has-background-dim-30 has-background-dim"></span><div class="wp-block-cover__inner-container">
+		<!-- wp:heading {"textColor":"background","level":3} -->
+		<h3 class="wp-block-heading has-background-color has-text-color"><a href="/product-category/sale"><?php echo esc_html__( 'On sale', 'flavian-shop' ); ?></a></h3>
+		<!-- /wp:heading -->
+		</div></div>
+		<!-- /wp:cover -->
+	</div>
+	<!-- /wp:column -->
+	</div>
+	<!-- /wp:columns -->
 </div>
 <!-- /wp:group -->

--- a/themes/flavian-shop/patterns/category-grid.php
+++ b/themes/flavian-shop/patterns/category-grid.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * Title: Category grid
+ * Slug: flavian-shop/category-grid
+ * Categories: flavian-shop, woocommerce
+ * Description: Three-column grid linking to product categories. Replace placeholder images and category links after inserting.
+ * Keywords: categories, navigation, grid
+ * Viewport Width: 1400
+ */
+?>
+<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"var:preset|spacing|50","right":"var:preset|spacing|40","bottom":"var:preset|spacing|50","left":"var:preset|spacing|40"}}},"backgroundColor":"surface","layout":{"type":"constrained"}} -->
+<div class="wp-block-group alignfull has-surface-background-color has-background" style="padding-top:var(--wp--preset--spacing--50);padding-right:var(--wp--preset--spacing--40);padding-bottom:var(--wp--preset--spacing--50);padding-left:var(--wp--preset--spacing--40)">
+  <!-- wp:heading {"textAlign":"center","level":2,"fontSize":"x-large"} -->
+  <h2 class="wp-block-heading has-text-align-center has-x-large-font-size"><?php echo esc_html__( 'Shop by category', 'flavian-shop' ); ?></h2>
+  <!-- /wp:heading -->
+
+  <!-- wp:columns -->
+  <div class="wp-block-columns">
+    <!-- wp:column -->
+    <div class="wp-block-column">
+      <!-- wp:cover {"dimRatio":30,"minHeight":280,"contentPosition":"bottom left","style":{"border":{"radius":"0.75rem"}}} -->
+      <div class="wp-block-cover has-custom-content-position is-position-bottom-left" style="border-radius:0.75rem;min-height:280px"><span aria-hidden="true" class="wp-block-cover__background has-background-dim-30 has-background-dim"></span><div class="wp-block-cover__inner-container">
+        <!-- wp:heading {"textColor":"background","level":3} -->
+        <h3 class="wp-block-heading has-background-color has-text-color"><a href="/product-category/new"><?php echo esc_html__( 'New arrivals', 'flavian-shop' ); ?></a></h3>
+        <!-- /wp:heading -->
+      </div></div>
+      <!-- /wp:cover -->
+    </div>
+    <!-- /wp:column -->
+
+    <!-- wp:column -->
+    <div class="wp-block-column">
+      <!-- wp:cover {"dimRatio":30,"minHeight":280,"contentPosition":"bottom left","style":{"border":{"radius":"0.75rem"}}} -->
+      <div class="wp-block-cover has-custom-content-position is-position-bottom-left" style="border-radius:0.75rem;min-height:280px"><span aria-hidden="true" class="wp-block-cover__background has-background-dim-30 has-background-dim"></span><div class="wp-block-cover__inner-container">
+        <!-- wp:heading {"textColor":"background","level":3} -->
+        <h3 class="wp-block-heading has-background-color has-text-color"><a href="/product-category/best-sellers"><?php echo esc_html__( 'Best sellers', 'flavian-shop' ); ?></a></h3>
+        <!-- /wp:heading -->
+      </div></div>
+      <!-- /wp:cover -->
+    </div>
+    <!-- /wp:column -->
+
+    <!-- wp:column -->
+    <div class="wp-block-column">
+      <!-- wp:cover {"dimRatio":30,"minHeight":280,"contentPosition":"bottom left","style":{"border":{"radius":"0.75rem"}}} -->
+      <div class="wp-block-cover has-custom-content-position is-position-bottom-left" style="border-radius:0.75rem;min-height:280px"><span aria-hidden="true" class="wp-block-cover__background has-background-dim-30 has-background-dim"></span><div class="wp-block-cover__inner-container">
+        <!-- wp:heading {"textColor":"background","level":3} -->
+        <h3 class="wp-block-heading has-background-color has-text-color"><a href="/product-category/sale"><?php echo esc_html__( 'On sale', 'flavian-shop' ); ?></a></h3>
+        <!-- /wp:heading -->
+      </div></div>
+      <!-- /wp:cover -->
+    </div>
+    <!-- /wp:column -->
+  </div>
+  <!-- /wp:columns -->
+</div>
+<!-- /wp:group -->

--- a/themes/flavian-shop/patterns/featured-products.php
+++ b/themes/flavian-shop/patterns/featured-products.php
@@ -7,37 +7,40 @@
  * Keywords: products, featured, grid, woocommerce
  * Block Types: woocommerce/product-collection
  * Viewport Width: 1400
+ *
+ * @package Flavian_Shop
  */
+
 ?>
 <!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"var:preset|spacing|50","right":"var:preset|spacing|40","bottom":"var:preset|spacing|50","left":"var:preset|spacing|40"}}},"layout":{"type":"constrained"}} -->
 <div class="wp-block-group alignfull" style="padding-top:var(--wp--preset--spacing--50);padding-right:var(--wp--preset--spacing--40);padding-bottom:var(--wp--preset--spacing--50);padding-left:var(--wp--preset--spacing--40)">
-  <!-- wp:group {"layout":{"type":"flex","justifyContent":"space-between","flexWrap":"nowrap"}} -->
-  <div class="wp-block-group">
-    <!-- wp:heading {"level":2,"fontSize":"x-large"} -->
-    <h2 class="wp-block-heading has-x-large-font-size"><?php echo esc_html__( 'Featured', 'flavian-shop' ); ?></h2>
-    <!-- /wp:heading -->
+	<!-- wp:group {"layout":{"type":"flex","justifyContent":"space-between","flexWrap":"nowrap"}} -->
+	<div class="wp-block-group">
+	<!-- wp:heading {"level":2,"fontSize":"x-large"} -->
+	<h2 class="wp-block-heading has-x-large-font-size"><?php echo esc_html__( 'Featured', 'flavian-shop' ); ?></h2>
+	<!-- /wp:heading -->
 
-    <!-- wp:paragraph -->
-    <p><a href="/shop"><?php echo esc_html__( 'View all →', 'flavian-shop' ); ?></a></p>
-    <!-- /wp:paragraph -->
-  </div>
-  <!-- /wp:group -->
+	<!-- wp:paragraph -->
+	<p><a href="/shop"><?php echo esc_html__( 'View all →', 'flavian-shop' ); ?></a></p>
+	<!-- /wp:paragraph -->
+	</div>
+	<!-- /wp:group -->
 
-  <!-- wp:woocommerce/product-collection {"queryId":10,"query":{"perPage":6,"pages":1,"offset":0,"postType":"product","order":"desc","orderBy":"date","search":"","exclude":[],"sticky":"","inherit":false,"taxQuery":{},"isProductCollectionBlock":true,"woocommerceOnSale":false,"woocommerceStockStatus":["instock","outofstock","onbackorder"],"woocommerceAttributes":[],"woocommerceHandPickedProducts":[],"featured":true},"tagName":"div","displayLayout":{"type":"flex","columns":3,"shrinkColumns":true},"queryContextIncludes":["collection"],"forcePageReload":false} -->
-  <div class="wp-block-woocommerce-product-collection">
-    <!-- wp:woocommerce/product-template -->
-      <!-- wp:woocommerce/product-image {"showSaleBadge":true,"saleBadgeAlign":"right","isDescendentOfQueryLoop":true} /-->
-      <!-- wp:post-title {"isLink":true,"level":3,"fontSize":"medium","__woocommerceNamespace":"woocommerce/product-collection/product-title"} /-->
-      <!-- wp:woocommerce/product-price {"isDescendentOfQueryLoop":true} /-->
-      <!-- wp:woocommerce/product-button {"isDescendentOfQueryLoop":true} /-->
-    <!-- /wp:woocommerce/product-template -->
+	<!-- wp:woocommerce/product-collection {"queryId":10,"query":{"perPage":6,"pages":1,"offset":0,"postType":"product","order":"desc","orderBy":"date","search":"","exclude":[],"sticky":"","inherit":false,"taxQuery":{},"isProductCollectionBlock":true,"woocommerceOnSale":false,"woocommerceStockStatus":["instock","outofstock","onbackorder"],"woocommerceAttributes":[],"woocommerceHandPickedProducts":[],"featured":true},"tagName":"div","displayLayout":{"type":"flex","columns":3,"shrinkColumns":true},"queryContextIncludes":["collection"],"forcePageReload":false} -->
+	<div class="wp-block-woocommerce-product-collection">
+	<!-- wp:woocommerce/product-template -->
+		<!-- wp:woocommerce/product-image {"showSaleBadge":true,"saleBadgeAlign":"right","isDescendentOfQueryLoop":true} /-->
+		<!-- wp:post-title {"isLink":true,"level":3,"fontSize":"medium","__woocommerceNamespace":"woocommerce/product-collection/product-title"} /-->
+		<!-- wp:woocommerce/product-price {"isDescendentOfQueryLoop":true} /-->
+		<!-- wp:woocommerce/product-button {"isDescendentOfQueryLoop":true} /-->
+	<!-- /wp:woocommerce/product-template -->
 
-    <!-- wp:woocommerce/product-collection-no-results -->
-      <!-- wp:paragraph -->
-      <p><?php echo esc_html__( 'No featured products yet — mark a product as featured in the WooCommerce admin.', 'flavian-shop' ); ?></p>
-      <!-- /wp:paragraph -->
-    <!-- /wp:woocommerce/product-collection-no-results -->
-  </div>
-  <!-- /wp:woocommerce/product-collection -->
+	<!-- wp:woocommerce/product-collection-no-results -->
+		<!-- wp:paragraph -->
+		<p><?php echo esc_html__( 'No featured products yet — mark a product as featured in the WooCommerce admin.', 'flavian-shop' ); ?></p>
+		<!-- /wp:paragraph -->
+	<!-- /wp:woocommerce/product-collection-no-results -->
+	</div>
+	<!-- /wp:woocommerce/product-collection -->
 </div>
 <!-- /wp:group -->

--- a/themes/flavian-shop/patterns/featured-products.php
+++ b/themes/flavian-shop/patterns/featured-products.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * Title: Featured products grid
+ * Slug: flavian-shop/featured-products
+ * Categories: flavian-shop, woocommerce
+ * Description: Three-column grid showing featured WooCommerce products with image, title, price, and add-to-cart button.
+ * Keywords: products, featured, grid, woocommerce
+ * Block Types: woocommerce/product-collection
+ * Viewport Width: 1400
+ */
+?>
+<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"var:preset|spacing|50","right":"var:preset|spacing|40","bottom":"var:preset|spacing|50","left":"var:preset|spacing|40"}}},"layout":{"type":"constrained"}} -->
+<div class="wp-block-group alignfull" style="padding-top:var(--wp--preset--spacing--50);padding-right:var(--wp--preset--spacing--40);padding-bottom:var(--wp--preset--spacing--50);padding-left:var(--wp--preset--spacing--40)">
+  <!-- wp:group {"layout":{"type":"flex","justifyContent":"space-between","flexWrap":"nowrap"}} -->
+  <div class="wp-block-group">
+    <!-- wp:heading {"level":2,"fontSize":"x-large"} -->
+    <h2 class="wp-block-heading has-x-large-font-size"><?php echo esc_html__( 'Featured', 'flavian-shop' ); ?></h2>
+    <!-- /wp:heading -->
+
+    <!-- wp:paragraph -->
+    <p><a href="/shop"><?php echo esc_html__( 'View all →', 'flavian-shop' ); ?></a></p>
+    <!-- /wp:paragraph -->
+  </div>
+  <!-- /wp:group -->
+
+  <!-- wp:woocommerce/product-collection {"queryId":10,"query":{"perPage":6,"pages":1,"offset":0,"postType":"product","order":"desc","orderBy":"date","search":"","exclude":[],"sticky":"","inherit":false,"taxQuery":{},"isProductCollectionBlock":true,"woocommerceOnSale":false,"woocommerceStockStatus":["instock","outofstock","onbackorder"],"woocommerceAttributes":[],"woocommerceHandPickedProducts":[],"featured":true},"tagName":"div","displayLayout":{"type":"flex","columns":3,"shrinkColumns":true},"queryContextIncludes":["collection"],"forcePageReload":false} -->
+  <div class="wp-block-woocommerce-product-collection">
+    <!-- wp:woocommerce/product-template -->
+      <!-- wp:woocommerce/product-image {"showSaleBadge":true,"saleBadgeAlign":"right","isDescendentOfQueryLoop":true} /-->
+      <!-- wp:post-title {"isLink":true,"level":3,"fontSize":"medium","__woocommerceNamespace":"woocommerce/product-collection/product-title"} /-->
+      <!-- wp:woocommerce/product-price {"isDescendentOfQueryLoop":true} /-->
+      <!-- wp:woocommerce/product-button {"isDescendentOfQueryLoop":true} /-->
+    <!-- /wp:woocommerce/product-template -->
+
+    <!-- wp:woocommerce/product-collection-no-results -->
+      <!-- wp:paragraph -->
+      <p><?php echo esc_html__( 'No featured products yet — mark a product as featured in the WooCommerce admin.', 'flavian-shop' ); ?></p>
+      <!-- /wp:paragraph -->
+    <!-- /wp:woocommerce/product-collection-no-results -->
+  </div>
+  <!-- /wp:woocommerce/product-collection -->
+</div>
+<!-- /wp:group -->

--- a/themes/flavian-shop/patterns/hero-shop.php
+++ b/themes/flavian-shop/patterns/hero-shop.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * Title: Shop hero
+ * Slug: flavian-shop/hero-shop
+ * Categories: flavian-shop, featured
+ * Description: A two-column shop hero with headline, supporting copy, primary CTA, and a side image. Edit copy and image after inserting.
+ * Keywords: hero, shop, landing, banner
+ * Block Types: core/cover
+ * Viewport Width: 1400
+ */
+?>
+<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"var:preset|spacing|60","right":"var:preset|spacing|40","bottom":"var:preset|spacing|60","left":"var:preset|spacing|40"}}},"backgroundColor":"surface","layout":{"type":"constrained"}} -->
+<div class="wp-block-group alignfull has-surface-background-color has-background" style="padding-top:var(--wp--preset--spacing--60);padding-right:var(--wp--preset--spacing--40);padding-bottom:var(--wp--preset--spacing--60);padding-left:var(--wp--preset--spacing--40)">
+  <!-- wp:columns {"verticalAlignment":"center"} -->
+  <div class="wp-block-columns are-vertically-aligned-center">
+    <!-- wp:column {"verticalAlignment":"center"} -->
+    <div class="wp-block-column is-vertically-aligned-center">
+      <!-- wp:paragraph {"fontSize":"small","textColor":"primary","style":{"typography":{"textTransform":"uppercase","letterSpacing":"0.08em","fontWeight":"600"}}} -->
+      <p class="has-primary-color has-text-color has-small-font-size" style="font-weight:600;letter-spacing:0.08em;text-transform:uppercase"><?php echo esc_html__( 'New collection', 'flavian-shop' ); ?></p>
+      <!-- /wp:paragraph -->
+
+      <!-- wp:heading {"level":1,"fontSize":"display"} -->
+      <h1 class="wp-block-heading has-display-font-size"><?php echo esc_html__( 'Goods made to last.', 'flavian-shop' ); ?></h1>
+      <!-- /wp:heading -->
+
+      <!-- wp:paragraph {"textColor":"muted","fontSize":"medium"} -->
+      <p class="has-muted-color has-text-color has-medium-font-size"><?php echo esc_html__( 'Carefully sourced, honestly priced. Browse our latest pieces and find your next favourite.', 'flavian-shop' ); ?></p>
+      <!-- /wp:paragraph -->
+
+      <!-- wp:buttons -->
+      <div class="wp-block-buttons">
+        <!-- wp:button -->
+        <div class="wp-block-button"><a class="wp-block-button__link wp-element-button" href="/shop"><?php echo esc_html__( 'Shop now', 'flavian-shop' ); ?></a></div>
+        <!-- /wp:button -->
+
+        <!-- wp:button {"className":"is-style-outline"} -->
+        <div class="wp-block-button is-style-outline"><a class="wp-block-button__link wp-element-button" href="/shop?orderby=date"><?php echo esc_html__( 'See what\'s new', 'flavian-shop' ); ?></a></div>
+        <!-- /wp:button -->
+      </div>
+      <!-- /wp:buttons -->
+    </div>
+    <!-- /wp:column -->
+
+    <!-- wp:column -->
+    <div class="wp-block-column">
+      <!-- wp:image {"sizeSlug":"large","style":{"border":{"radius":"0.75rem"}}} -->
+      <figure class="wp-block-image size-large has-custom-border"><img alt="" style="border-radius:0.75rem"/></figure>
+      <!-- /wp:image -->
+    </div>
+    <!-- /wp:column -->
+  </div>
+  <!-- /wp:columns -->
+</div>
+<!-- /wp:group -->

--- a/themes/flavian-shop/patterns/hero-shop.php
+++ b/themes/flavian-shop/patterns/hero-shop.php
@@ -7,48 +7,51 @@
  * Keywords: hero, shop, landing, banner
  * Block Types: core/cover
  * Viewport Width: 1400
+ *
+ * @package Flavian_Shop
  */
+
 ?>
 <!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"var:preset|spacing|60","right":"var:preset|spacing|40","bottom":"var:preset|spacing|60","left":"var:preset|spacing|40"}}},"backgroundColor":"surface","layout":{"type":"constrained"}} -->
 <div class="wp-block-group alignfull has-surface-background-color has-background" style="padding-top:var(--wp--preset--spacing--60);padding-right:var(--wp--preset--spacing--40);padding-bottom:var(--wp--preset--spacing--60);padding-left:var(--wp--preset--spacing--40)">
-  <!-- wp:columns {"verticalAlignment":"center"} -->
-  <div class="wp-block-columns are-vertically-aligned-center">
-    <!-- wp:column {"verticalAlignment":"center"} -->
-    <div class="wp-block-column is-vertically-aligned-center">
-      <!-- wp:paragraph {"fontSize":"small","textColor":"primary","style":{"typography":{"textTransform":"uppercase","letterSpacing":"0.08em","fontWeight":"600"}}} -->
-      <p class="has-primary-color has-text-color has-small-font-size" style="font-weight:600;letter-spacing:0.08em;text-transform:uppercase"><?php echo esc_html__( 'New collection', 'flavian-shop' ); ?></p>
-      <!-- /wp:paragraph -->
+	<!-- wp:columns {"verticalAlignment":"center"} -->
+	<div class="wp-block-columns are-vertically-aligned-center">
+	<!-- wp:column {"verticalAlignment":"center"} -->
+	<div class="wp-block-column is-vertically-aligned-center">
+		<!-- wp:paragraph {"fontSize":"small","textColor":"primary","style":{"typography":{"textTransform":"uppercase","letterSpacing":"0.08em","fontWeight":"600"}}} -->
+		<p class="has-primary-color has-text-color has-small-font-size" style="font-weight:600;letter-spacing:0.08em;text-transform:uppercase"><?php echo esc_html__( 'New collection', 'flavian-shop' ); ?></p>
+		<!-- /wp:paragraph -->
 
-      <!-- wp:heading {"level":1,"fontSize":"display"} -->
-      <h1 class="wp-block-heading has-display-font-size"><?php echo esc_html__( 'Goods made to last.', 'flavian-shop' ); ?></h1>
-      <!-- /wp:heading -->
+		<!-- wp:heading {"level":1,"fontSize":"display"} -->
+		<h1 class="wp-block-heading has-display-font-size"><?php echo esc_html__( 'Goods made to last.', 'flavian-shop' ); ?></h1>
+		<!-- /wp:heading -->
 
-      <!-- wp:paragraph {"textColor":"muted","fontSize":"medium"} -->
-      <p class="has-muted-color has-text-color has-medium-font-size"><?php echo esc_html__( 'Carefully sourced, honestly priced. Browse our latest pieces and find your next favourite.', 'flavian-shop' ); ?></p>
-      <!-- /wp:paragraph -->
+		<!-- wp:paragraph {"textColor":"muted","fontSize":"medium"} -->
+		<p class="has-muted-color has-text-color has-medium-font-size"><?php echo esc_html__( 'Carefully sourced, honestly priced. Browse our latest pieces and find your next favourite.', 'flavian-shop' ); ?></p>
+		<!-- /wp:paragraph -->
 
-      <!-- wp:buttons -->
-      <div class="wp-block-buttons">
-        <!-- wp:button -->
-        <div class="wp-block-button"><a class="wp-block-button__link wp-element-button" href="/shop"><?php echo esc_html__( 'Shop now', 'flavian-shop' ); ?></a></div>
-        <!-- /wp:button -->
+		<!-- wp:buttons -->
+		<div class="wp-block-buttons">
+		<!-- wp:button -->
+		<div class="wp-block-button"><a class="wp-block-button__link wp-element-button" href="/shop"><?php echo esc_html__( 'Shop now', 'flavian-shop' ); ?></a></div>
+		<!-- /wp:button -->
 
-        <!-- wp:button {"className":"is-style-outline"} -->
-        <div class="wp-block-button is-style-outline"><a class="wp-block-button__link wp-element-button" href="/shop?orderby=date"><?php echo esc_html__( 'See what\'s new', 'flavian-shop' ); ?></a></div>
-        <!-- /wp:button -->
-      </div>
-      <!-- /wp:buttons -->
-    </div>
-    <!-- /wp:column -->
+		<!-- wp:button {"className":"is-style-outline"} -->
+		<div class="wp-block-button is-style-outline"><a class="wp-block-button__link wp-element-button" href="/shop?orderby=date"><?php echo esc_html__( 'See what\'s new', 'flavian-shop' ); ?></a></div>
+		<!-- /wp:button -->
+		</div>
+		<!-- /wp:buttons -->
+	</div>
+	<!-- /wp:column -->
 
-    <!-- wp:column -->
-    <div class="wp-block-column">
-      <!-- wp:image {"sizeSlug":"large","style":{"border":{"radius":"0.75rem"}}} -->
-      <figure class="wp-block-image size-large has-custom-border"><img alt="" style="border-radius:0.75rem"/></figure>
-      <!-- /wp:image -->
-    </div>
-    <!-- /wp:column -->
-  </div>
-  <!-- /wp:columns -->
+	<!-- wp:column -->
+	<div class="wp-block-column">
+		<!-- wp:image {"sizeSlug":"large","style":{"border":{"radius":"0.75rem"}}} -->
+		<figure class="wp-block-image size-large has-custom-border"><img alt="" style="border-radius:0.75rem"/></figure>
+		<!-- /wp:image -->
+	</div>
+	<!-- /wp:column -->
+	</div>
+	<!-- /wp:columns -->
 </div>
 <!-- /wp:group -->

--- a/themes/flavian-shop/patterns/newsletter.php
+++ b/themes/flavian-shop/patterns/newsletter.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * Title: Newsletter signup
+ * Slug: flavian-shop/newsletter
+ * Categories: flavian-shop, featured
+ * Description: Centered newsletter signup with heading, supporting text, and a placeholder form. Replace with your provider's embed (Mailchimp, Klaviyo, etc.) after inserting.
+ * Keywords: newsletter, email, signup, marketing
+ * Viewport Width: 1200
+ */
+?>
+<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"var:preset|spacing|60","right":"var:preset|spacing|40","bottom":"var:preset|spacing|60","left":"var:preset|spacing|40"}}},"backgroundColor":"foreground","textColor":"background","layout":{"type":"constrained","contentSize":"640px"}} -->
+<div class="wp-block-group alignfull has-background-color has-foreground-background-color has-text-color has-background" style="padding-top:var(--wp--preset--spacing--60);padding-right:var(--wp--preset--spacing--40);padding-bottom:var(--wp--preset--spacing--60);padding-left:var(--wp--preset--spacing--40)">
+  <!-- wp:heading {"textAlign":"center","level":2,"fontSize":"x-large"} -->
+  <h2 class="wp-block-heading has-text-align-center has-x-large-font-size"><?php echo esc_html__( 'Get 10% off your first order', 'flavian-shop' ); ?></h2>
+  <!-- /wp:heading -->
+
+  <!-- wp:paragraph {"align":"center","fontSize":"medium"} -->
+  <p class="has-text-align-center has-medium-font-size"><?php echo esc_html__( 'Subscribe for new arrivals, restocks, and the occasional thoughtful note. No spam.', 'flavian-shop' ); ?></p>
+  <!-- /wp:paragraph -->
+
+  <!-- wp:html -->
+  <form action="#" method="post" class="flavian-shop-newsletter">
+    <label class="screen-reader-text" for="flavian-newsletter-email"><?php echo esc_html__( 'Your email', 'flavian-shop' ); ?></label>
+    <input id="flavian-newsletter-email" type="email" name="email" required placeholder="<?php echo esc_attr__( 'you@example.com', 'flavian-shop' ); ?>">
+    <button type="submit"><?php echo esc_html__( 'Subscribe', 'flavian-shop' ); ?></button>
+  </form>
+  <!-- /wp:html -->
+</div>
+<!-- /wp:group -->

--- a/themes/flavian-shop/patterns/newsletter.php
+++ b/themes/flavian-shop/patterns/newsletter.php
@@ -6,24 +6,27 @@
  * Description: Centered newsletter signup with heading, supporting text, and a placeholder form. Replace with your provider's embed (Mailchimp, Klaviyo, etc.) after inserting.
  * Keywords: newsletter, email, signup, marketing
  * Viewport Width: 1200
+ *
+ * @package Flavian_Shop
  */
+
 ?>
 <!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"var:preset|spacing|60","right":"var:preset|spacing|40","bottom":"var:preset|spacing|60","left":"var:preset|spacing|40"}}},"backgroundColor":"foreground","textColor":"background","layout":{"type":"constrained","contentSize":"640px"}} -->
 <div class="wp-block-group alignfull has-background-color has-foreground-background-color has-text-color has-background" style="padding-top:var(--wp--preset--spacing--60);padding-right:var(--wp--preset--spacing--40);padding-bottom:var(--wp--preset--spacing--60);padding-left:var(--wp--preset--spacing--40)">
-  <!-- wp:heading {"textAlign":"center","level":2,"fontSize":"x-large"} -->
-  <h2 class="wp-block-heading has-text-align-center has-x-large-font-size"><?php echo esc_html__( 'Get 10% off your first order', 'flavian-shop' ); ?></h2>
-  <!-- /wp:heading -->
+	<!-- wp:heading {"textAlign":"center","level":2,"fontSize":"x-large"} -->
+	<h2 class="wp-block-heading has-text-align-center has-x-large-font-size"><?php echo esc_html__( 'Get 10% off your first order', 'flavian-shop' ); ?></h2>
+	<!-- /wp:heading -->
 
-  <!-- wp:paragraph {"align":"center","fontSize":"medium"} -->
-  <p class="has-text-align-center has-medium-font-size"><?php echo esc_html__( 'Subscribe for new arrivals, restocks, and the occasional thoughtful note. No spam.', 'flavian-shop' ); ?></p>
-  <!-- /wp:paragraph -->
+	<!-- wp:paragraph {"align":"center","fontSize":"medium"} -->
+	<p class="has-text-align-center has-medium-font-size"><?php echo esc_html__( 'Subscribe for new arrivals, restocks, and the occasional thoughtful note. No spam.', 'flavian-shop' ); ?></p>
+	<!-- /wp:paragraph -->
 
-  <!-- wp:html -->
-  <form action="#" method="post" class="flavian-shop-newsletter">
-    <label class="screen-reader-text" for="flavian-newsletter-email"><?php echo esc_html__( 'Your email', 'flavian-shop' ); ?></label>
-    <input id="flavian-newsletter-email" type="email" name="email" required placeholder="<?php echo esc_attr__( 'you@example.com', 'flavian-shop' ); ?>">
-    <button type="submit"><?php echo esc_html__( 'Subscribe', 'flavian-shop' ); ?></button>
-  </form>
-  <!-- /wp:html -->
+	<!-- wp:html -->
+	<form action="#" method="post" class="flavian-shop-newsletter">
+	<label class="screen-reader-text" for="flavian-newsletter-email"><?php echo esc_html__( 'Your email', 'flavian-shop' ); ?></label>
+	<input id="flavian-newsletter-email" type="email" name="email" required placeholder="<?php echo esc_attr__( 'you@example.com', 'flavian-shop' ); ?>">
+	<button type="submit"><?php echo esc_html__( 'Subscribe', 'flavian-shop' ); ?></button>
+	</form>
+	<!-- /wp:html -->
 </div>
 <!-- /wp:group -->

--- a/themes/flavian-shop/patterns/product-grid.php
+++ b/themes/flavian-shop/patterns/product-grid.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * Title: Product grid (4 columns)
+ * Slug: flavian-shop/product-grid
+ * Categories: flavian-shop, woocommerce
+ * Description: Compact 4-column product grid. Drop into shop, category, or landing pages.
+ * Keywords: products, grid, shop, woocommerce
+ * Block Types: woocommerce/product-collection
+ * Viewport Width: 1400
+ */
+?>
+<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"var:preset|spacing|40","right":"var:preset|spacing|40","bottom":"var:preset|spacing|40","left":"var:preset|spacing|40"}}},"layout":{"type":"constrained"}} -->
+<div class="wp-block-group alignfull" style="padding-top:var(--wp--preset--spacing--40);padding-right:var(--wp--preset--spacing--40);padding-bottom:var(--wp--preset--spacing--40);padding-left:var(--wp--preset--spacing--40)">
+  <!-- wp:woocommerce/product-collection {"queryId":11,"query":{"perPage":8,"pages":1,"offset":0,"postType":"product","order":"desc","orderBy":"date","search":"","exclude":[],"sticky":"","inherit":false,"taxQuery":{},"isProductCollectionBlock":true,"woocommerceOnSale":false,"woocommerceStockStatus":["instock","outofstock","onbackorder"],"woocommerceAttributes":[],"woocommerceHandPickedProducts":[]},"tagName":"div","displayLayout":{"type":"flex","columns":4,"shrinkColumns":true},"queryContextIncludes":["collection"],"forcePageReload":false} -->
+  <div class="wp-block-woocommerce-product-collection">
+    <!-- wp:woocommerce/product-template -->
+      <!-- wp:woocommerce/product-image {"showSaleBadge":true,"saleBadgeAlign":"right","isDescendentOfQueryLoop":true} /-->
+      <!-- wp:post-title {"isLink":true,"level":3,"fontSize":"medium","__woocommerceNamespace":"woocommerce/product-collection/product-title"} /-->
+      <!-- wp:woocommerce/product-price {"isDescendentOfQueryLoop":true} /-->
+      <!-- wp:woocommerce/product-button {"isDescendentOfQueryLoop":true} /-->
+    <!-- /wp:woocommerce/product-template -->
+
+    <!-- wp:woocommerce/product-collection-no-results -->
+      <!-- wp:paragraph -->
+      <p><?php echo esc_html__( 'No products found.', 'flavian-shop' ); ?></p>
+      <!-- /wp:paragraph -->
+    <!-- /wp:woocommerce/product-collection-no-results -->
+  </div>
+  <!-- /wp:woocommerce/product-collection -->
+</div>
+<!-- /wp:group -->

--- a/themes/flavian-shop/patterns/product-grid.php
+++ b/themes/flavian-shop/patterns/product-grid.php
@@ -7,25 +7,28 @@
  * Keywords: products, grid, shop, woocommerce
  * Block Types: woocommerce/product-collection
  * Viewport Width: 1400
+ *
+ * @package Flavian_Shop
  */
+
 ?>
 <!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"var:preset|spacing|40","right":"var:preset|spacing|40","bottom":"var:preset|spacing|40","left":"var:preset|spacing|40"}}},"layout":{"type":"constrained"}} -->
 <div class="wp-block-group alignfull" style="padding-top:var(--wp--preset--spacing--40);padding-right:var(--wp--preset--spacing--40);padding-bottom:var(--wp--preset--spacing--40);padding-left:var(--wp--preset--spacing--40)">
-  <!-- wp:woocommerce/product-collection {"queryId":11,"query":{"perPage":8,"pages":1,"offset":0,"postType":"product","order":"desc","orderBy":"date","search":"","exclude":[],"sticky":"","inherit":false,"taxQuery":{},"isProductCollectionBlock":true,"woocommerceOnSale":false,"woocommerceStockStatus":["instock","outofstock","onbackorder"],"woocommerceAttributes":[],"woocommerceHandPickedProducts":[]},"tagName":"div","displayLayout":{"type":"flex","columns":4,"shrinkColumns":true},"queryContextIncludes":["collection"],"forcePageReload":false} -->
-  <div class="wp-block-woocommerce-product-collection">
-    <!-- wp:woocommerce/product-template -->
-      <!-- wp:woocommerce/product-image {"showSaleBadge":true,"saleBadgeAlign":"right","isDescendentOfQueryLoop":true} /-->
-      <!-- wp:post-title {"isLink":true,"level":3,"fontSize":"medium","__woocommerceNamespace":"woocommerce/product-collection/product-title"} /-->
-      <!-- wp:woocommerce/product-price {"isDescendentOfQueryLoop":true} /-->
-      <!-- wp:woocommerce/product-button {"isDescendentOfQueryLoop":true} /-->
-    <!-- /wp:woocommerce/product-template -->
+	<!-- wp:woocommerce/product-collection {"queryId":11,"query":{"perPage":8,"pages":1,"offset":0,"postType":"product","order":"desc","orderBy":"date","search":"","exclude":[],"sticky":"","inherit":false,"taxQuery":{},"isProductCollectionBlock":true,"woocommerceOnSale":false,"woocommerceStockStatus":["instock","outofstock","onbackorder"],"woocommerceAttributes":[],"woocommerceHandPickedProducts":[]},"tagName":"div","displayLayout":{"type":"flex","columns":4,"shrinkColumns":true},"queryContextIncludes":["collection"],"forcePageReload":false} -->
+	<div class="wp-block-woocommerce-product-collection">
+	<!-- wp:woocommerce/product-template -->
+		<!-- wp:woocommerce/product-image {"showSaleBadge":true,"saleBadgeAlign":"right","isDescendentOfQueryLoop":true} /-->
+		<!-- wp:post-title {"isLink":true,"level":3,"fontSize":"medium","__woocommerceNamespace":"woocommerce/product-collection/product-title"} /-->
+		<!-- wp:woocommerce/product-price {"isDescendentOfQueryLoop":true} /-->
+		<!-- wp:woocommerce/product-button {"isDescendentOfQueryLoop":true} /-->
+	<!-- /wp:woocommerce/product-template -->
 
-    <!-- wp:woocommerce/product-collection-no-results -->
-      <!-- wp:paragraph -->
-      <p><?php echo esc_html__( 'No products found.', 'flavian-shop' ); ?></p>
-      <!-- /wp:paragraph -->
-    <!-- /wp:woocommerce/product-collection-no-results -->
-  </div>
-  <!-- /wp:woocommerce/product-collection -->
+	<!-- wp:woocommerce/product-collection-no-results -->
+		<!-- wp:paragraph -->
+		<p><?php echo esc_html__( 'No products found.', 'flavian-shop' ); ?></p>
+		<!-- /wp:paragraph -->
+	<!-- /wp:woocommerce/product-collection-no-results -->
+	</div>
+	<!-- /wp:woocommerce/product-collection -->
 </div>
 <!-- /wp:group -->

--- a/themes/flavian-shop/patterns/usp-strip.php
+++ b/themes/flavian-shop/patterns/usp-strip.php
@@ -6,56 +6,59 @@
  * Description: Four-column unique-selling-points strip — free shipping, easy returns, secure checkout, support.
  * Keywords: usp, trust, badges, shipping
  * Viewport Width: 1200
+ *
+ * @package Flavian_Shop
  */
+
 ?>
 <!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"var:preset|spacing|40","right":"var:preset|spacing|40","bottom":"var:preset|spacing|40","left":"var:preset|spacing|40"}},"border":{"top":{"color":"var:preset|color|border","width":"1px"},"bottom":{"color":"var:preset|color|border","width":"1px"}}},"layout":{"type":"constrained"}} -->
 <div class="wp-block-group alignfull" style="border-top-color:var(--wp--preset--color--border);border-top-width:1px;border-bottom-color:var(--wp--preset--color--border);border-bottom-width:1px;padding-top:var(--wp--preset--spacing--40);padding-right:var(--wp--preset--spacing--40);padding-bottom:var(--wp--preset--spacing--40);padding-left:var(--wp--preset--spacing--40)">
-  <!-- wp:columns {"isStackedOnMobile":true} -->
-  <div class="wp-block-columns">
-    <!-- wp:column -->
-    <div class="wp-block-column">
-      <!-- wp:heading {"textAlign":"center","level":3,"fontSize":"medium"} -->
-      <h3 class="wp-block-heading has-text-align-center has-medium-font-size"><?php echo esc_html__( 'Free shipping', 'flavian-shop' ); ?></h3>
-      <!-- /wp:heading -->
-      <!-- wp:paragraph {"align":"center","textColor":"muted","fontSize":"small"} -->
-      <p class="has-text-align-center has-muted-color has-text-color has-small-font-size"><?php echo esc_html__( 'On orders over $75', 'flavian-shop' ); ?></p>
-      <!-- /wp:paragraph -->
-    </div>
-    <!-- /wp:column -->
+	<!-- wp:columns {"isStackedOnMobile":true} -->
+	<div class="wp-block-columns">
+	<!-- wp:column -->
+	<div class="wp-block-column">
+		<!-- wp:heading {"textAlign":"center","level":3,"fontSize":"medium"} -->
+		<h3 class="wp-block-heading has-text-align-center has-medium-font-size"><?php echo esc_html__( 'Free shipping', 'flavian-shop' ); ?></h3>
+		<!-- /wp:heading -->
+		<!-- wp:paragraph {"align":"center","textColor":"muted","fontSize":"small"} -->
+		<p class="has-text-align-center has-muted-color has-text-color has-small-font-size"><?php echo esc_html__( 'On orders over $75', 'flavian-shop' ); ?></p>
+		<!-- /wp:paragraph -->
+	</div>
+	<!-- /wp:column -->
 
-    <!-- wp:column -->
-    <div class="wp-block-column">
-      <!-- wp:heading {"textAlign":"center","level":3,"fontSize":"medium"} -->
-      <h3 class="wp-block-heading has-text-align-center has-medium-font-size"><?php echo esc_html__( 'Easy returns', 'flavian-shop' ); ?></h3>
-      <!-- /wp:heading -->
-      <!-- wp:paragraph {"align":"center","textColor":"muted","fontSize":"small"} -->
-      <p class="has-text-align-center has-muted-color has-text-color has-small-font-size"><?php echo esc_html__( '30 days, no questions', 'flavian-shop' ); ?></p>
-      <!-- /wp:paragraph -->
-    </div>
-    <!-- /wp:column -->
+	<!-- wp:column -->
+	<div class="wp-block-column">
+		<!-- wp:heading {"textAlign":"center","level":3,"fontSize":"medium"} -->
+		<h3 class="wp-block-heading has-text-align-center has-medium-font-size"><?php echo esc_html__( 'Easy returns', 'flavian-shop' ); ?></h3>
+		<!-- /wp:heading -->
+		<!-- wp:paragraph {"align":"center","textColor":"muted","fontSize":"small"} -->
+		<p class="has-text-align-center has-muted-color has-text-color has-small-font-size"><?php echo esc_html__( '30 days, no questions', 'flavian-shop' ); ?></p>
+		<!-- /wp:paragraph -->
+	</div>
+	<!-- /wp:column -->
 
-    <!-- wp:column -->
-    <div class="wp-block-column">
-      <!-- wp:heading {"textAlign":"center","level":3,"fontSize":"medium"} -->
-      <h3 class="wp-block-heading has-text-align-center has-medium-font-size"><?php echo esc_html__( 'Secure checkout', 'flavian-shop' ); ?></h3>
-      <!-- /wp:heading -->
-      <!-- wp:paragraph {"align":"center","textColor":"muted","fontSize":"small"} -->
-      <p class="has-text-align-center has-muted-color has-text-color has-small-font-size"><?php echo esc_html__( 'SSL-encrypted payments', 'flavian-shop' ); ?></p>
-      <!-- /wp:paragraph -->
-    </div>
-    <!-- /wp:column -->
+	<!-- wp:column -->
+	<div class="wp-block-column">
+		<!-- wp:heading {"textAlign":"center","level":3,"fontSize":"medium"} -->
+		<h3 class="wp-block-heading has-text-align-center has-medium-font-size"><?php echo esc_html__( 'Secure checkout', 'flavian-shop' ); ?></h3>
+		<!-- /wp:heading -->
+		<!-- wp:paragraph {"align":"center","textColor":"muted","fontSize":"small"} -->
+		<p class="has-text-align-center has-muted-color has-text-color has-small-font-size"><?php echo esc_html__( 'SSL-encrypted payments', 'flavian-shop' ); ?></p>
+		<!-- /wp:paragraph -->
+	</div>
+	<!-- /wp:column -->
 
-    <!-- wp:column -->
-    <div class="wp-block-column">
-      <!-- wp:heading {"textAlign":"center","level":3,"fontSize":"medium"} -->
-      <h3 class="wp-block-heading has-text-align-center has-medium-font-size"><?php echo esc_html__( 'Real support', 'flavian-shop' ); ?></h3>
-      <!-- /wp:heading -->
-      <!-- wp:paragraph {"align":"center","textColor":"muted","fontSize":"small"} -->
-      <p class="has-text-align-center has-muted-color has-text-color has-small-font-size"><?php echo esc_html__( 'Talk to a human, fast', 'flavian-shop' ); ?></p>
-      <!-- /wp:paragraph -->
-    </div>
-    <!-- /wp:column -->
-  </div>
-  <!-- /wp:columns -->
+	<!-- wp:column -->
+	<div class="wp-block-column">
+		<!-- wp:heading {"textAlign":"center","level":3,"fontSize":"medium"} -->
+		<h3 class="wp-block-heading has-text-align-center has-medium-font-size"><?php echo esc_html__( 'Real support', 'flavian-shop' ); ?></h3>
+		<!-- /wp:heading -->
+		<!-- wp:paragraph {"align":"center","textColor":"muted","fontSize":"small"} -->
+		<p class="has-text-align-center has-muted-color has-text-color has-small-font-size"><?php echo esc_html__( 'Talk to a human, fast', 'flavian-shop' ); ?></p>
+		<!-- /wp:paragraph -->
+	</div>
+	<!-- /wp:column -->
+	</div>
+	<!-- /wp:columns -->
 </div>
 <!-- /wp:group -->

--- a/themes/flavian-shop/patterns/usp-strip.php
+++ b/themes/flavian-shop/patterns/usp-strip.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * Title: USP strip
+ * Slug: flavian-shop/usp-strip
+ * Categories: flavian-shop, featured
+ * Description: Four-column unique-selling-points strip — free shipping, easy returns, secure checkout, support.
+ * Keywords: usp, trust, badges, shipping
+ * Viewport Width: 1200
+ */
+?>
+<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"var:preset|spacing|40","right":"var:preset|spacing|40","bottom":"var:preset|spacing|40","left":"var:preset|spacing|40"}},"border":{"top":{"color":"var:preset|color|border","width":"1px"},"bottom":{"color":"var:preset|color|border","width":"1px"}}},"layout":{"type":"constrained"}} -->
+<div class="wp-block-group alignfull" style="border-top-color:var(--wp--preset--color--border);border-top-width:1px;border-bottom-color:var(--wp--preset--color--border);border-bottom-width:1px;padding-top:var(--wp--preset--spacing--40);padding-right:var(--wp--preset--spacing--40);padding-bottom:var(--wp--preset--spacing--40);padding-left:var(--wp--preset--spacing--40)">
+  <!-- wp:columns {"isStackedOnMobile":true} -->
+  <div class="wp-block-columns">
+    <!-- wp:column -->
+    <div class="wp-block-column">
+      <!-- wp:heading {"textAlign":"center","level":3,"fontSize":"medium"} -->
+      <h3 class="wp-block-heading has-text-align-center has-medium-font-size"><?php echo esc_html__( 'Free shipping', 'flavian-shop' ); ?></h3>
+      <!-- /wp:heading -->
+      <!-- wp:paragraph {"align":"center","textColor":"muted","fontSize":"small"} -->
+      <p class="has-text-align-center has-muted-color has-text-color has-small-font-size"><?php echo esc_html__( 'On orders over $75', 'flavian-shop' ); ?></p>
+      <!-- /wp:paragraph -->
+    </div>
+    <!-- /wp:column -->
+
+    <!-- wp:column -->
+    <div class="wp-block-column">
+      <!-- wp:heading {"textAlign":"center","level":3,"fontSize":"medium"} -->
+      <h3 class="wp-block-heading has-text-align-center has-medium-font-size"><?php echo esc_html__( 'Easy returns', 'flavian-shop' ); ?></h3>
+      <!-- /wp:heading -->
+      <!-- wp:paragraph {"align":"center","textColor":"muted","fontSize":"small"} -->
+      <p class="has-text-align-center has-muted-color has-text-color has-small-font-size"><?php echo esc_html__( '30 days, no questions', 'flavian-shop' ); ?></p>
+      <!-- /wp:paragraph -->
+    </div>
+    <!-- /wp:column -->
+
+    <!-- wp:column -->
+    <div class="wp-block-column">
+      <!-- wp:heading {"textAlign":"center","level":3,"fontSize":"medium"} -->
+      <h3 class="wp-block-heading has-text-align-center has-medium-font-size"><?php echo esc_html__( 'Secure checkout', 'flavian-shop' ); ?></h3>
+      <!-- /wp:heading -->
+      <!-- wp:paragraph {"align":"center","textColor":"muted","fontSize":"small"} -->
+      <p class="has-text-align-center has-muted-color has-text-color has-small-font-size"><?php echo esc_html__( 'SSL-encrypted payments', 'flavian-shop' ); ?></p>
+      <!-- /wp:paragraph -->
+    </div>
+    <!-- /wp:column -->
+
+    <!-- wp:column -->
+    <div class="wp-block-column">
+      <!-- wp:heading {"textAlign":"center","level":3,"fontSize":"medium"} -->
+      <h3 class="wp-block-heading has-text-align-center has-medium-font-size"><?php echo esc_html__( 'Real support', 'flavian-shop' ); ?></h3>
+      <!-- /wp:heading -->
+      <!-- wp:paragraph {"align":"center","textColor":"muted","fontSize":"small"} -->
+      <p class="has-text-align-center has-muted-color has-text-color has-small-font-size"><?php echo esc_html__( 'Talk to a human, fast', 'flavian-shop' ); ?></p>
+      <!-- /wp:paragraph -->
+    </div>
+    <!-- /wp:column -->
+  </div>
+  <!-- /wp:columns -->
+</div>
+<!-- /wp:group -->

--- a/themes/flavian-shop/style.css
+++ b/themes/flavian-shop/style.css
@@ -1,0 +1,15 @@
+/*
+Theme Name: Flavian Shop
+Theme URI: https://github.com/PMDevSolutions/Flavian
+Author: Flavian Contributors
+Author URI: https://github.com/PMDevSolutions/Flavian
+Description: A WooCommerce-ready Full Site Editing (FSE) starter theme. Ships with shop, single-product, cart, checkout, and account templates plus a set of e-commerce block patterns. Designed as a scaffold — copy, rename, and customise.
+Tags: full-site-editing, block-templates, e-commerce, woocommerce, accessibility-ready
+Version: 0.1.0
+Requires at least: 6.5
+Tested up to: 6.7
+Requires PHP: 7.4
+License: GPL-2.0-or-later
+License URI: https://www.gnu.org/licenses/gpl-2.0.html
+Text Domain: flavian-shop
+*/

--- a/themes/flavian-shop/templates/404.html
+++ b/themes/flavian-shop/templates/404.html
@@ -1,0 +1,25 @@
+<!-- wp:template-part {"slug":"header","tagName":"header"} /-->
+
+<!-- wp:group {"tagName":"main","style":{"spacing":{"padding":{"top":"var:preset|spacing|60","bottom":"var:preset|spacing|60"}}},"layout":{"type":"constrained"}} -->
+<main class="wp-block-group" style="padding-top:var(--wp--preset--spacing--60);padding-bottom:var(--wp--preset--spacing--60)">
+  <!-- wp:heading {"textAlign":"center","level":1,"fontSize":"display"} -->
+  <h1 class="wp-block-heading has-text-align-center has-display-font-size">Not found</h1>
+  <!-- /wp:heading -->
+
+  <!-- wp:paragraph {"align":"center","textColor":"muted"} -->
+  <p class="has-text-align-center has-muted-color has-text-color">The page you were looking for doesn't exist. Try the search below or head back to the shop.</p>
+  <!-- /wp:paragraph -->
+
+  <!-- wp:search {"label":"","showLabel":false,"placeholder":"Search products…","buttonText":"Search","buttonPosition":"button-inside","query":{"post_type":"product"}} /-->
+
+  <!-- wp:buttons {"layout":{"type":"flex","justifyContent":"center"}} -->
+  <div class="wp-block-buttons">
+    <!-- wp:button -->
+    <div class="wp-block-button"><a class="wp-block-button__link wp-element-button" href="/shop">Browse all products</a></div>
+    <!-- /wp:button -->
+  </div>
+  <!-- /wp:buttons -->
+</main>
+<!-- /wp:group -->
+
+<!-- wp:template-part {"slug":"footer","tagName":"footer"} /-->

--- a/themes/flavian-shop/templates/archive-product.html
+++ b/themes/flavian-shop/templates/archive-product.html
@@ -1,0 +1,74 @@
+<!-- wp:template-part {"slug":"header","tagName":"header"} /-->
+
+<!-- wp:group {"tagName":"main","layout":{"type":"constrained"}} -->
+<main class="wp-block-group">
+  <!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"var:preset|spacing|50","right":"var:preset|spacing|40","bottom":"var:preset|spacing|40","left":"var:preset|spacing|40"}}},"backgroundColor":"surface","layout":{"type":"constrained"}} -->
+  <div class="wp-block-group alignfull has-surface-background-color has-background" style="padding-top:var(--wp--preset--spacing--50);padding-right:var(--wp--preset--spacing--40);padding-bottom:var(--wp--preset--spacing--40);padding-left:var(--wp--preset--spacing--40)">
+    <!-- wp:post-title {"level":1} /-->
+    <!-- wp:term-description /-->
+  </div>
+  <!-- /wp:group -->
+
+  <!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|40","bottom":"var:preset|spacing|60"}}},"layout":{"type":"constrained"}} -->
+  <div class="wp-block-group" style="padding-top:var(--wp--preset--spacing--40);padding-bottom:var(--wp--preset--spacing--60)">
+    <!-- wp:columns -->
+    <div class="wp-block-columns">
+      <!-- wp:column {"width":"260px"} -->
+      <div class="wp-block-column" style="flex-basis:260px">
+        <!-- wp:woocommerce/filter-wrapper {"filterType":"price-filter","heading":"Filter by price"} -->
+          <!-- wp:woocommerce/price-filter /-->
+        <!-- /wp:woocommerce/filter-wrapper -->
+
+        <!-- wp:woocommerce/filter-wrapper {"filterType":"stock-filter","heading":"Availability"} -->
+          <!-- wp:woocommerce/stock-filter /-->
+        <!-- /wp:woocommerce/filter-wrapper -->
+
+        <!-- wp:woocommerce/filter-wrapper {"filterType":"active-filters","heading":"Active filters"} -->
+          <!-- wp:woocommerce/active-filters /-->
+        <!-- /wp:woocommerce/filter-wrapper -->
+      </div>
+      <!-- /wp:column -->
+
+      <!-- wp:column -->
+      <div class="wp-block-column">
+        <!-- wp:group {"layout":{"type":"flex","justifyContent":"space-between","flexWrap":"nowrap"}} -->
+        <div class="wp-block-group">
+          <!-- wp:woocommerce/store-notices /-->
+          <!-- wp:woocommerce/catalog-sorting /-->
+        </div>
+        <!-- /wp:group -->
+
+        <!-- wp:woocommerce/product-results-count /-->
+
+        <!-- wp:query {"queryId":1,"query":{"perPage":12,"pages":0,"offset":0,"postType":"product","order":"asc","orderBy":"title","inherit":true}} -->
+        <div class="wp-block-query">
+          <!-- wp:post-template {"layout":{"type":"grid","columnCount":3}} -->
+            <!-- wp:woocommerce/product-image {"showSaleBadge":true,"saleBadgeAlign":"right","isDescendentOfQueryLoop":true} /-->
+            <!-- wp:post-title {"isLink":true,"level":3,"fontSize":"medium"} /-->
+            <!-- wp:woocommerce/product-price {"isDescendentOfQueryLoop":true} /-->
+            <!-- wp:woocommerce/product-button {"isDescendentOfQueryLoop":true} /-->
+          <!-- /wp:post-template -->
+
+          <!-- wp:query-pagination {"layout":{"type":"flex","justifyContent":"center"}} -->
+            <!-- wp:query-pagination-previous /-->
+            <!-- wp:query-pagination-numbers /-->
+            <!-- wp:query-pagination-next /-->
+          <!-- /wp:query-pagination -->
+
+          <!-- wp:query-no-results -->
+            <!-- wp:paragraph -->
+            <p>No products match your filters.</p>
+            <!-- /wp:paragraph -->
+          <!-- /wp:query-no-results -->
+        </div>
+        <!-- /wp:query -->
+      </div>
+      <!-- /wp:column -->
+    </div>
+    <!-- /wp:columns -->
+  </div>
+  <!-- /wp:group -->
+</main>
+<!-- /wp:group -->
+
+<!-- wp:template-part {"slug":"footer","tagName":"footer"} /-->

--- a/themes/flavian-shop/templates/index.html
+++ b/themes/flavian-shop/templates/index.html
@@ -1,0 +1,30 @@
+<!-- wp:template-part {"slug":"header","tagName":"header"} /-->
+
+<!-- wp:group {"tagName":"main","layout":{"type":"constrained"}} -->
+<main class="wp-block-group">
+  <!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|50","bottom":"var:preset|spacing|50"}}},"layout":{"type":"constrained"}} -->
+  <div class="wp-block-group" style="padding-top:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--50)">
+    <!-- wp:query {"queryId":0,"query":{"perPage":10,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","inherit":true}} -->
+    <div class="wp-block-query">
+      <!-- wp:post-template -->
+        <!-- wp:post-title {"isLink":true,"level":2} /-->
+        <!-- wp:post-excerpt /-->
+      <!-- /wp:post-template -->
+      <!-- wp:query-pagination {"layout":{"type":"flex","justifyContent":"space-between"}} -->
+        <!-- wp:query-pagination-previous /-->
+        <!-- wp:query-pagination-numbers /-->
+        <!-- wp:query-pagination-next /-->
+      <!-- /wp:query-pagination -->
+      <!-- wp:query-no-results -->
+        <!-- wp:paragraph -->
+        <p>Nothing here yet.</p>
+        <!-- /wp:paragraph -->
+      <!-- /wp:query-no-results -->
+    </div>
+    <!-- /wp:query -->
+  </div>
+  <!-- /wp:group -->
+</main>
+<!-- /wp:group -->
+
+<!-- wp:template-part {"slug":"footer","tagName":"footer"} /-->

--- a/themes/flavian-shop/templates/page-cart.html
+++ b/themes/flavian-shop/templates/page-cart.html
@@ -1,0 +1,18 @@
+<!-- wp:template-part {"slug":"header","tagName":"header"} /-->
+
+<!-- wp:group {"tagName":"main","layout":{"type":"constrained"}} -->
+<main class="wp-block-group">
+  <!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|50","bottom":"var:preset|spacing|60"}}},"layout":{"type":"constrained"}} -->
+  <div class="wp-block-group" style="padding-top:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--60)">
+    <!-- wp:heading {"level":1} -->
+    <h1 class="wp-block-heading">Your cart</h1>
+    <!-- /wp:heading -->
+
+    <!-- wp:woocommerce/store-notices /-->
+    <!-- wp:woocommerce/cart /-->
+  </div>
+  <!-- /wp:group -->
+</main>
+<!-- /wp:group -->
+
+<!-- wp:template-part {"slug":"footer","tagName":"footer"} /-->

--- a/themes/flavian-shop/templates/page-checkout.html
+++ b/themes/flavian-shop/templates/page-checkout.html
@@ -1,0 +1,18 @@
+<!-- wp:template-part {"slug":"header","tagName":"header"} /-->
+
+<!-- wp:group {"tagName":"main","layout":{"type":"constrained"}} -->
+<main class="wp-block-group">
+  <!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|50","bottom":"var:preset|spacing|60"}}},"layout":{"type":"constrained"}} -->
+  <div class="wp-block-group" style="padding-top:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--60)">
+    <!-- wp:heading {"level":1} -->
+    <h1 class="wp-block-heading">Checkout</h1>
+    <!-- /wp:heading -->
+
+    <!-- wp:woocommerce/store-notices /-->
+    <!-- wp:woocommerce/checkout /-->
+  </div>
+  <!-- /wp:group -->
+</main>
+<!-- /wp:group -->
+
+<!-- wp:template-part {"slug":"footer","tagName":"footer"} /-->

--- a/themes/flavian-shop/templates/page-myaccount.html
+++ b/themes/flavian-shop/templates/page-myaccount.html
@@ -1,0 +1,18 @@
+<!-- wp:template-part {"slug":"header","tagName":"header"} /-->
+
+<!-- wp:group {"tagName":"main","layout":{"type":"constrained"}} -->
+<main class="wp-block-group">
+  <!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|50","bottom":"var:preset|spacing|60"}}},"layout":{"type":"constrained"}} -->
+  <div class="wp-block-group" style="padding-top:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--60)">
+    <!-- wp:heading {"level":1} -->
+    <h1 class="wp-block-heading">My account</h1>
+    <!-- /wp:heading -->
+
+    <!-- wp:woocommerce/store-notices /-->
+    <!-- wp:post-content /-->
+  </div>
+  <!-- /wp:group -->
+</main>
+<!-- /wp:group -->
+
+<!-- wp:template-part {"slug":"footer","tagName":"footer"} /-->

--- a/themes/flavian-shop/templates/page-shop.html
+++ b/themes/flavian-shop/templates/page-shop.html
@@ -1,0 +1,13 @@
+<!-- wp:template-part {"slug":"header","tagName":"header"} /-->
+
+<!-- wp:group {"tagName":"main","layout":{"type":"constrained"}} -->
+<main class="wp-block-group">
+  <!-- wp:pattern {"slug":"flavian-shop/hero-shop"} /-->
+  <!-- wp:pattern {"slug":"flavian-shop/usp-strip"} /-->
+  <!-- wp:pattern {"slug":"flavian-shop/featured-products"} /-->
+  <!-- wp:pattern {"slug":"flavian-shop/category-grid"} /-->
+  <!-- wp:pattern {"slug":"flavian-shop/newsletter"} /-->
+</main>
+<!-- /wp:group -->
+
+<!-- wp:template-part {"slug":"footer","tagName":"footer"} /-->

--- a/themes/flavian-shop/templates/page.html
+++ b/themes/flavian-shop/templates/page.html
@@ -1,0 +1,14 @@
+<!-- wp:template-part {"slug":"header","tagName":"header"} /-->
+
+<!-- wp:group {"tagName":"main","layout":{"type":"constrained"}} -->
+<main class="wp-block-group">
+  <!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|50","bottom":"var:preset|spacing|50"}}},"layout":{"type":"constrained"}} -->
+  <div class="wp-block-group" style="padding-top:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--50)">
+    <!-- wp:post-title {"level":1} /-->
+    <!-- wp:post-content /-->
+  </div>
+  <!-- /wp:group -->
+</main>
+<!-- /wp:group -->
+
+<!-- wp:template-part {"slug":"footer","tagName":"footer"} /-->

--- a/themes/flavian-shop/templates/single-product.html
+++ b/themes/flavian-shop/templates/single-product.html
@@ -1,0 +1,47 @@
+<!-- wp:template-part {"slug":"header","tagName":"header"} /-->
+
+<!-- wp:group {"tagName":"main","layout":{"type":"constrained"}} -->
+<main class="wp-block-group">
+  <!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|50","bottom":"var:preset|spacing|60"}}},"layout":{"type":"constrained"}} -->
+  <div class="wp-block-group" style="padding-top:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--60)">
+    <!-- wp:woocommerce/breadcrumbs /-->
+    <!-- wp:woocommerce/store-notices /-->
+
+    <!-- wp:columns -->
+    <div class="wp-block-columns">
+      <!-- wp:column {"width":"55%"} -->
+      <div class="wp-block-column" style="flex-basis:55%">
+        <!-- wp:woocommerce/product-image-gallery /-->
+      </div>
+      <!-- /wp:column -->
+
+      <!-- wp:column -->
+      <div class="wp-block-column">
+        <!-- wp:post-title {"level":1} /-->
+        <!-- wp:woocommerce/product-rating /-->
+        <!-- wp:woocommerce/product-price /-->
+        <!-- wp:post-excerpt /-->
+        <!-- wp:woocommerce/add-to-cart-form /-->
+        <!-- wp:woocommerce/product-meta /-->
+      </div>
+      <!-- /wp:column -->
+    </div>
+    <!-- /wp:columns -->
+
+    <!-- wp:woocommerce/product-details {"hideTabTitle":false} /-->
+  </div>
+  <!-- /wp:group -->
+
+  <!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"var:preset|spacing|50","right":"var:preset|spacing|40","bottom":"var:preset|spacing|60","left":"var:preset|spacing|40"}}},"backgroundColor":"surface","layout":{"type":"constrained"}} -->
+  <div class="wp-block-group alignfull has-surface-background-color has-background" style="padding-top:var(--wp--preset--spacing--50);padding-right:var(--wp--preset--spacing--40);padding-bottom:var(--wp--preset--spacing--60);padding-left:var(--wp--preset--spacing--40)">
+    <!-- wp:heading {"level":2,"fontSize":"x-large"} -->
+    <h2 class="wp-block-heading has-x-large-font-size">Related products</h2>
+    <!-- /wp:heading -->
+
+    <!-- wp:woocommerce/related-products {"columns":4,"rows":1} /-->
+  </div>
+  <!-- /wp:group -->
+</main>
+<!-- /wp:group -->
+
+<!-- wp:template-part {"slug":"footer","tagName":"footer"} /-->

--- a/themes/flavian-shop/templates/taxonomy-product_cat.html
+++ b/themes/flavian-shop/templates/taxonomy-product_cat.html
@@ -1,0 +1,47 @@
+<!-- wp:template-part {"slug":"header","tagName":"header"} /-->
+
+<!-- wp:group {"tagName":"main","layout":{"type":"constrained"}} -->
+<main class="wp-block-group">
+  <!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"var:preset|spacing|50","right":"var:preset|spacing|40","bottom":"var:preset|spacing|40","left":"var:preset|spacing|40"}}},"backgroundColor":"surface","layout":{"type":"constrained"}} -->
+  <div class="wp-block-group alignfull has-surface-background-color has-background" style="padding-top:var(--wp--preset--spacing--50);padding-right:var(--wp--preset--spacing--40);padding-bottom:var(--wp--preset--spacing--40);padding-left:var(--wp--preset--spacing--40)">
+    <!-- wp:paragraph {"fontSize":"small","textColor":"muted"} -->
+    <p class="has-muted-color has-text-color has-small-font-size">Category</p>
+    <!-- /wp:paragraph -->
+    <!-- wp:post-title {"level":1} /-->
+    <!-- wp:term-description /-->
+  </div>
+  <!-- /wp:group -->
+
+  <!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|40","bottom":"var:preset|spacing|60"}}},"layout":{"type":"constrained"}} -->
+  <div class="wp-block-group" style="padding-top:var(--wp--preset--spacing--40);padding-bottom:var(--wp--preset--spacing--60)">
+    <!-- wp:woocommerce/catalog-sorting /-->
+    <!-- wp:woocommerce/product-results-count /-->
+
+    <!-- wp:query {"queryId":2,"query":{"perPage":12,"pages":0,"offset":0,"postType":"product","order":"asc","orderBy":"title","inherit":true}} -->
+    <div class="wp-block-query">
+      <!-- wp:post-template {"layout":{"type":"grid","columnCount":4}} -->
+        <!-- wp:woocommerce/product-image {"showSaleBadge":true,"saleBadgeAlign":"right","isDescendentOfQueryLoop":true} /-->
+        <!-- wp:post-title {"isLink":true,"level":3,"fontSize":"medium"} /-->
+        <!-- wp:woocommerce/product-price {"isDescendentOfQueryLoop":true} /-->
+        <!-- wp:woocommerce/product-button {"isDescendentOfQueryLoop":true} /-->
+      <!-- /wp:post-template -->
+
+      <!-- wp:query-pagination {"layout":{"type":"flex","justifyContent":"center"}} -->
+        <!-- wp:query-pagination-previous /-->
+        <!-- wp:query-pagination-numbers /-->
+        <!-- wp:query-pagination-next /-->
+      <!-- /wp:query-pagination -->
+
+      <!-- wp:query-no-results -->
+        <!-- wp:paragraph -->
+        <p>No products in this category yet.</p>
+        <!-- /wp:paragraph -->
+      <!-- /wp:query-no-results -->
+    </div>
+    <!-- /wp:query -->
+  </div>
+  <!-- /wp:group -->
+</main>
+<!-- /wp:group -->
+
+<!-- wp:template-part {"slug":"footer","tagName":"footer"} /-->

--- a/themes/flavian-shop/theme.json
+++ b/themes/flavian-shop/theme.json
@@ -1,0 +1,91 @@
+{
+  "$schema": "https://schemas.wp.org/trunk/theme.json",
+  "version": 3,
+  "settings": {
+    "appearanceTools": true,
+    "useRootPaddingAwareAlignments": true,
+    "color": {
+      "defaultDuotone": false,
+      "defaultGradients": false,
+      "defaultPalette": false,
+      "palette": [
+        { "slug": "background",    "color": "#ffffff", "name": "Background" },
+        { "slug": "surface",       "color": "#f7f6f2", "name": "Surface" },
+        { "slug": "foreground",    "color": "#111111", "name": "Foreground" },
+        { "slug": "muted",         "color": "#5b5b5b", "name": "Muted" },
+        { "slug": "primary",       "color": "#0b5cff", "name": "Primary" },
+        { "slug": "primary-hover", "color": "#003fcc", "name": "Primary Hover" },
+        { "slug": "accent",        "color": "#ff6f3c", "name": "Accent" },
+        { "slug": "success",       "color": "#0a7d34", "name": "Success" },
+        { "slug": "danger",        "color": "#b00020", "name": "Danger" },
+        { "slug": "border",        "color": "#e6e4dd", "name": "Border" }
+      ]
+    },
+    "typography": {
+      "fluid": true,
+      "defaultFontSizes": false,
+      "fontFamilies": [
+        {
+          "slug": "sans",
+          "name": "Sans",
+          "fontFamily": "system-ui, -apple-system, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif"
+        },
+        {
+          "slug": "serif",
+          "name": "Serif",
+          "fontFamily": "Georgia, 'Times New Roman', serif"
+        }
+      ],
+      "fontSizes": [
+        { "slug": "small",   "size": "0.875rem",                "name": "Small" },
+        { "slug": "base",    "size": "1rem",                    "name": "Base" },
+        { "slug": "medium",  "size": "1.125rem",                "name": "Medium" },
+        { "slug": "large",   "size": "clamp(1.25rem, 2vw, 1.5rem)",  "name": "Large" },
+        { "slug": "x-large", "size": "clamp(1.75rem, 3vw, 2.25rem)", "name": "X Large" },
+        { "slug": "display", "size": "clamp(2.25rem, 5vw, 3.5rem)",  "name": "Display" }
+      ]
+    },
+    "layout": {
+      "contentSize": "768px",
+      "wideSize": "1200px"
+    },
+    "spacing": {
+      "units": ["px", "em", "rem", "%", "vh", "vw"],
+      "spacingScale": { "operator": "*", "increment": 1.5, "steps": 7, "mediumStep": 1.5, "unit": "rem" }
+    }
+  },
+  "styles": {
+    "color": {
+      "background": "var(--wp--preset--color--background)",
+      "text": "var(--wp--preset--color--foreground)"
+    },
+    "typography": {
+      "fontFamily": "var(--wp--preset--font-family--sans)",
+      "fontSize": "var(--wp--preset--font-size--base)",
+      "lineHeight": "1.6"
+    },
+    "elements": {
+      "h1": { "typography": { "fontSize": "var(--wp--preset--font-size--display)", "lineHeight": "1.15", "fontWeight": "700" } },
+      "h2": { "typography": { "fontSize": "var(--wp--preset--font-size--x-large)", "lineHeight": "1.2",  "fontWeight": "700" } },
+      "h3": { "typography": { "fontSize": "var(--wp--preset--font-size--large)",   "lineHeight": "1.3",  "fontWeight": "600" } },
+      "link": {
+        "color": { "text": "var(--wp--preset--color--primary)" },
+        ":hover": { "color": { "text": "var(--wp--preset--color--primary-hover)" } }
+      },
+      "button": {
+        "color": { "background": "var(--wp--preset--color--primary)", "text": "var(--wp--preset--color--background)" },
+        "border": { "radius": "0.375rem" },
+        "spacing": { "padding": { "top": "0.75rem", "right": "1.25rem", "bottom": "0.75rem", "left": "1.25rem" } },
+        ":hover": { "color": { "background": "var(--wp--preset--color--primary-hover)" } }
+      }
+    }
+  },
+  "templateParts": [
+    { "name": "header", "title": "Header", "area": "header" },
+    { "name": "footer", "title": "Footer", "area": "footer" }
+  ],
+  "customTemplates": [
+    { "name": "page-shop",     "title": "Shop landing", "postTypes": ["page"] },
+    { "name": "page-no-title", "title": "Page (no title)", "postTypes": ["page"] }
+  ]
+}


### PR DESCRIPTION
## Summary

Adds end-to-end WooCommerce support to the Flavian scaffold:

- **`themes/flavian-shop/`** — a WooCommerce-ready FSE starter theme with
  design-token theme.json, header/footer parts, and 10 block templates
  covering shop, single product, category, cart, checkout, my-account, shop
  landing, plus index/page/404.
- **6 WooCommerce block patterns** (hero-shop, usp-strip, featured-products,
  product-grid, category-grid, newsletter) — pattern-first architecture so
  templates stay thin.
- **One-shot Docker installer** under the `woocommerce` compose profile:
  `docker compose --profile woocommerce up woocommerce-installer`. Driven by
  env vars in `.env.example` (`WC_INSTALL_SAMPLE_DATA`, `WC_DEFAULT_THEME`,
  `WC_DEFAULT_CURRENCY`, `WC_DEFAULT_COUNTRY`).
- **`scripts/wordpress-install/setup-woocommerce.sh`** — idempotent installer
  that activates WC, creates the four shop pages with the right page-template
  assignments, sets base options, imports sample data, and activates the
  starter theme. Works both from the host (`docker compose exec`) and from
  the sibling installer container (`docker exec`).
- **`woocommerce-agent`** — specialises in WC store setup, product import,
  shipping zones, taxes, payment-gateway scaffolding, and FSE template
  customisation against `flavian-shop`.

Closes #17

## Acceptance criteria

- [x] WooCommerce block templates included in scaffold
- [x] WooCommerce-specific agent created
- [x] Docker setup includes WooCommerce by default (opt-in profile, one
      command from a fresh `up`)

## What changed

| Area | Details |
|---|---|
| Theme | `themes/flavian-shop/` — style.css, theme.json, functions.php, 2 parts, 10 templates, 6 patterns, README |
| Installer | `scripts/wordpress-install/setup-woocommerce.sh` (idempotent, dual-mode) |
| Docker | `docker-compose.yml` — new `woocommerce-installer` service under `woocommerce` profile |
| Agent | `.claude/agents/woocommerce-agent.md` |
| Env | `.env.example` — `WC_*` defaults |
| Docs | `CLAUDE.md` and `CUSTOM-AGENTS-GUIDE.md` bumped to 51 agents |

## Test plan

- [x] `validate-agent-configs.sh` passes (0 warnings)
- [x] `bash -n setup-woocommerce.sh` passes
- [x] `docker compose --profile woocommerce config` parses cleanly and shows
      the new service
- [x] `php -l` passes on every PHP file in the theme
- [ ] End-to-end: `docker compose up -d && docker compose --profile
      woocommerce up woocommerce-installer` against a fresh install
      completes and the shop URLs return 200
- [ ] Walk a sample product to checkout in the local container