### PR TITLE
feat: add plugin scaffold generator with flavian-starter reference plugin

### DIFF
--- a/.claude/agents/plugin-developer.md
+++ b/.claude/agents/plugin-developer.md
@@ -1,6 +1,6 @@
 ---
 name: plugin-developer
-description: Use this agent when developing WordPress plugins including custom post types, REST API endpoints, admin pages, Gutenberg blocks, and plugin architecture.
+description: Use this agent when developing WordPress plugins including custom post types, REST API endpoints, admin pages, Gutenberg blocks, plugin architecture, and scaffolding new plugins via scripts/scaffold-plugin.sh.
 tools: Write, Read, MultiEdit, Bash, Grep, Glob, AskUserQuestion, TaskOutput, Edits, KillShell, Skill, Task, TodoWrite, WebFetch, WebSearch
 model: opus
 permissionMode: bypassPermissions
@@ -22,32 +22,54 @@ hooks:
 
 You are a WordPress plugin development specialist with deep expertise in the WordPress Plugin API, hooks system, REST API, custom post types, Gutenberg block development, and admin UI creation. You build secure, performant, standards-compliant WordPress plugins.
 
+## Starting a new plugin
+
+**Use the scaffold script first, then edit the generated code.** Do not hand-write boilerplate.
+
+```bash
+bash scripts/scaffold-plugin.sh <plugin-slug> \
+  --name "Human Readable Name" \
+  --description "What it does" \
+  --author "Author Name"
+```
+
+This generates `plugins/<plugin-slug>/` from the templates in `.claude/templates/plugin/` with PSR-4 autoloading (`Flavian\Plugins\<PluginClass>`), Composer config, PHPUnit (Brain Monkey), PHPCS (`WordPress-Extra`), a settings page, a CPT + taxonomy pair, and a server-rendered block. Feature flags: `--no-cpt`, `--no-taxonomy`, `--no-settings`, `--no-block`, `--minimal`.
+
+The reference plugin `plugins/flavian-starter/` is the canonical example — copy its patterns rather than inventing new ones. Drift between templates and the reference plugin is enforced by `.github/workflows/plugin-validation.yml`.
+
 ## Primary Responsibilities
 
 ### 1. Plugin Architecture
 
-When creating plugins, follow the standard structure:
+Scaffold-generated plugins use PSR-4 under `src/`:
 
 ```
-plugins/plugin-name/
-├── plugin-name.php            # Main plugin file with header
-├── includes/                  # Core PHP classes
-│   ├── class-plugin-name.php  # Main plugin class
-│   ├── class-loader.php       # Hook loader
-│   └── class-activator.php    # Activation/deactivation
-├── admin/                     # Admin-facing code
-│   ├── class-admin.php        # Admin hooks and pages
-│   ├── css/                   # Admin styles
-│   ├── js/                    # Admin scripts
-│   └── partials/              # Admin view templates
-├── public/                    # Public-facing code
-│   ├── class-public.php       # Public hooks
-│   ├── css/                   # Public styles
-│   └── js/                    # Public scripts
-├── languages/                 # Translation files
-├── tests/                     # PHPUnit tests
-└── readme.txt                 # WordPress.org readme
+plugins/<slug>/
+├── <slug>.php                       # Main file: headers, autoload, register hooks
+├── uninstall.php                    # Hard-uninstall cleanup
+├── composer.json                    # PSR-4 + dev deps
+├── phpunit.xml.dist                 # PHPUnit config
+├── .phpcs.xml.dist                  # WordPress-Extra ruleset
+├── README.md
+├── src/
+│   ├── Plugin.php                   # Bootstrap singleton (class_exists() guards)
+│   ├── Activator.php                # Registration + flush_rewrite_rules
+│   ├── Deactivator.php
+│   ├── PostTypes/<Name>.php
+│   ├── Taxonomies/<Name>.php
+│   ├── Admin/Settings.php           # Settings API page
+│   └── Blocks/<Name>.php            # register_block_type + render callback
+├── assets/
+│   ├── css/admin.css
+│   ├── js/admin.js
+│   └── blocks/<block-slug>/         # block.json + index.js (no build step) + CSS
+└── tests/
+    ├── bootstrap.php                # Brain Monkey
+    ├── TestCase.php                 # Base case w/ setUp/tearDown
+    └── <Feature>Test.php
 ```
+
+When extending the scaffold output, mirror this structure — add new CPTs under `src/PostTypes/`, new blocks under `src/Blocks/`, new admin pages under `src/Admin/`.
 
 ### 2. Plugin Header
 

--- a/.claude/templates/plugin/.phpcs.xml.dist.tmpl
+++ b/.claude/templates/plugin/.phpcs.xml.dist.tmpl
@@ -1,0 +1,31 @@
+<?xml version="1.0"?>
+<ruleset name="{{PLUGIN_NAME}}">
+    <description>PHPCS ruleset for {{PLUGIN_NAME}}.</description>
+
+    <file>.</file>
+    <exclude-pattern>vendor/*</exclude-pattern>
+    <exclude-pattern>tests/*</exclude-pattern>
+
+    <arg name="extensions" value="php"/>
+    <arg name="colors"/>
+    <arg value="ps"/>
+
+    <rule ref="WordPress-Extra"/>
+    <rule ref="WordPress-Docs"/>
+
+    <config name="minimum_supported_wp_version" value="6.5"/>
+    <config name="testVersion" value="8.0-"/>
+
+    <rule ref="WordPress.WP.I18n">
+        <properties>
+            <property name="text_domain" type="array">
+                <element value="{{TEXT_DOMAIN}}"/>
+            </property>
+        </properties>
+    </rule>
+
+    <rule ref="WordPress.Files.FileName">
+        <exclude name="WordPress.Files.FileName.NotHyphenatedLowercase"/>
+        <exclude name="WordPress.Files.FileName.InvalidClassFileName"/>
+    </rule>
+</ruleset>

--- a/.claude/templates/plugin/.phpcs.xml.dist.tmpl
+++ b/.claude/templates/plugin/.phpcs.xml.dist.tmpl
@@ -9,8 +9,13 @@
     <arg name="extensions" value="php"/>
     <arg name="colors"/>
     <arg value="ps"/>
+    <arg name="basepath" value="."/>
 
-    <rule ref="WordPress-Extra"/>
+    <!-- Skip WordPress's classic class-foo-bar.php file naming convention.
+         PSR-4 autoloading uses PascalCase filenames matching the class name. -->
+    <rule ref="WordPress-Extra">
+        <exclude name="WordPress.Files.FileName"/>
+    </rule>
     <rule ref="WordPress-Docs"/>
 
     <config name="minimum_supported_wp_version" value="6.5"/>
@@ -22,10 +27,5 @@
                 <element value="{{TEXT_DOMAIN}}"/>
             </property>
         </properties>
-    </rule>
-
-    <rule ref="WordPress.Files.FileName">
-        <exclude name="WordPress.Files.FileName.NotHyphenatedLowercase"/>
-        <exclude name="WordPress.Files.FileName.InvalidClassFileName"/>
     </rule>
 </ruleset>

--- a/.claude/templates/plugin/PLUGIN_SLUG.php.tmpl
+++ b/.claude/templates/plugin/PLUGIN_SLUG.php.tmpl
@@ -22,12 +22,12 @@ namespace {{PLUGIN_NS}};
 defined( 'ABSPATH' ) || exit;
 
 define( '{{PLUGIN_CONST}}_VERSION', '{{VERSION}}' );
-define( '{{PLUGIN_CONST}}_FILE',    __FILE__ );
-define( '{{PLUGIN_CONST}}_PATH',    plugin_dir_path( __FILE__ ) );
-define( '{{PLUGIN_CONST}}_URL',     plugin_dir_url( __FILE__ ) );
+define( '{{PLUGIN_CONST}}_FILE', __FILE__ );
+define( '{{PLUGIN_CONST}}_PATH', plugin_dir_path( __FILE__ ) );
+define( '{{PLUGIN_CONST}}_URL', plugin_dir_url( __FILE__ ) );
 
-$autoload = {{PLUGIN_CONST}}_PATH . 'vendor/autoload.php';
-if ( ! file_exists( $autoload ) ) {
+$flavian_autoload = {{PLUGIN_CONST}}_PATH . 'vendor/autoload.php';
+if ( ! file_exists( $flavian_autoload ) ) {
 	add_action(
 		'admin_notices',
 		static function (): void {
@@ -41,10 +41,10 @@ if ( ! file_exists( $autoload ) ) {
 	);
 	return;
 }
-require_once $autoload;
+require_once $flavian_autoload;
 
-register_activation_hook(   __FILE__, [ Activator::class,   'activate'   ] );
-register_deactivation_hook( __FILE__, [ Deactivator::class, 'deactivate' ] );
+register_activation_hook( __FILE__, array( Activator::class, 'activate' ) );
+register_deactivation_hook( __FILE__, array( Deactivator::class, 'deactivate' ) );
 
 add_action(
 	'plugins_loaded',

--- a/.claude/templates/plugin/PLUGIN_SLUG.php.tmpl
+++ b/.claude/templates/plugin/PLUGIN_SLUG.php.tmpl
@@ -1,0 +1,54 @@
+<?php
+/**
+ * Plugin Name:       {{PLUGIN_NAME}}
+ * Plugin URI:        https://github.com/PMDevSolutions/Flavian
+ * Description:       {{PLUGIN_DESC}}
+ * Version:           {{VERSION}}
+ * Requires at least: 6.5
+ * Requires PHP:      8.0
+ * Author:            {{AUTHOR}}
+ * License:           GPL-2.0-or-later
+ * License URI:       https://www.gnu.org/licenses/gpl-2.0.html
+ * Text Domain:       {{TEXT_DOMAIN}}
+ * Domain Path:       /languages
+ *
+ * @package {{PLUGIN_NS}}
+ */
+
+declare( strict_types=1 );
+
+namespace {{PLUGIN_NS}};
+
+defined( 'ABSPATH' ) || exit;
+
+define( '{{PLUGIN_CONST}}_VERSION', '{{VERSION}}' );
+define( '{{PLUGIN_CONST}}_FILE',    __FILE__ );
+define( '{{PLUGIN_CONST}}_PATH',    plugin_dir_path( __FILE__ ) );
+define( '{{PLUGIN_CONST}}_URL',     plugin_dir_url( __FILE__ ) );
+
+$autoload = {{PLUGIN_CONST}}_PATH . 'vendor/autoload.php';
+if ( ! file_exists( $autoload ) ) {
+	add_action(
+		'admin_notices',
+		static function (): void {
+			echo '<div class="notice notice-error"><p>';
+			esc_html_e(
+				'{{PLUGIN_NAME}}: vendor/autoload.php not found. Run "composer install" inside the plugin directory.',
+				'{{TEXT_DOMAIN}}'
+			);
+			echo '</p></div>';
+		}
+	);
+	return;
+}
+require_once $autoload;
+
+register_activation_hook(   __FILE__, [ Activator::class,   'activate'   ] );
+register_deactivation_hook( __FILE__, [ Deactivator::class, 'deactivate' ] );
+
+add_action(
+	'plugins_loaded',
+	static function (): void {
+		Plugin::instance()->boot();
+	}
+);

--- a/.claude/templates/plugin/README.md
+++ b/.claude/templates/plugin/README.md
@@ -1,0 +1,43 @@
+# Plugin Template
+
+Source templates consumed by `scripts/scaffold-plugin.sh` to generate new
+WordPress plugins under `plugins/`.
+
+## Token substitution
+
+Every `*.tmpl` file is copied to `plugins/<slug>/<path>` with the `.tmpl`
+suffix stripped, and the following tokens replaced:
+
+| Token              | Source                                              |
+| ------------------ | --------------------------------------------------- |
+| `{{PLUGIN_SLUG}}`  | first positional arg, validated `^[a-z][a-z0-9-]*$` |
+| `{{PLUGIN_NAME}}`  | `--name`, default = slug title-cased                |
+| `{{PLUGIN_DESC}}`  | `--description`, default placeholder                |
+| `{{PLUGIN_CLASS}}` | StudlyCase of slug (`flavian-starter` → `FlavianStarter`) |
+| `{{PLUGIN_CONST}}` | UPPER_SNAKE of slug (`FLAVIAN_STARTER`)             |
+| `{{PLUGIN_NS}}`    | `--namespace`, default `Flavian\Plugins\<PluginClass>` |
+| `{{TEXT_DOMAIN}}`  | always equals the slug                              |
+| `{{AUTHOR}}`       | `--author`, default = `git config user.name` or `Anonymous` |
+| `{{VERSION}}`      | always `0.1.0`                                      |
+
+Path tokens are also substituted — `PLUGIN_SLUG.php.tmpl` becomes
+`flavian-starter.php`.
+
+## Adding a new template file
+
+1. Add `<path>.tmpl` here under the appropriate subdirectory.
+2. Use the tokens above for any value that depends on the plugin identity.
+3. Regenerate `plugins/flavian-starter/` to verify the template renders:
+   ```bash
+   bash scripts/scaffold-plugin.sh flavian-starter --force
+   ```
+4. Commit both the new template and the regenerated reference plugin
+   in the same PR. CI runs a drift check that diffs the regenerated output
+   against the committed copy.
+
+## Conditional features
+
+`--no-cpt`, `--no-taxonomy`, `--no-settings`, and `--no-block` cause the
+scaffold script to delete the corresponding files after rendering. The
+`Plugin` class uses `class_exists()` guards so omitted features fail silently
+at boot time without breaking the rest of the plugin.

--- a/.claude/templates/plugin/README.md.tmpl
+++ b/.claude/templates/plugin/README.md.tmpl
@@ -1,0 +1,47 @@
+# {{PLUGIN_NAME}}
+
+{{PLUGIN_DESC}}
+
+## Requirements
+
+- WordPress 6.5+
+- PHP 8.0+
+- Composer (for development and testing)
+
+## Installation
+
+1. Copy this directory into your WordPress site's `wp-content/plugins/` directory.
+2. From inside the plugin directory, run `composer install` to generate the autoloader.
+3. Activate the plugin via the WordPress admin or with WP-CLI:
+   ```bash
+   wp plugin activate {{PLUGIN_SLUG}}
+   ```
+
+## What this plugin demonstrates
+
+- **Custom post type** — `{{PLUGIN_SLUG}}_event` registered via `src/PostTypes/Event.php`.
+- **Custom taxonomy** — `{{PLUGIN_SLUG}}_event_category` attached to the event CPT.
+- **Settings page** — `Settings → {{PLUGIN_NAME}}` using the WordPress Settings API.
+- **Dynamic block** — `{{PLUGIN_SLUG}}/featured-event` server-rendered via `register_block_type` + `block.json` (no build step required).
+- **Activation / deactivation hooks** — `flush_rewrite_rules()` on both transitions.
+- **PSR-4 autoloading** — `{{PLUGIN_NS}}` namespace, autoloaded from `src/`.
+- **Uninstall cleanup** — `uninstall.php` removes plugin options and CPT entries on hard uninstall.
+
+## Development
+
+```bash
+composer install
+composer test    # PHPUnit (unit tests, Brain Monkey)
+composer lint    # PHPCS with WordPress-Extra ruleset
+```
+
+### Adding integration tests
+
+Unit tests run against Brain Monkey mocks — no MySQL or `wp-tests-lib` required.
+For full WordPress integration tests, see
+[`wordpress-testing-workflows` skill](../../.claude/skills/wordpress-testing-workflows/SKILL.md)
+for the canonical setup.
+
+## License
+
+GPL-2.0-or-later.

--- a/.claude/templates/plugin/assets/blocks/featured-event/block.json.tmpl
+++ b/.claude/templates/plugin/assets/blocks/featured-event/block.json.tmpl
@@ -1,0 +1,19 @@
+{
+    "$schema": "https://schemas.wp.org/trunk/block.json",
+    "apiVersion": 3,
+    "name": "{{PLUGIN_SLUG}}/featured-event",
+    "version": "{{VERSION}}",
+    "title": "Featured Event",
+    "category": "widgets",
+    "icon": "calendar-alt",
+    "description": "Displays the most recent published event.",
+    "keywords": ["event", "featured"],
+    "supports": {
+        "html": false,
+        "align": ["wide", "full"]
+    },
+    "textdomain": "{{TEXT_DOMAIN}}",
+    "editorScript": "file:./index.js",
+    "editorStyle": "file:./editor.css",
+    "style": "file:./style.css"
+}

--- a/.claude/templates/plugin/assets/blocks/featured-event/editor.css.tmpl
+++ b/.claude/templates/plugin/assets/blocks/featured-event/editor.css.tmpl
@@ -1,0 +1,9 @@
+/* {{PLUGIN_NAME}} — Featured Event editor placeholder */
+
+.{{PLUGIN_SLUG}}-featured-event-placeholder {
+	padding: 1rem;
+	border: 2px dashed #ccc;
+	text-align: center;
+	background: #f6f7f7;
+	color: #50575e;
+}

--- a/.claude/templates/plugin/assets/blocks/featured-event/index.js.tmpl
+++ b/.claude/templates/plugin/assets/blocks/featured-event/index.js.tmpl
@@ -1,0 +1,39 @@
+/* global window */
+/**
+ * Editor-side registration for the Featured Event block.
+ *
+ * Uses the WordPress runtime globals (wp.blocks, wp.element, wp.blockEditor,
+ * wp.i18n) directly so the block works without an ESM/JSX build step.
+ */
+( function ( blocks, element, blockEditor, i18n ) {
+	'use strict';
+
+	var registerBlockType = blocks.registerBlockType;
+	var useBlockProps     = blockEditor.useBlockProps;
+	var el                = element.createElement;
+	var __                = i18n.__;
+
+	registerBlockType( '{{PLUGIN_SLUG}}/featured-event', {
+		edit: function () {
+			var props = useBlockProps( {
+				className: '{{PLUGIN_SLUG}}-featured-event-placeholder',
+			} );
+			return el(
+				'div',
+				props,
+				el( 'strong', null, __( 'Featured Event', '{{TEXT_DOMAIN}}' ) ),
+				el(
+					'p',
+					null,
+					__(
+						'Rendered server-side from the most recent published event.',
+						'{{TEXT_DOMAIN}}'
+					)
+				)
+			);
+		},
+		save: function () {
+			return null;
+		},
+	} );
+}( window.wp.blocks, window.wp.element, window.wp.blockEditor, window.wp.i18n ) );

--- a/.claude/templates/plugin/assets/blocks/featured-event/style.css.tmpl
+++ b/.claude/templates/plugin/assets/blocks/featured-event/style.css.tmpl
@@ -1,0 +1,17 @@
+/* {{PLUGIN_NAME}} — Featured Event front-end styles */
+
+.wp-block-{{PLUGIN_SLUG}}-featured-event {
+	padding: 1.5rem;
+	border: 1px solid #e0e0e0;
+	border-radius: 4px;
+	background: #fff;
+}
+
+.wp-block-{{PLUGIN_SLUG}}-featured-event .{{PLUGIN_SLUG}}-featured-event__title {
+	margin-top: 0;
+}
+
+.wp-block-{{PLUGIN_SLUG}}-featured-event .{{PLUGIN_SLUG}}-featured-event__link {
+	display: inline-block;
+	margin-top: 0.75rem;
+}

--- a/.claude/templates/plugin/assets/css/admin.css.tmpl
+++ b/.claude/templates/plugin/assets/css/admin.css.tmpl
@@ -1,0 +1,8 @@
+/* {{PLUGIN_NAME}} — admin styles */
+
+.wrap .{{PLUGIN_SLUG}}-notice {
+	border-left: 4px solid #2271b1;
+	padding: 12px;
+	background: #fff;
+	margin: 12px 0;
+}

--- a/.claude/templates/plugin/assets/js/admin.js.tmpl
+++ b/.claude/templates/plugin/assets/js/admin.js.tmpl
@@ -1,0 +1,6 @@
+/* global window */
+/* {{PLUGIN_NAME}} — admin script (loaded only on the Settings page). */
+( function () {
+	'use strict';
+	// Add admin-page enhancements here.
+}() );

--- a/.claude/templates/plugin/composer.json.tmpl
+++ b/.claude/templates/plugin/composer.json.tmpl
@@ -1,0 +1,38 @@
+{
+    "name": "flavian/{{PLUGIN_SLUG}}",
+    "description": "{{PLUGIN_DESC}}",
+    "type": "wordpress-plugin",
+    "license": "GPL-2.0-or-later",
+    "require": {
+        "php": ">=8.0"
+    },
+    "require-dev": {
+        "phpunit/phpunit": "^9.6",
+        "brain/monkey": "^2.6",
+        "yoast/phpunit-polyfills": "^2.0",
+        "squizlabs/php_codesniffer": "^3.10",
+        "wp-coding-standards/wpcs": "^3.0",
+        "phpcompatibility/phpcompatibility-wp": "^2.1",
+        "dealerdirect/phpcodesniffer-composer-installer": "^1.0"
+    },
+    "autoload": {
+        "psr-4": {
+            "{{PLUGIN_NS_JSON}}\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "{{PLUGIN_NS_JSON}}\\Tests\\": "tests/"
+        }
+    },
+    "scripts": {
+        "test": "phpunit",
+        "lint": "phpcs"
+    },
+    "config": {
+        "allow-plugins": {
+            "dealerdirect/phpcodesniffer-composer-installer": true
+        },
+        "sort-packages": true
+    }
+}

--- a/.claude/templates/plugin/phpunit.xml.dist.tmpl
+++ b/.claude/templates/plugin/phpunit.xml.dist.tmpl
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.6/phpunit.xsd"
+    bootstrap="tests/bootstrap.php"
+    colors="true"
+    cacheResultFile=".phpunit.result.cache"
+    failOnRisky="true"
+    failOnWarning="true"
+    beStrictAboutTestsThatDoNotTestAnything="true"
+    beStrictAboutOutputDuringTests="true"
+>
+    <testsuites>
+        <testsuite name="unit">
+            <directory>tests</directory>
+            <exclude>tests/bootstrap.php</exclude>
+            <exclude>tests/TestCase.php</exclude>
+        </testsuite>
+    </testsuites>
+    <coverage>
+        <include>
+            <directory>src</directory>
+        </include>
+    </coverage>
+</phpunit>

--- a/.claude/templates/plugin/src/Activator.php.tmpl
+++ b/.claude/templates/plugin/src/Activator.php.tmpl
@@ -11,11 +11,16 @@ namespace {{PLUGIN_NS}};
 
 defined( 'ABSPATH' ) || exit;
 
+/**
+ * Runs once when the plugin is activated.
+ */
 final class Activator {
 
 	/**
-	 * Runs once when the plugin is activated. Registers types eagerly so
-	 * rewrite rules can be flushed against the final permalink structure.
+	 * Register types eagerly so rewrite rules can be flushed against the
+	 * final permalink structure.
+	 *
+	 * @return void
 	 */
 	public static function activate(): void {
 		if ( class_exists( PostTypes\Event::class ) ) {

--- a/.claude/templates/plugin/src/Activator.php.tmpl
+++ b/.claude/templates/plugin/src/Activator.php.tmpl
@@ -1,0 +1,29 @@
+<?php
+/**
+ * Plugin activation handler.
+ *
+ * @package {{PLUGIN_NS}}
+ */
+
+declare( strict_types=1 );
+
+namespace {{PLUGIN_NS}};
+
+defined( 'ABSPATH' ) || exit;
+
+final class Activator {
+
+	/**
+	 * Runs once when the plugin is activated. Registers types eagerly so
+	 * rewrite rules can be flushed against the final permalink structure.
+	 */
+	public static function activate(): void {
+		if ( class_exists( PostTypes\Event::class ) ) {
+			( new PostTypes\Event() )->register();
+		}
+		if ( class_exists( Taxonomies\EventCategory::class ) ) {
+			( new Taxonomies\EventCategory() )->register();
+		}
+		flush_rewrite_rules();
+	}
+}

--- a/.claude/templates/plugin/src/Admin/Settings.php.tmpl
+++ b/.claude/templates/plugin/src/Admin/Settings.php.tmpl
@@ -11,6 +11,9 @@ namespace {{PLUGIN_NS}}\Admin;
 
 defined( 'ABSPATH' ) || exit;
 
+/**
+ * Registers an options page under Settings → {{PLUGIN_NAME}}.
+ */
 final class Settings {
 
 	public const OPTION_GROUP = '{{PLUGIN_SLUG}}_settings';
@@ -19,14 +22,18 @@ final class Settings {
 
 	/**
 	 * Hook menu and Settings API registration.
+	 *
+	 * @return void
 	 */
 	public function register(): void {
-		add_action( 'admin_menu', [ $this, 'add_menu' ] );
-		add_action( 'admin_init', [ $this, 'register_settings' ] );
+		add_action( 'admin_menu', array( $this, 'add_menu' ) );
+		add_action( 'admin_init', array( $this, 'register_settings' ) );
 	}
 
 	/**
 	 * Add the page under Settings.
+	 *
+	 * @return void
 	 */
 	public function add_menu(): void {
 		add_options_page(
@@ -34,23 +41,25 @@ final class Settings {
 			__( '{{PLUGIN_NAME}}', '{{TEXT_DOMAIN}}' ),
 			'manage_options',
 			self::PAGE_SLUG,
-			[ $this, 'render_page' ]
+			array( $this, 'render_page' )
 		);
 	}
 
 	/**
 	 * Register option group, section and field.
+	 *
+	 * @return void
 	 */
 	public function register_settings(): void {
 		register_setting(
 			self::OPTION_GROUP,
 			self::OPTION_NAME,
-			[
+			array(
 				'type'              => 'array',
-				'sanitize_callback' => [ $this, 'sanitize' ],
-				'default'           => [ 'greeting' => '' ],
+				'sanitize_callback' => array( $this, 'sanitize' ),
+				'default'           => array( 'greeting' => '' ),
 				'show_in_rest'      => false,
-			]
+			)
 		);
 
 		add_settings_section(
@@ -63,7 +72,7 @@ final class Settings {
 		add_settings_field(
 			'{{PLUGIN_SLUG}}_greeting',
 			__( 'Greeting', '{{TEXT_DOMAIN}}' ),
-			[ $this, 'render_greeting_field' ],
+			array( $this, 'render_greeting_field' ),
 			self::PAGE_SLUG,
 			'{{PLUGIN_SLUG}}_general'
 		);
@@ -76,17 +85,19 @@ final class Settings {
 	 * @return array<string, string>
 	 */
 	public function sanitize( $input ): array {
-		$input = is_array( $input ) ? $input : [];
-		return [
+		$input = is_array( $input ) ? $input : array();
+		return array(
 			'greeting' => isset( $input['greeting'] ) ? sanitize_text_field( (string) $input['greeting'] ) : '',
-		];
+		);
 	}
 
 	/**
 	 * Render the single text-input field.
+	 *
+	 * @return void
 	 */
 	public function render_greeting_field(): void {
-		$options  = get_option( self::OPTION_NAME, [ 'greeting' => '' ] );
+		$options  = get_option( self::OPTION_NAME, array( 'greeting' => '' ) );
 		$greeting = isset( $options['greeting'] ) ? (string) $options['greeting'] : '';
 		printf(
 			'<input type="text" name="%1$s[greeting]" value="%2$s" class="regular-text" />',
@@ -97,6 +108,8 @@ final class Settings {
 
 	/**
 	 * Render the page wrapper.
+	 *
+	 * @return void
 	 */
 	public function render_page(): void {
 		if ( ! current_user_can( 'manage_options' ) ) {

--- a/.claude/templates/plugin/src/Admin/Settings.php.tmpl
+++ b/.claude/templates/plugin/src/Admin/Settings.php.tmpl
@@ -1,0 +1,118 @@
+<?php
+/**
+ * Settings page using the WordPress Settings API.
+ *
+ * @package {{PLUGIN_NS}}
+ */
+
+declare( strict_types=1 );
+
+namespace {{PLUGIN_NS}}\Admin;
+
+defined( 'ABSPATH' ) || exit;
+
+final class Settings {
+
+	public const OPTION_GROUP = '{{PLUGIN_SLUG}}_settings';
+	public const OPTION_NAME  = '{{PLUGIN_SLUG}}_options';
+	public const PAGE_SLUG    = '{{PLUGIN_SLUG}}';
+
+	/**
+	 * Hook menu and Settings API registration.
+	 */
+	public function register(): void {
+		add_action( 'admin_menu', [ $this, 'add_menu' ] );
+		add_action( 'admin_init', [ $this, 'register_settings' ] );
+	}
+
+	/**
+	 * Add the page under Settings.
+	 */
+	public function add_menu(): void {
+		add_options_page(
+			__( '{{PLUGIN_NAME}}', '{{TEXT_DOMAIN}}' ),
+			__( '{{PLUGIN_NAME}}', '{{TEXT_DOMAIN}}' ),
+			'manage_options',
+			self::PAGE_SLUG,
+			[ $this, 'render_page' ]
+		);
+	}
+
+	/**
+	 * Register option group, section and field.
+	 */
+	public function register_settings(): void {
+		register_setting(
+			self::OPTION_GROUP,
+			self::OPTION_NAME,
+			[
+				'type'              => 'array',
+				'sanitize_callback' => [ $this, 'sanitize' ],
+				'default'           => [ 'greeting' => '' ],
+				'show_in_rest'      => false,
+			]
+		);
+
+		add_settings_section(
+			'{{PLUGIN_SLUG}}_general',
+			__( 'General', '{{TEXT_DOMAIN}}' ),
+			'__return_false',
+			self::PAGE_SLUG
+		);
+
+		add_settings_field(
+			'{{PLUGIN_SLUG}}_greeting',
+			__( 'Greeting', '{{TEXT_DOMAIN}}' ),
+			[ $this, 'render_greeting_field' ],
+			self::PAGE_SLUG,
+			'{{PLUGIN_SLUG}}_general'
+		);
+	}
+
+	/**
+	 * Sanitize the option array before save.
+	 *
+	 * @param mixed $input Raw submitted value.
+	 * @return array<string, string>
+	 */
+	public function sanitize( $input ): array {
+		$input = is_array( $input ) ? $input : [];
+		return [
+			'greeting' => isset( $input['greeting'] ) ? sanitize_text_field( (string) $input['greeting'] ) : '',
+		];
+	}
+
+	/**
+	 * Render the single text-input field.
+	 */
+	public function render_greeting_field(): void {
+		$options  = get_option( self::OPTION_NAME, [ 'greeting' => '' ] );
+		$greeting = isset( $options['greeting'] ) ? (string) $options['greeting'] : '';
+		printf(
+			'<input type="text" name="%1$s[greeting]" value="%2$s" class="regular-text" />',
+			esc_attr( self::OPTION_NAME ),
+			esc_attr( $greeting )
+		);
+	}
+
+	/**
+	 * Render the page wrapper.
+	 */
+	public function render_page(): void {
+		if ( ! current_user_can( 'manage_options' ) ) {
+			return;
+		}
+		?>
+		<div class="wrap">
+			<h1><?php echo esc_html( get_admin_page_title() ); ?></h1>
+			<form action="options.php" method="post">
+				<?php
+				settings_fields( self::OPTION_GROUP );
+				do_settings_sections( self::PAGE_SLUG );
+				submit_button();
+				?>
+			</form>
+		</div>
+		<?php
+	}
+}

--- a/.claude/templates/plugin/src/Blocks/FeaturedEvent.php.tmpl
+++ b/.claude/templates/plugin/src/Blocks/FeaturedEvent.php.tmpl
@@ -1,0 +1,87 @@
+<?php
+/**
+ * Featured Event dynamic block.
+ *
+ * Server-rendered — no build step required. The editor-side script in
+ * assets/blocks/featured-event/index.js uses the WP runtime globals
+ * (wp.blocks, wp.element, wp.blockEditor, wp.i18n) directly instead of an
+ * ESM/JSX bundle, so the plugin works the moment it's activated.
+ *
+ * @package {{PLUGIN_NS}}
+ */
+
+declare( strict_types=1 );
+
+namespace {{PLUGIN_NS}}\Blocks;
+
+use {{PLUGIN_NS}}\PostTypes\Event;
+
+defined( 'ABSPATH' ) || exit;
+
+final class FeaturedEvent {
+
+	/**
+	 * Hook block registration to `init` (required by register_block_type).
+	 */
+	public function register(): void {
+		add_action( 'init', [ $this, 'register_block' ] );
+	}
+
+	/**
+	 * Register the block by pointing register_block_type at the block.json.
+	 */
+	public function register_block(): void {
+		register_block_type(
+			{{PLUGIN_CONST}}_PATH . 'assets/blocks/featured-event',
+			[
+				'render_callback' => [ $this, 'render' ],
+			]
+		);
+	}
+
+	/**
+	 * Server-side render: pulls the most recent published event.
+	 *
+	 * @param array<string, mixed> $attributes Block attributes (unused here).
+	 * @param string               $content    Inner content (unused here).
+	 */
+	public function render( array $attributes, string $content ): string {
+		unset( $attributes, $content );
+
+		$post_type = class_exists( Event::class ) ? Event::POST_TYPE : '{{PLUGIN_SLUG}}_event';
+
+		$events = get_posts(
+			[
+				'post_type'      => $post_type,
+				'posts_per_page' => 1,
+				'post_status'    => 'publish',
+				'no_found_rows'  => true,
+			]
+		);
+
+		if ( empty( $events ) ) {
+			return '';
+		}
+
+		$event   = $events[0];
+		$excerpt = '' !== $event->post_excerpt
+			? $event->post_excerpt
+			: wp_trim_words( $event->post_content, 30 );
+
+		ob_start();
+		?>
+		<div <?php echo wp_kses_data( get_block_wrapper_attributes() ); ?>>
+			<h3 class="{{PLUGIN_SLUG}}-featured-event__title">
+				<?php echo esc_html( $event->post_title ); ?>
+			</h3>
+			<div class="{{PLUGIN_SLUG}}-featured-event__excerpt">
+				<?php echo wp_kses_post( wpautop( $excerpt ) ); ?>
+			</div>
+			<a class="{{PLUGIN_SLUG}}-featured-event__link" href="<?php echo esc_url( (string) get_permalink( $event ) ); ?>">
+				<?php esc_html_e( 'Read more', '{{TEXT_DOMAIN}}' ); ?>
+			</a>
+		</div>
+		<?php
+		return (string) ob_get_clean();
+	}
+}

--- a/.claude/templates/plugin/src/Blocks/FeaturedEvent.php.tmpl
+++ b/.claude/templates/plugin/src/Blocks/FeaturedEvent.php.tmpl
@@ -18,32 +18,40 @@ use {{PLUGIN_NS}}\PostTypes\Event;
 
 defined( 'ABSPATH' ) || exit;
 
+/**
+ * Registers and server-renders the Featured Event block.
+ */
 final class FeaturedEvent {
 
 	/**
 	 * Hook block registration to `init` (required by register_block_type).
+	 *
+	 * @return void
 	 */
 	public function register(): void {
-		add_action( 'init', [ $this, 'register_block' ] );
+		add_action( 'init', array( $this, 'register_block' ) );
 	}
 
 	/**
 	 * Register the block by pointing register_block_type at the block.json.
+	 *
+	 * @return void
 	 */
 	public function register_block(): void {
 		register_block_type(
 			{{PLUGIN_CONST}}_PATH . 'assets/blocks/featured-event',
-			[
-				'render_callback' => [ $this, 'render' ],
-			]
+			array(
+				'render_callback' => array( $this, 'render' ),
+			)
 		);
 	}
 
 	/**
 	 * Server-side render: pulls the most recent published event.
 	 *
-	 * @param array<string, mixed> $attributes Block attributes (unused here).
-	 * @param string               $content    Inner content (unused here).
+	 * @param array<string, mixed> $attributes Block attributes (unused).
+	 * @param string               $content    Inner content (unused).
+	 * @return string
 	 */
 	public function render( array $attributes, string $content ): string {
 		unset( $attributes, $content );
@@ -51,12 +59,12 @@ final class FeaturedEvent {
 		$post_type = class_exists( Event::class ) ? Event::POST_TYPE : '{{PLUGIN_SLUG}}_event';
 
 		$events = get_posts(
-			[
+			array(
 				'post_type'      => $post_type,
 				'posts_per_page' => 1,
 				'post_status'    => 'publish',
 				'no_found_rows'  => true,
-			]
+			)
 		);
 
 		if ( empty( $events ) ) {

--- a/.claude/templates/plugin/src/Deactivator.php.tmpl
+++ b/.claude/templates/plugin/src/Deactivator.php.tmpl
@@ -1,0 +1,23 @@
+<?php
+/**
+ * Plugin deactivation handler.
+ *
+ * @package {{PLUGIN_NS}}
+ */
+
+declare( strict_types=1 );
+
+namespace {{PLUGIN_NS}};
+
+defined( 'ABSPATH' ) || exit;
+
+final class Deactivator {
+
+	/**
+	 * Runs once when the plugin is deactivated. Flushes rewrite rules so the
+	 * custom post type's permalink rules disappear cleanly.
+	 */
+	public static function deactivate(): void {
+		flush_rewrite_rules();
+	}
+}

--- a/.claude/templates/plugin/src/Deactivator.php.tmpl
+++ b/.claude/templates/plugin/src/Deactivator.php.tmpl
@@ -11,11 +11,15 @@ namespace {{PLUGIN_NS}};
 
 defined( 'ABSPATH' ) || exit;
 
+/**
+ * Runs once when the plugin is deactivated.
+ */
 final class Deactivator {
 
 	/**
-	 * Runs once when the plugin is deactivated. Flushes rewrite rules so the
-	 * custom post type's permalink rules disappear cleanly.
+	 * Flush rewrite rules so the custom post type's permalink rules disappear cleanly.
+	 *
+	 * @return void
 	 */
 	public static function deactivate(): void {
 		flush_rewrite_rules();

--- a/.claude/templates/plugin/src/Plugin.php.tmpl
+++ b/.claude/templates/plugin/src/Plugin.php.tmpl
@@ -27,6 +27,8 @@ final class Plugin {
 
 	/**
 	 * Accessor for the singleton instance.
+	 *
+	 * @return self
 	 */
 	public static function instance(): self {
 		if ( null === self::$instance ) {
@@ -42,6 +44,8 @@ final class Plugin {
 
 	/**
 	 * Wire feature classes into WordPress.
+	 *
+	 * @return void
 	 */
 	public function boot(): void {
 		if ( class_exists( PostTypes\Event::class ) ) {
@@ -57,12 +61,14 @@ final class Plugin {
 			( new Blocks\FeaturedEvent() )->register();
 		}
 
-		add_action( 'init', [ $this, 'load_textdomain' ] );
-		add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_admin_assets' ] );
+		add_action( 'init', array( $this, 'load_textdomain' ) );
+		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_admin_assets' ) );
 	}
 
 	/**
 	 * Load the plugin's text domain.
+	 *
+	 * @return void
 	 */
 	public function load_textdomain(): void {
 		load_plugin_textdomain(
@@ -76,6 +82,7 @@ final class Plugin {
 	 * Enqueue admin-only assets.
 	 *
 	 * @param string $hook Current admin page hook suffix.
+	 * @return void
 	 */
 	public function enqueue_admin_assets( string $hook ): void {
 		if ( 'settings_page_{{PLUGIN_SLUG}}' !== $hook ) {
@@ -84,13 +91,13 @@ final class Plugin {
 		wp_enqueue_style(
 			'{{PLUGIN_SLUG}}-admin',
 			{{PLUGIN_CONST}}_URL . 'assets/css/admin.css',
-			[],
+			array(),
 			{{PLUGIN_CONST}}_VERSION
 		);
 		wp_enqueue_script(
 			'{{PLUGIN_SLUG}}-admin',
 			{{PLUGIN_CONST}}_URL . 'assets/js/admin.js',
-			[],
+			array(),
 			{{PLUGIN_CONST}}_VERSION,
 			true
 		);

--- a/.claude/templates/plugin/src/Plugin.php.tmpl
+++ b/.claude/templates/plugin/src/Plugin.php.tmpl
@@ -1,0 +1,98 @@
+<?php
+/**
+ * Bootstrap class for {{PLUGIN_NAME}}.
+ *
+ * @package {{PLUGIN_NS}}
+ */
+
+declare( strict_types=1 );
+
+namespace {{PLUGIN_NS}};
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Singleton bootstrap. Conditionally wires each feature based on which classes
+ * the autoloader can resolve — so removing a feature directory does not break
+ * the rest of the plugin.
+ */
+final class Plugin {
+
+	/**
+	 * Singleton instance.
+	 *
+	 * @var self|null
+	 */
+	private static ?self $instance = null;
+
+	/**
+	 * Accessor for the singleton instance.
+	 */
+	public static function instance(): self {
+		if ( null === self::$instance ) {
+			self::$instance = new self();
+		}
+		return self::$instance;
+	}
+
+	/**
+	 * Private constructor — use {@see self::instance()}.
+	 */
+	private function __construct() {}
+
+	/**
+	 * Wire feature classes into WordPress.
+	 */
+	public function boot(): void {
+		if ( class_exists( PostTypes\Event::class ) ) {
+			( new PostTypes\Event() )->register();
+		}
+		if ( class_exists( Taxonomies\EventCategory::class ) ) {
+			( new Taxonomies\EventCategory() )->register();
+		}
+		if ( class_exists( Admin\Settings::class ) ) {
+			( new Admin\Settings() )->register();
+		}
+		if ( class_exists( Blocks\FeaturedEvent::class ) ) {
+			( new Blocks\FeaturedEvent() )->register();
+		}
+
+		add_action( 'init', [ $this, 'load_textdomain' ] );
+		add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_admin_assets' ] );
+	}
+
+	/**
+	 * Load the plugin's text domain.
+	 */
+	public function load_textdomain(): void {
+		load_plugin_textdomain(
+			'{{TEXT_DOMAIN}}',
+			false,
+			dirname( plugin_basename( {{PLUGIN_CONST}}_FILE ) ) . '/languages'
+		);
+	}
+
+	/**
+	 * Enqueue admin-only assets.
+	 *
+	 * @param string $hook Current admin page hook suffix.
+	 */
+	public function enqueue_admin_assets( string $hook ): void {
+		if ( 'settings_page_{{PLUGIN_SLUG}}' !== $hook ) {
+			return;
+		}
+		wp_enqueue_style(
+			'{{PLUGIN_SLUG}}-admin',
+			{{PLUGIN_CONST}}_URL . 'assets/css/admin.css',
+			[],
+			{{PLUGIN_CONST}}_VERSION
+		);
+		wp_enqueue_script(
+			'{{PLUGIN_SLUG}}-admin',
+			{{PLUGIN_CONST}}_URL . 'assets/js/admin.js',
+			[],
+			{{PLUGIN_CONST}}_VERSION,
+			true
+		);
+	}
+}

--- a/.claude/templates/plugin/src/PostTypes/Event.php.tmpl
+++ b/.claude/templates/plugin/src/PostTypes/Event.php.tmpl
@@ -1,0 +1,52 @@
+<?php
+/**
+ * Example custom post type.
+ *
+ * @package {{PLUGIN_NS}}
+ */
+
+declare( strict_types=1 );
+
+namespace {{PLUGIN_NS}}\PostTypes;
+
+defined( 'ABSPATH' ) || exit;
+
+final class Event {
+
+	public const POST_TYPE = '{{PLUGIN_SLUG}}_event';
+
+	/**
+	 * Hook the registration onto `init`.
+	 */
+	public function register(): void {
+		add_action( 'init', [ $this, 'register_post_type' ] );
+	}
+
+	/**
+	 * Register the post type. Public, REST-enabled, with archive at /events/.
+	 */
+	public function register_post_type(): void {
+		register_post_type(
+			self::POST_TYPE,
+			[
+				'labels'       => [
+					'name'               => __( 'Events', '{{TEXT_DOMAIN}}' ),
+					'singular_name'      => __( 'Event', '{{TEXT_DOMAIN}}' ),
+					'add_new_item'       => __( 'Add New Event', '{{TEXT_DOMAIN}}' ),
+					'edit_item'          => __( 'Edit Event', '{{TEXT_DOMAIN}}' ),
+					'new_item'           => __( 'New Event', '{{TEXT_DOMAIN}}' ),
+					'view_item'          => __( 'View Event', '{{TEXT_DOMAIN}}' ),
+					'search_items'       => __( 'Search Events', '{{TEXT_DOMAIN}}' ),
+					'not_found'          => __( 'No events found.', '{{TEXT_DOMAIN}}' ),
+					'not_found_in_trash' => __( 'No events found in Trash.', '{{TEXT_DOMAIN}}' ),
+				],
+				'public'       => true,
+				'show_in_rest' => true,
+				'has_archive'  => true,
+				'menu_icon'    => 'dashicons-calendar-alt',
+				'supports'     => [ 'title', 'editor', 'thumbnail', 'excerpt' ],
+				'rewrite'      => [ 'slug' => 'events' ],
+			]
+		);
+	}
+}

--- a/.claude/templates/plugin/src/PostTypes/Event.php.tmpl
+++ b/.claude/templates/plugin/src/PostTypes/Event.php.tmpl
@@ -11,25 +11,32 @@ namespace {{PLUGIN_NS}}\PostTypes;
 
 defined( 'ABSPATH' ) || exit;
 
+/**
+ * Registers the Event custom post type.
+ */
 final class Event {
 
 	public const POST_TYPE = '{{PLUGIN_SLUG}}_event';
 
 	/**
 	 * Hook the registration onto `init`.
+	 *
+	 * @return void
 	 */
 	public function register(): void {
-		add_action( 'init', [ $this, 'register_post_type' ] );
+		add_action( 'init', array( $this, 'register_post_type' ) );
 	}
 
 	/**
 	 * Register the post type. Public, REST-enabled, with archive at /events/.
+	 *
+	 * @return void
 	 */
 	public function register_post_type(): void {
 		register_post_type(
 			self::POST_TYPE,
-			[
-				'labels'       => [
+			array(
+				'labels'       => array(
 					'name'               => __( 'Events', '{{TEXT_DOMAIN}}' ),
 					'singular_name'      => __( 'Event', '{{TEXT_DOMAIN}}' ),
 					'add_new_item'       => __( 'Add New Event', '{{TEXT_DOMAIN}}' ),
@@ -39,14 +46,14 @@ final class Event {
 					'search_items'       => __( 'Search Events', '{{TEXT_DOMAIN}}' ),
 					'not_found'          => __( 'No events found.', '{{TEXT_DOMAIN}}' ),
 					'not_found_in_trash' => __( 'No events found in Trash.', '{{TEXT_DOMAIN}}' ),
-				],
+				),
 				'public'       => true,
 				'show_in_rest' => true,
 				'has_archive'  => true,
 				'menu_icon'    => 'dashicons-calendar-alt',
-				'supports'     => [ 'title', 'editor', 'thumbnail', 'excerpt' ],
-				'rewrite'      => [ 'slug' => 'events' ],
-			]
+				'supports'     => array( 'title', 'editor', 'thumbnail', 'excerpt' ),
+				'rewrite'      => array( 'slug' => 'events' ),
+			)
 		);
 	}
 }

--- a/.claude/templates/plugin/src/Taxonomies/EventCategory.php.tmpl
+++ b/.claude/templates/plugin/src/Taxonomies/EventCategory.php.tmpl
@@ -1,0 +1,48 @@
+<?php
+/**
+ * Example custom taxonomy.
+ *
+ * @package {{PLUGIN_NS}}
+ */
+
+declare( strict_types=1 );
+
+namespace {{PLUGIN_NS}}\Taxonomies;
+
+use {{PLUGIN_NS}}\PostTypes\Event;
+
+defined( 'ABSPATH' ) || exit;
+
+final class EventCategory {
+
+	public const TAXONOMY = '{{PLUGIN_SLUG}}_event_category';
+
+	/**
+	 * Hook the registration onto `init`.
+	 */
+	public function register(): void {
+		add_action( 'init', [ $this, 'register_taxonomy' ] );
+	}
+
+	/**
+	 * Register the taxonomy against the Event post type.
+	 */
+	public function register_taxonomy(): void {
+		$object_type = class_exists( Event::class ) ? Event::POST_TYPE : '{{PLUGIN_SLUG}}_event';
+
+		register_taxonomy(
+			self::TAXONOMY,
+			[ $object_type ],
+			[
+				'labels'            => [
+					'name'          => __( 'Event Categories', '{{TEXT_DOMAIN}}' ),
+					'singular_name' => __( 'Event Category', '{{TEXT_DOMAIN}}' ),
+				],
+				'hierarchical'      => true,
+				'show_in_rest'      => true,
+				'show_admin_column' => true,
+				'rewrite'           => [ 'slug' => 'event-category' ],
+			]
+		);
+	}
+}

--- a/.claude/templates/plugin/src/Taxonomies/EventCategory.php.tmpl
+++ b/.claude/templates/plugin/src/Taxonomies/EventCategory.php.tmpl
@@ -13,36 +13,43 @@ use {{PLUGIN_NS}}\PostTypes\Event;
 
 defined( 'ABSPATH' ) || exit;
 
+/**
+ * Registers the Event Category taxonomy against the Event post type.
+ */
 final class EventCategory {
 
 	public const TAXONOMY = '{{PLUGIN_SLUG}}_event_category';
 
 	/**
 	 * Hook the registration onto `init`.
+	 *
+	 * @return void
 	 */
 	public function register(): void {
-		add_action( 'init', [ $this, 'register_taxonomy' ] );
+		add_action( 'init', array( $this, 'register_taxonomy' ) );
 	}
 
 	/**
-	 * Register the taxonomy against the Event post type.
+	 * Register the taxonomy.
+	 *
+	 * @return void
 	 */
 	public function register_taxonomy(): void {
 		$object_type = class_exists( Event::class ) ? Event::POST_TYPE : '{{PLUGIN_SLUG}}_event';
 
 		register_taxonomy(
 			self::TAXONOMY,
-			[ $object_type ],
-			[
-				'labels'            => [
+			array( $object_type ),
+			array(
+				'labels'            => array(
 					'name'          => __( 'Event Categories', '{{TEXT_DOMAIN}}' ),
 					'singular_name' => __( 'Event Category', '{{TEXT_DOMAIN}}' ),
-				],
+				),
 				'hierarchical'      => true,
 				'show_in_rest'      => true,
 				'show_admin_column' => true,
-				'rewrite'           => [ 'slug' => 'event-category' ],
-			]
+				'rewrite'           => array( 'slug' => 'event-category' ),
+			)
 		);
 	}
 }

--- a/.claude/templates/plugin/tests/PluginTest.php.tmpl
+++ b/.claude/templates/plugin/tests/PluginTest.php.tmpl
@@ -16,6 +16,11 @@ use {{PLUGIN_NS}}\Plugin;
  */
 final class PluginTest extends TestCase {
 
+	/**
+	 * Plugin::instance() should return the same object across calls.
+	 *
+	 * @return void
+	 */
 	public function test_instance_returns_singleton(): void {
 		$a = Plugin::instance();
 		$b = Plugin::instance();

--- a/.claude/templates/plugin/tests/PluginTest.php.tmpl
+++ b/.claude/templates/plugin/tests/PluginTest.php.tmpl
@@ -1,0 +1,24 @@
+<?php
+/**
+ * Tests the bootstrap singleton.
+ *
+ * @package {{PLUGIN_NS}}\Tests
+ */
+
+declare( strict_types=1 );
+
+namespace {{PLUGIN_NS}}\Tests;
+
+use {{PLUGIN_NS}}\Plugin;
+
+/**
+ * @covers \{{PLUGIN_NS}}\Plugin
+ */
+final class PluginTest extends TestCase {
+
+	public function test_instance_returns_singleton(): void {
+		$a = Plugin::instance();
+		$b = Plugin::instance();
+		$this->assertSame( $a, $b );
+	}
+}

--- a/.claude/templates/plugin/tests/PostTypes/EventTest.php.tmpl
+++ b/.claude/templates/plugin/tests/PostTypes/EventTest.php.tmpl
@@ -11,6 +11,7 @@ namespace {{PLUGIN_NS}}\Tests\PostTypes;
 
 use Brain\Monkey\Actions;
 use Brain\Monkey\Functions;
+use Mockery;
 use {{PLUGIN_NS}}\PostTypes\Event;
 use {{PLUGIN_NS}}\Tests\TestCase;
 
@@ -19,24 +20,42 @@ use {{PLUGIN_NS}}\Tests\TestCase;
  */
 final class EventTest extends TestCase {
 
+	/**
+	 * The slug constant should namespace the post type with the plugin slug.
+	 *
+	 * @return void
+	 */
 	public function test_post_type_constant_uses_plugin_slug(): void {
 		$this->assertSame( '{{PLUGIN_SLUG}}_event', Event::POST_TYPE );
 	}
 
+	/**
+	 * register() should hook a callable onto the 'init' action.
+	 *
+	 * @return void
+	 */
 	public function test_register_hooks_post_type_onto_init(): void {
 		Actions\expectAdded( 'init' )
 			->once()
-			->with( \Mockery::type( 'array' ) );
+			->with( Mockery::type( 'array' ) );
 
 		( new Event() )->register();
 	}
 
+	/**
+	 * register_post_type() should pass the expected slug and args.
+	 *
+	 * @return void
+	 */
 	public function test_register_post_type_passes_expected_args(): void {
-		$captured = [];
+		$captured = array();
 
 		Functions\when( 'register_post_type' )->alias(
 			static function ( $slug, $args ) use ( &$captured ): void {
-				$captured = [ 'slug' => $slug, 'args' => $args ];
+				$captured = array(
+					'slug' => $slug,
+					'args' => $args,
+				);
 			}
 		);
 

--- a/.claude/templates/plugin/tests/PostTypes/EventTest.php.tmpl
+++ b/.claude/templates/plugin/tests/PostTypes/EventTest.php.tmpl
@@ -1,0 +1,52 @@
+<?php
+/**
+ * Tests for the Event custom post type registration.
+ *
+ * @package {{PLUGIN_NS}}\Tests
+ */
+
+declare( strict_types=1 );
+
+namespace {{PLUGIN_NS}}\Tests\PostTypes;
+
+use Brain\Monkey\Actions;
+use Brain\Monkey\Functions;
+use {{PLUGIN_NS}}\PostTypes\Event;
+use {{PLUGIN_NS}}\Tests\TestCase;
+
+/**
+ * @covers \{{PLUGIN_NS}}\PostTypes\Event
+ */
+final class EventTest extends TestCase {
+
+	public function test_post_type_constant_uses_plugin_slug(): void {
+		$this->assertSame( '{{PLUGIN_SLUG}}_event', Event::POST_TYPE );
+	}
+
+	public function test_register_hooks_post_type_onto_init(): void {
+		Actions\expectAdded( 'init' )
+			->once()
+			->with( \Mockery::type( 'array' ) );
+
+		( new Event() )->register();
+	}
+
+	public function test_register_post_type_passes_expected_args(): void {
+		$captured = [];
+
+		Functions\when( 'register_post_type' )->alias(
+			static function ( $slug, $args ) use ( &$captured ): void {
+				$captured = [ 'slug' => $slug, 'args' => $args ];
+			}
+		);
+
+		( new Event() )->register_post_type();
+
+		$this->assertSame( '{{PLUGIN_SLUG}}_event', $captured['slug'] );
+		$this->assertTrue( $captured['args']['public'] );
+		$this->assertTrue( $captured['args']['show_in_rest'] );
+		$this->assertContains( 'title', $captured['args']['supports'] );
+		$this->assertContains( 'editor', $captured['args']['supports'] );
+		$this->assertSame( 'events', $captured['args']['rewrite']['slug'] );
+	}
+}

--- a/.claude/templates/plugin/tests/TestCase.php.tmpl
+++ b/.claude/templates/plugin/tests/TestCase.php.tmpl
@@ -1,0 +1,26 @@
+<?php
+/**
+ * Base test case wiring Brain Monkey setUp/tearDown.
+ *
+ * @package {{PLUGIN_NS}}\Tests
+ */
+
+declare( strict_types=1 );
+
+namespace {{PLUGIN_NS}}\Tests;
+
+use Brain\Monkey;
+use PHPUnit\Framework\TestCase as BaseTestCase;
+
+abstract class TestCase extends BaseTestCase {
+
+	protected function setUp(): void {
+		parent::setUp();
+		Monkey\setUp();
+	}
+
+	protected function tearDown(): void {
+		Monkey\tearDown();
+		parent::tearDown();
+	}
+}

--- a/.claude/templates/plugin/tests/TestCase.php.tmpl
+++ b/.claude/templates/plugin/tests/TestCase.php.tmpl
@@ -1,6 +1,6 @@
 <?php
 /**
- * Base test case wiring Brain Monkey setUp/tearDown.
+ * Base test case wiring Brain Monkey + Mockery into PHPUnit.
  *
  * @package {{PLUGIN_NS}}\Tests
  */
@@ -10,15 +10,38 @@ declare( strict_types=1 );
 namespace {{PLUGIN_NS}}\Tests;
 
 use Brain\Monkey;
+use Brain\Monkey\Functions;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
 use PHPUnit\Framework\TestCase as BaseTestCase;
 
+/**
+ * Shared base. MockeryPHPUnitIntegration bridges Mockery expectations
+ * (used by Brain Monkey's Actions/Functions verifiers) into PHPUnit's
+ * assertion counter so verified expectations don't trip "risky test".
+ */
 abstract class TestCase extends BaseTestCase {
 
+	use MockeryPHPUnitIntegration;
+
+	/**
+	 * Initialise Brain Monkey and stub WordPress i18n + escape helpers so
+	 * namespaced code can call __(), esc_html(), etc. without hitting
+	 * "undefined function" errors.
+	 *
+	 * @return void
+	 */
 	protected function setUp(): void {
 		parent::setUp();
 		Monkey\setUp();
+		Functions\stubTranslationFunctions();
+		Functions\stubEscapeFunctions();
 	}
 
+	/**
+	 * Tear down Brain Monkey (which closes Mockery for us).
+	 *
+	 * @return void
+	 */
 	protected function tearDown(): void {
 		Monkey\tearDown();
 		parent::tearDown();

--- a/.claude/templates/plugin/tests/bootstrap.php.tmpl
+++ b/.claude/templates/plugin/tests/bootstrap.php.tmpl
@@ -1,0 +1,28 @@
+<?php
+/**
+ * PHPUnit bootstrap.
+ *
+ * Brain Monkey stands in for the WordPress runtime — no MySQL or
+ * wp-tests-lib install required. Tests against real WordPress should live in
+ * a separate tests/integration/ directory with its own bootstrap.
+ *
+ * @package {{PLUGIN_NS}}\Tests
+ */
+
+declare( strict_types=1 );
+
+defined( 'ABSPATH' ) || define( 'ABSPATH', '/tmp/wordpress/' );
+
+if ( ! defined( '{{PLUGIN_CONST}}_VERSION' ) ) {
+	define( '{{PLUGIN_CONST}}_VERSION', '0.0.0-test' );
+	define( '{{PLUGIN_CONST}}_FILE',    dirname( __DIR__ ) . '/{{PLUGIN_SLUG}}.php' );
+	define( '{{PLUGIN_CONST}}_PATH',    dirname( __DIR__ ) . '/' );
+	define( '{{PLUGIN_CONST}}_URL',     'http://example.test/wp-content/plugins/{{PLUGIN_SLUG}}/' );
+}
+
+$autoload = __DIR__ . '/../vendor/autoload.php';
+if ( ! file_exists( $autoload ) ) {
+	fwrite( STDERR, "\nRun `composer install` inside this plugin before running tests.\n" );
+	exit( 1 );
+}
+require_once $autoload;

--- a/.claude/templates/plugin/uninstall.php.tmpl
+++ b/.claude/templates/plugin/uninstall.php.tmpl
@@ -11,14 +11,14 @@ defined( 'WP_UNINSTALL_PLUGIN' ) || exit;
 
 delete_option( '{{PLUGIN_SLUG}}_options' );
 
-$post_ids = get_posts(
-	[
+$flavian_post_ids = get_posts(
+	array(
 		'post_type'   => '{{PLUGIN_SLUG}}_event',
 		'numberposts' => -1,
 		'fields'      => 'ids',
 		'post_status' => 'any',
-	]
+	)
 );
-foreach ( $post_ids as $post_id ) {
-	wp_delete_post( (int) $post_id, true );
+foreach ( $flavian_post_ids as $flavian_pid ) {
+	wp_delete_post( (int) $flavian_pid, true );
 }

--- a/.claude/templates/plugin/uninstall.php.tmpl
+++ b/.claude/templates/plugin/uninstall.php.tmpl
@@ -1,0 +1,24 @@
+<?php
+/**
+ * Fires when {{PLUGIN_NAME}} is deleted via the Plugins screen (not deactivated).
+ *
+ * @package {{PLUGIN_NS}}
+ */
+
+declare( strict_types=1 );
+
+defined( 'WP_UNINSTALL_PLUGIN' ) || exit;
+
+delete_option( '{{PLUGIN_SLUG}}_options' );
+
+$post_ids = get_posts(
+	[
+		'post_type'   => '{{PLUGIN_SLUG}}_event',
+		'numberposts' => -1,
+		'fields'      => 'ids',
+		'post_status' => 'any',
+	]
+);
+foreach ( $post_ids as $post_id ) {
+	wp_delete_post( (int) $post_id, true );
+}

--- a/.github/workflows/phpcs.yml
+++ b/.github/workflows/phpcs.yml
@@ -38,11 +38,13 @@ jobs:
 
       - name: Run PHPCS on plugins
         if: hashFiles('plugins/**/*.php') != ''
+        # First-party plugins (plugins/flavian-*) carry their own .phpcs.xml.dist
+        # and are linted by .github/workflows/plugin-validation.yml — skip them here.
         run: >
           ./vendor/bin/phpcs
           --standard=WordPress-Extra,WordPress-Docs
           --extensions=php
-          --ignore=*/index.php,plugins/akismet/*,plugins/hello.php
+          --ignore=*/index.php,plugins/akismet/*,plugins/hello.php,plugins/flavian-*/*
           --report=checkstyle
           plugins/
           | cs2pr

--- a/.github/workflows/plugin-validation.yml
+++ b/.github/workflows/plugin-validation.yml
@@ -1,0 +1,113 @@
+name: plugin-validation
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - "plugins/flavian-*/**"
+      - ".claude/templates/plugin/**"
+      - "scripts/scaffold-plugin.sh"
+      - ".github/workflows/plugin-validation.yml"
+  push:
+    branches: [main]
+    paths:
+      - "plugins/flavian-*/**"
+      - ".claude/templates/plugin/**"
+      - "scripts/scaffold-plugin.sh"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: plugin-validation-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  # 1. Catch template / reference-plugin drift. If the scaffold output of
+  # `flavian-starter` diverges from the committed copy, the templates were
+  # changed without regenerating the reference plugin (or vice versa).
+  scaffold-drift:
+    name: Scaffold drift check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Regenerate flavian-starter from templates
+        run: |
+          rm -rf plugins/flavian-starter
+          bash scripts/scaffold-plugin.sh flavian-starter \
+            --name "Flavian Starter" \
+            --description "Starter plugin for Flavian-based projects. Demonstrates CPT, taxonomy, settings, and a server-rendered block." \
+            --author "PMDevSolutions" \
+            --force
+      - name: Diff regenerated vs committed
+        run: |
+          if ! git diff --exit-code plugins/flavian-starter; then
+            echo "::error title=Scaffold drift::plugins/flavian-starter/ differs from regenerated output."
+            echo "Run: bash scripts/scaffold-plugin.sh flavian-starter --name \"Flavian Starter\" --description \"...\" --author \"PMDevSolutions\" --force"
+            exit 1
+          fi
+
+  # 2. Build a matrix of all first-party plugins (plugins/flavian-*/) so adding
+  # a new one only requires the directory — no workflow edit needed.
+  discover:
+    name: Discover plugins
+    runs-on: ubuntu-latest
+    outputs:
+      plugins: ${{ steps.list.outputs.plugins }}
+      count: ${{ steps.list.outputs.count }}
+    steps:
+      - uses: actions/checkout@v4
+      - id: list
+        run: |
+          plugins=$(find plugins -mindepth 1 -maxdepth 1 -type d -name 'flavian-*' -printf '%f\n' \
+            | LC_ALL=C sort \
+            | jq -R -s -c 'split("\n") | map(select(length > 0))')
+          count=$(echo "$plugins" | jq 'length')
+          echo "plugins=$plugins" >> "$GITHUB_OUTPUT"
+          echo "count=$count" >> "$GITHUB_OUTPUT"
+          echo "Found $count first-party plugin(s): $plugins"
+
+  phpunit:
+    name: PHPUnit · ${{ matrix.plugin }}
+    needs: discover
+    if: needs.discover.outputs.count != '0'
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        plugin: ${{ fromJSON(needs.discover.outputs.plugins) }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: "8.2"
+          tools: composer
+          coverage: none
+      - name: Composer install
+        working-directory: plugins/${{ matrix.plugin }}
+        run: composer install --prefer-dist --no-interaction --no-progress
+      - name: PHPUnit
+        working-directory: plugins/${{ matrix.plugin }}
+        run: vendor/bin/phpunit --no-coverage
+
+  phpcs:
+    name: PHPCS · ${{ matrix.plugin }}
+    needs: discover
+    if: needs.discover.outputs.count != '0'
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        plugin: ${{ fromJSON(needs.discover.outputs.plugins) }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: "8.2"
+          tools: composer, cs2pr
+      - name: Composer install
+        working-directory: plugins/${{ matrix.plugin }}
+        run: composer install --prefer-dist --no-interaction --no-progress
+      - name: PHPCS
+        working-directory: plugins/${{ matrix.plugin }}
+        run: vendor/bin/phpcs --report=checkstyle | cs2pr

--- a/.github/workflows/plugin-validation.yml
+++ b/.github/workflows/plugin-validation.yml
@@ -110,4 +110,5 @@ jobs:
         run: composer install --prefer-dist --no-interaction --no-progress
       - name: PHPCS
         working-directory: plugins/${{ matrix.plugin }}
-        run: vendor/bin/phpcs --report=checkstyle | cs2pr
+        # -q suppresses the progress bar so cs2pr only sees the checkstyle XML.
+        run: vendor/bin/phpcs -q --report=checkstyle | cs2pr

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 !.claude/hooks/
 !.claude/validation/
 !.claude/config/
+!.claude/templates/
 !.claude/*.md
 !.claude/settings.json
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -115,6 +115,44 @@ Before submitting your changes:
 - Ensure there are no PHP errors or warnings
 - Run any relevant linting or PHPCS checks
 
+### Creating a new plugin
+
+Don't hand-write plugin boilerplate. Use the scaffold:
+
+```bash
+bash scripts/scaffold-plugin.sh my-plugin \
+  --name "My Plugin" \
+  --description "What it does" \
+  --author "Your Name"
+```
+
+The script generates `plugins/my-plugin/` from `.claude/templates/plugin/`
+with PSR-4 autoloading (`Flavian\Plugins\MyPlugin`), Composer config,
+PHPUnit + Brain Monkey, PHPCS (`WordPress-Extra`), a Settings API page, a
+CPT + taxonomy pair, and a server-rendered block. Feature flags:
+`--no-cpt`, `--no-taxonomy`, `--no-settings`, `--no-block`, or `--minimal`
+for headers + activation hooks only.
+
+After scaffolding:
+
+```bash
+cd plugins/my-plugin
+composer install
+composer test    # PHPUnit (Brain Monkey — no MySQL needed)
+composer lint    # PHPCS WordPress-Extra
+```
+
+The reference plugin `plugins/flavian-starter/` is the canonical example
+of scaffold output. CI's `plugin-validation` workflow regenerates it from
+templates and fails if it diverges, so:
+
+- **Changing a template?** Regenerate `flavian-starter` in the same PR
+  (`bash scripts/scaffold-plugin.sh flavian-starter ... --force`) and
+  commit both.
+- **Adding a new first-party plugin?** Place it under `plugins/flavian-*/`
+  — the validation workflow's plugin matrix auto-discovers any directory
+  matching that glob.
+
 ### Visual regression
 
 PRs that touch `themes/**` automatically run the visual regression suite,

--- a/plugins/flavian-starter/.phpcs.xml.dist
+++ b/plugins/flavian-starter/.phpcs.xml.dist
@@ -9,8 +9,13 @@
     <arg name="extensions" value="php"/>
     <arg name="colors"/>
     <arg value="ps"/>
+    <arg name="basepath" value="."/>
 
-    <rule ref="WordPress-Extra"/>
+    <!-- Skip WordPress's classic class-foo-bar.php file naming convention.
+         PSR-4 autoloading uses PascalCase filenames matching the class name. -->
+    <rule ref="WordPress-Extra">
+        <exclude name="WordPress.Files.FileName"/>
+    </rule>
     <rule ref="WordPress-Docs"/>
 
     <config name="minimum_supported_wp_version" value="6.5"/>
@@ -22,10 +27,5 @@
                 <element value="flavian-starter"/>
             </property>
         </properties>
-    </rule>
-
-    <rule ref="WordPress.Files.FileName">
-        <exclude name="WordPress.Files.FileName.NotHyphenatedLowercase"/>
-        <exclude name="WordPress.Files.FileName.InvalidClassFileName"/>
     </rule>
 </ruleset>

--- a/plugins/flavian-starter/.phpcs.xml.dist
+++ b/plugins/flavian-starter/.phpcs.xml.dist
@@ -1,0 +1,31 @@
+<?xml version="1.0"?>
+<ruleset name="Flavian Starter">
+    <description>PHPCS ruleset for Flavian Starter.</description>
+
+    <file>.</file>
+    <exclude-pattern>vendor/*</exclude-pattern>
+    <exclude-pattern>tests/*</exclude-pattern>
+
+    <arg name="extensions" value="php"/>
+    <arg name="colors"/>
+    <arg value="ps"/>
+
+    <rule ref="WordPress-Extra"/>
+    <rule ref="WordPress-Docs"/>
+
+    <config name="minimum_supported_wp_version" value="6.5"/>
+    <config name="testVersion" value="8.0-"/>
+
+    <rule ref="WordPress.WP.I18n">
+        <properties>
+            <property name="text_domain" type="array">
+                <element value="flavian-starter"/>
+            </property>
+        </properties>
+    </rule>
+
+    <rule ref="WordPress.Files.FileName">
+        <exclude name="WordPress.Files.FileName.NotHyphenatedLowercase"/>
+        <exclude name="WordPress.Files.FileName.InvalidClassFileName"/>
+    </rule>
+</ruleset>

--- a/plugins/flavian-starter/README.md
+++ b/plugins/flavian-starter/README.md
@@ -1,0 +1,47 @@
+# Flavian Starter
+
+Starter plugin for Flavian-based projects. Demonstrates CPT, taxonomy, settings, and a server-rendered block.
+
+## Requirements
+
+- WordPress 6.5+
+- PHP 8.0+
+- Composer (for development and testing)
+
+## Installation
+
+1. Copy this directory into your WordPress site's `wp-content/plugins/` directory.
+2. From inside the plugin directory, run `composer install` to generate the autoloader.
+3. Activate the plugin via the WordPress admin or with WP-CLI:
+   ```bash
+   wp plugin activate flavian-starter
+   ```
+
+## What this plugin demonstrates
+
+- **Custom post type** — `flavian-starter_event` registered via `src/PostTypes/Event.php`.
+- **Custom taxonomy** — `flavian-starter_event_category` attached to the event CPT.
+- **Settings page** — `Settings → Flavian Starter` using the WordPress Settings API.
+- **Dynamic block** — `flavian-starter/featured-event` server-rendered via `register_block_type` + `block.json` (no build step required).
+- **Activation / deactivation hooks** — `flush_rewrite_rules()` on both transitions.
+- **PSR-4 autoloading** — `Flavian\Plugins\FlavianStarter` namespace, autoloaded from `src/`.
+- **Uninstall cleanup** — `uninstall.php` removes plugin options and CPT entries on hard uninstall.
+
+## Development
+
+```bash
+composer install
+composer test    # PHPUnit (unit tests, Brain Monkey)
+composer lint    # PHPCS with WordPress-Extra ruleset
+```
+
+### Adding integration tests
+
+Unit tests run against Brain Monkey mocks — no MySQL or `wp-tests-lib` required.
+For full WordPress integration tests, see
+[`wordpress-testing-workflows` skill](../../.claude/skills/wordpress-testing-workflows/SKILL.md)
+for the canonical setup.
+
+## License
+
+GPL-2.0-or-later.

--- a/plugins/flavian-starter/assets/blocks/featured-event/block.json
+++ b/plugins/flavian-starter/assets/blocks/featured-event/block.json
@@ -1,0 +1,19 @@
+{
+    "$schema": "https://schemas.wp.org/trunk/block.json",
+    "apiVersion": 3,
+    "name": "flavian-starter/featured-event",
+    "version": "0.1.0",
+    "title": "Featured Event",
+    "category": "widgets",
+    "icon": "calendar-alt",
+    "description": "Displays the most recent published event.",
+    "keywords": ["event", "featured"],
+    "supports": {
+        "html": false,
+        "align": ["wide", "full"]
+    },
+    "textdomain": "flavian-starter",
+    "editorScript": "file:./index.js",
+    "editorStyle": "file:./editor.css",
+    "style": "file:./style.css"
+}

--- a/plugins/flavian-starter/assets/blocks/featured-event/editor.css
+++ b/plugins/flavian-starter/assets/blocks/featured-event/editor.css
@@ -1,0 +1,9 @@
+/* Flavian Starter — Featured Event editor placeholder */
+
+.flavian-starter-featured-event-placeholder {
+	padding: 1rem;
+	border: 2px dashed #ccc;
+	text-align: center;
+	background: #f6f7f7;
+	color: #50575e;
+}

--- a/plugins/flavian-starter/assets/blocks/featured-event/index.js
+++ b/plugins/flavian-starter/assets/blocks/featured-event/index.js
@@ -1,0 +1,39 @@
+/* global window */
+/**
+ * Editor-side registration for the Featured Event block.
+ *
+ * Uses the WordPress runtime globals (wp.blocks, wp.element, wp.blockEditor,
+ * wp.i18n) directly so the block works without an ESM/JSX build step.
+ */
+( function ( blocks, element, blockEditor, i18n ) {
+	'use strict';
+
+	var registerBlockType = blocks.registerBlockType;
+	var useBlockProps     = blockEditor.useBlockProps;
+	var el                = element.createElement;
+	var __                = i18n.__;
+
+	registerBlockType( 'flavian-starter/featured-event', {
+		edit: function () {
+			var props = useBlockProps( {
+				className: 'flavian-starter-featured-event-placeholder',
+			} );
+			return el(
+				'div',
+				props,
+				el( 'strong', null, __( 'Featured Event', 'flavian-starter' ) ),
+				el(
+					'p',
+					null,
+					__(
+						'Rendered server-side from the most recent published event.',
+						'flavian-starter'
+					)
+				)
+			);
+		},
+		save: function () {
+			return null;
+		},
+	} );
+}( window.wp.blocks, window.wp.element, window.wp.blockEditor, window.wp.i18n ) );

--- a/plugins/flavian-starter/assets/blocks/featured-event/style.css
+++ b/plugins/flavian-starter/assets/blocks/featured-event/style.css
@@ -1,0 +1,17 @@
+/* Flavian Starter — Featured Event front-end styles */
+
+.wp-block-flavian-starter-featured-event {
+	padding: 1.5rem;
+	border: 1px solid #e0e0e0;
+	border-radius: 4px;
+	background: #fff;
+}
+
+.wp-block-flavian-starter-featured-event .flavian-starter-featured-event__title {
+	margin-top: 0;
+}
+
+.wp-block-flavian-starter-featured-event .flavian-starter-featured-event__link {
+	display: inline-block;
+	margin-top: 0.75rem;
+}

--- a/plugins/flavian-starter/assets/css/admin.css
+++ b/plugins/flavian-starter/assets/css/admin.css
@@ -1,0 +1,8 @@
+/* Flavian Starter — admin styles */
+
+.wrap .flavian-starter-notice {
+	border-left: 4px solid #2271b1;
+	padding: 12px;
+	background: #fff;
+	margin: 12px 0;
+}

--- a/plugins/flavian-starter/assets/js/admin.js
+++ b/plugins/flavian-starter/assets/js/admin.js
@@ -1,0 +1,6 @@
+/* global window */
+/* Flavian Starter — admin script (loaded only on the Settings page). */
+( function () {
+	'use strict';
+	// Add admin-page enhancements here.
+}() );

--- a/plugins/flavian-starter/composer.json
+++ b/plugins/flavian-starter/composer.json
@@ -1,0 +1,38 @@
+{
+    "name": "flavian/flavian-starter",
+    "description": "Starter plugin for Flavian-based projects. Demonstrates CPT, taxonomy, settings, and a server-rendered block.",
+    "type": "wordpress-plugin",
+    "license": "GPL-2.0-or-later",
+    "require": {
+        "php": ">=8.0"
+    },
+    "require-dev": {
+        "phpunit/phpunit": "^9.6",
+        "brain/monkey": "^2.6",
+        "yoast/phpunit-polyfills": "^2.0",
+        "squizlabs/php_codesniffer": "^3.10",
+        "wp-coding-standards/wpcs": "^3.0",
+        "phpcompatibility/phpcompatibility-wp": "^2.1",
+        "dealerdirect/phpcodesniffer-composer-installer": "^1.0"
+    },
+    "autoload": {
+        "psr-4": {
+            "Flavian\\Plugins\\FlavianStarter\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Flavian\\Plugins\\FlavianStarter\\Tests\\": "tests/"
+        }
+    },
+    "scripts": {
+        "test": "phpunit",
+        "lint": "phpcs"
+    },
+    "config": {
+        "allow-plugins": {
+            "dealerdirect/phpcodesniffer-composer-installer": true
+        },
+        "sort-packages": true
+    }
+}

--- a/plugins/flavian-starter/flavian-starter.php
+++ b/plugins/flavian-starter/flavian-starter.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * Plugin Name:       Flavian Starter
+ * Plugin URI:        https://github.com/PMDevSolutions/Flavian
+ * Description:       Starter plugin for Flavian-based projects. Demonstrates CPT, taxonomy, settings, and a server-rendered block.
+ * Version:           0.1.0
+ * Requires at least: 6.5
+ * Requires PHP:      8.0
+ * Author:            PMDevSolutions
+ * License:           GPL-2.0-or-later
+ * License URI:       https://www.gnu.org/licenses/gpl-2.0.html
+ * Text Domain:       flavian-starter
+ * Domain Path:       /languages
+ *
+ * @package Flavian\Plugins\FlavianStarter
+ */
+
+declare( strict_types=1 );
+
+namespace Flavian\Plugins\FlavianStarter;
+
+defined( 'ABSPATH' ) || exit;
+
+define( 'FLAVIAN_STARTER_VERSION', '0.1.0' );
+define( 'FLAVIAN_STARTER_FILE',    __FILE__ );
+define( 'FLAVIAN_STARTER_PATH',    plugin_dir_path( __FILE__ ) );
+define( 'FLAVIAN_STARTER_URL',     plugin_dir_url( __FILE__ ) );
+
+$autoload = FLAVIAN_STARTER_PATH . 'vendor/autoload.php';
+if ( ! file_exists( $autoload ) ) {
+	add_action(
+		'admin_notices',
+		static function (): void {
+			echo '<div class="notice notice-error"><p>';
+			esc_html_e(
+				'Flavian Starter: vendor/autoload.php not found. Run "composer install" inside the plugin directory.',
+				'flavian-starter'
+			);
+			echo '</p></div>';
+		}
+	);
+	return;
+}
+require_once $autoload;
+
+register_activation_hook(   __FILE__, [ Activator::class,   'activate'   ] );
+register_deactivation_hook( __FILE__, [ Deactivator::class, 'deactivate' ] );
+
+add_action(
+	'plugins_loaded',
+	static function (): void {
+		Plugin::instance()->boot();
+	}
+);

--- a/plugins/flavian-starter/flavian-starter.php
+++ b/plugins/flavian-starter/flavian-starter.php
@@ -22,12 +22,12 @@ namespace Flavian\Plugins\FlavianStarter;
 defined( 'ABSPATH' ) || exit;
 
 define( 'FLAVIAN_STARTER_VERSION', '0.1.0' );
-define( 'FLAVIAN_STARTER_FILE',    __FILE__ );
-define( 'FLAVIAN_STARTER_PATH',    plugin_dir_path( __FILE__ ) );
-define( 'FLAVIAN_STARTER_URL',     plugin_dir_url( __FILE__ ) );
+define( 'FLAVIAN_STARTER_FILE', __FILE__ );
+define( 'FLAVIAN_STARTER_PATH', plugin_dir_path( __FILE__ ) );
+define( 'FLAVIAN_STARTER_URL', plugin_dir_url( __FILE__ ) );
 
-$autoload = FLAVIAN_STARTER_PATH . 'vendor/autoload.php';
-if ( ! file_exists( $autoload ) ) {
+$flavian_autoload = FLAVIAN_STARTER_PATH . 'vendor/autoload.php';
+if ( ! file_exists( $flavian_autoload ) ) {
 	add_action(
 		'admin_notices',
 		static function (): void {
@@ -41,10 +41,10 @@ if ( ! file_exists( $autoload ) ) {
 	);
 	return;
 }
-require_once $autoload;
+require_once $flavian_autoload;
 
-register_activation_hook(   __FILE__, [ Activator::class,   'activate'   ] );
-register_deactivation_hook( __FILE__, [ Deactivator::class, 'deactivate' ] );
+register_activation_hook( __FILE__, array( Activator::class, 'activate' ) );
+register_deactivation_hook( __FILE__, array( Deactivator::class, 'deactivate' ) );
 
 add_action(
 	'plugins_loaded',

--- a/plugins/flavian-starter/phpunit.xml.dist
+++ b/plugins/flavian-starter/phpunit.xml.dist
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.6/phpunit.xsd"
+    bootstrap="tests/bootstrap.php"
+    colors="true"
+    cacheResultFile=".phpunit.result.cache"
+    failOnRisky="true"
+    failOnWarning="true"
+    beStrictAboutTestsThatDoNotTestAnything="true"
+    beStrictAboutOutputDuringTests="true"
+>
+    <testsuites>
+        <testsuite name="unit">
+            <directory>tests</directory>
+            <exclude>tests/bootstrap.php</exclude>
+            <exclude>tests/TestCase.php</exclude>
+        </testsuite>
+    </testsuites>
+    <coverage>
+        <include>
+            <directory>src</directory>
+        </include>
+    </coverage>
+</phpunit>

--- a/plugins/flavian-starter/src/Activator.php
+++ b/plugins/flavian-starter/src/Activator.php
@@ -11,11 +11,16 @@ namespace Flavian\Plugins\FlavianStarter;
 
 defined( 'ABSPATH' ) || exit;
 
+/**
+ * Runs once when the plugin is activated.
+ */
 final class Activator {
 
 	/**
-	 * Runs once when the plugin is activated. Registers types eagerly so
-	 * rewrite rules can be flushed against the final permalink structure.
+	 * Register types eagerly so rewrite rules can be flushed against the
+	 * final permalink structure.
+	 *
+	 * @return void
 	 */
 	public static function activate(): void {
 		if ( class_exists( PostTypes\Event::class ) ) {

--- a/plugins/flavian-starter/src/Activator.php
+++ b/plugins/flavian-starter/src/Activator.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * Plugin activation handler.
+ *
+ * @package Flavian\Plugins\FlavianStarter
+ */
+
+declare( strict_types=1 );
+
+namespace Flavian\Plugins\FlavianStarter;
+
+defined( 'ABSPATH' ) || exit;
+
+final class Activator {
+
+	/**
+	 * Runs once when the plugin is activated. Registers types eagerly so
+	 * rewrite rules can be flushed against the final permalink structure.
+	 */
+	public static function activate(): void {
+		if ( class_exists( PostTypes\Event::class ) ) {
+			( new PostTypes\Event() )->register();
+		}
+		if ( class_exists( Taxonomies\EventCategory::class ) ) {
+			( new Taxonomies\EventCategory() )->register();
+		}
+		flush_rewrite_rules();
+	}
+}

--- a/plugins/flavian-starter/src/Admin/Settings.php
+++ b/plugins/flavian-starter/src/Admin/Settings.php
@@ -11,6 +11,9 @@ namespace Flavian\Plugins\FlavianStarter\Admin;
 
 defined( 'ABSPATH' ) || exit;
 
+/**
+ * Registers an options page under Settings → Flavian Starter.
+ */
 final class Settings {
 
 	public const OPTION_GROUP = 'flavian-starter_settings';
@@ -19,14 +22,18 @@ final class Settings {
 
 	/**
 	 * Hook menu and Settings API registration.
+	 *
+	 * @return void
 	 */
 	public function register(): void {
-		add_action( 'admin_menu', [ $this, 'add_menu' ] );
-		add_action( 'admin_init', [ $this, 'register_settings' ] );
+		add_action( 'admin_menu', array( $this, 'add_menu' ) );
+		add_action( 'admin_init', array( $this, 'register_settings' ) );
 	}
 
 	/**
 	 * Add the page under Settings.
+	 *
+	 * @return void
 	 */
 	public function add_menu(): void {
 		add_options_page(
@@ -34,23 +41,25 @@ final class Settings {
 			__( 'Flavian Starter', 'flavian-starter' ),
 			'manage_options',
 			self::PAGE_SLUG,
-			[ $this, 'render_page' ]
+			array( $this, 'render_page' )
 		);
 	}
 
 	/**
 	 * Register option group, section and field.
+	 *
+	 * @return void
 	 */
 	public function register_settings(): void {
 		register_setting(
 			self::OPTION_GROUP,
 			self::OPTION_NAME,
-			[
+			array(
 				'type'              => 'array',
-				'sanitize_callback' => [ $this, 'sanitize' ],
-				'default'           => [ 'greeting' => '' ],
+				'sanitize_callback' => array( $this, 'sanitize' ),
+				'default'           => array( 'greeting' => '' ),
 				'show_in_rest'      => false,
-			]
+			)
 		);
 
 		add_settings_section(
@@ -63,7 +72,7 @@ final class Settings {
 		add_settings_field(
 			'flavian-starter_greeting',
 			__( 'Greeting', 'flavian-starter' ),
-			[ $this, 'render_greeting_field' ],
+			array( $this, 'render_greeting_field' ),
 			self::PAGE_SLUG,
 			'flavian-starter_general'
 		);
@@ -76,17 +85,19 @@ final class Settings {
 	 * @return array<string, string>
 	 */
 	public function sanitize( $input ): array {
-		$input = is_array( $input ) ? $input : [];
-		return [
+		$input = is_array( $input ) ? $input : array();
+		return array(
 			'greeting' => isset( $input['greeting'] ) ? sanitize_text_field( (string) $input['greeting'] ) : '',
-		];
+		);
 	}
 
 	/**
 	 * Render the single text-input field.
+	 *
+	 * @return void
 	 */
 	public function render_greeting_field(): void {
-		$options  = get_option( self::OPTION_NAME, [ 'greeting' => '' ] );
+		$options  = get_option( self::OPTION_NAME, array( 'greeting' => '' ) );
 		$greeting = isset( $options['greeting'] ) ? (string) $options['greeting'] : '';
 		printf(
 			'<input type="text" name="%1$s[greeting]" value="%2$s" class="regular-text" />',
@@ -97,6 +108,8 @@ final class Settings {
 
 	/**
 	 * Render the page wrapper.
+	 *
+	 * @return void
 	 */
 	public function render_page(): void {
 		if ( ! current_user_can( 'manage_options' ) ) {

--- a/plugins/flavian-starter/src/Admin/Settings.php
+++ b/plugins/flavian-starter/src/Admin/Settings.php
@@ -1,0 +1,118 @@
+<?php
+/**
+ * Settings page using the WordPress Settings API.
+ *
+ * @package Flavian\Plugins\FlavianStarter
+ */
+
+declare( strict_types=1 );
+
+namespace Flavian\Plugins\FlavianStarter\Admin;
+
+defined( 'ABSPATH' ) || exit;
+
+final class Settings {
+
+	public const OPTION_GROUP = 'flavian-starter_settings';
+	public const OPTION_NAME  = 'flavian-starter_options';
+	public const PAGE_SLUG    = 'flavian-starter';
+
+	/**
+	 * Hook menu and Settings API registration.
+	 */
+	public function register(): void {
+		add_action( 'admin_menu', [ $this, 'add_menu' ] );
+		add_action( 'admin_init', [ $this, 'register_settings' ] );
+	}
+
+	/**
+	 * Add the page under Settings.
+	 */
+	public function add_menu(): void {
+		add_options_page(
+			__( 'Flavian Starter', 'flavian-starter' ),
+			__( 'Flavian Starter', 'flavian-starter' ),
+			'manage_options',
+			self::PAGE_SLUG,
+			[ $this, 'render_page' ]
+		);
+	}
+
+	/**
+	 * Register option group, section and field.
+	 */
+	public function register_settings(): void {
+		register_setting(
+			self::OPTION_GROUP,
+			self::OPTION_NAME,
+			[
+				'type'              => 'array',
+				'sanitize_callback' => [ $this, 'sanitize' ],
+				'default'           => [ 'greeting' => '' ],
+				'show_in_rest'      => false,
+			]
+		);
+
+		add_settings_section(
+			'flavian-starter_general',
+			__( 'General', 'flavian-starter' ),
+			'__return_false',
+			self::PAGE_SLUG
+		);
+
+		add_settings_field(
+			'flavian-starter_greeting',
+			__( 'Greeting', 'flavian-starter' ),
+			[ $this, 'render_greeting_field' ],
+			self::PAGE_SLUG,
+			'flavian-starter_general'
+		);
+	}
+
+	/**
+	 * Sanitize the option array before save.
+	 *
+	 * @param mixed $input Raw submitted value.
+	 * @return array<string, string>
+	 */
+	public function sanitize( $input ): array {
+		$input = is_array( $input ) ? $input : [];
+		return [
+			'greeting' => isset( $input['greeting'] ) ? sanitize_text_field( (string) $input['greeting'] ) : '',
+		];
+	}
+
+	/**
+	 * Render the single text-input field.
+	 */
+	public function render_greeting_field(): void {
+		$options  = get_option( self::OPTION_NAME, [ 'greeting' => '' ] );
+		$greeting = isset( $options['greeting'] ) ? (string) $options['greeting'] : '';
+		printf(
+			'<input type="text" name="%1$s[greeting]" value="%2$s" class="regular-text" />',
+			esc_attr( self::OPTION_NAME ),
+			esc_attr( $greeting )
+		);
+	}
+
+	/**
+	 * Render the page wrapper.
+	 */
+	public function render_page(): void {
+		if ( ! current_user_can( 'manage_options' ) ) {
+			return;
+		}
+		?>
+		<div class="wrap">
+			<h1><?php echo esc_html( get_admin_page_title() ); ?></h1>
+			<form action="options.php" method="post">
+				<?php
+				settings_fields( self::OPTION_GROUP );
+				do_settings_sections( self::PAGE_SLUG );
+				submit_button();
+				?>
+			</form>
+		</div>
+		<?php
+	}
+}

--- a/plugins/flavian-starter/src/Blocks/FeaturedEvent.php
+++ b/plugins/flavian-starter/src/Blocks/FeaturedEvent.php
@@ -18,32 +18,40 @@ use Flavian\Plugins\FlavianStarter\PostTypes\Event;
 
 defined( 'ABSPATH' ) || exit;
 
+/**
+ * Registers and server-renders the Featured Event block.
+ */
 final class FeaturedEvent {
 
 	/**
 	 * Hook block registration to `init` (required by register_block_type).
+	 *
+	 * @return void
 	 */
 	public function register(): void {
-		add_action( 'init', [ $this, 'register_block' ] );
+		add_action( 'init', array( $this, 'register_block' ) );
 	}
 
 	/**
 	 * Register the block by pointing register_block_type at the block.json.
+	 *
+	 * @return void
 	 */
 	public function register_block(): void {
 		register_block_type(
 			FLAVIAN_STARTER_PATH . 'assets/blocks/featured-event',
-			[
-				'render_callback' => [ $this, 'render' ],
-			]
+			array(
+				'render_callback' => array( $this, 'render' ),
+			)
 		);
 	}
 
 	/**
 	 * Server-side render: pulls the most recent published event.
 	 *
-	 * @param array<string, mixed> $attributes Block attributes (unused here).
-	 * @param string               $content    Inner content (unused here).
+	 * @param array<string, mixed> $attributes Block attributes (unused).
+	 * @param string               $content    Inner content (unused).
+	 * @return string
 	 */
 	public function render( array $attributes, string $content ): string {
 		unset( $attributes, $content );
@@ -51,12 +59,12 @@ final class FeaturedEvent {
 		$post_type = class_exists( Event::class ) ? Event::POST_TYPE : 'flavian-starter_event';
 
 		$events = get_posts(
-			[
+			array(
 				'post_type'      => $post_type,
 				'posts_per_page' => 1,
 				'post_status'    => 'publish',
 				'no_found_rows'  => true,
-			]
+			)
 		);
 
 		if ( empty( $events ) ) {

--- a/plugins/flavian-starter/src/Blocks/FeaturedEvent.php
+++ b/plugins/flavian-starter/src/Blocks/FeaturedEvent.php
@@ -1,0 +1,87 @@
+<?php
+/**
+ * Featured Event dynamic block.
+ *
+ * Server-rendered — no build step required. The editor-side script in
+ * assets/blocks/featured-event/index.js uses the WP runtime globals
+ * (wp.blocks, wp.element, wp.blockEditor, wp.i18n) directly instead of an
+ * ESM/JSX bundle, so the plugin works the moment it's activated.
+ *
+ * @package Flavian\Plugins\FlavianStarter
+ */
+
+declare( strict_types=1 );
+
+namespace Flavian\Plugins\FlavianStarter\Blocks;
+
+use Flavian\Plugins\FlavianStarter\PostTypes\Event;
+
+defined( 'ABSPATH' ) || exit;
+
+final class FeaturedEvent {
+
+	/**
+	 * Hook block registration to `init` (required by register_block_type).
+	 */
+	public function register(): void {
+		add_action( 'init', [ $this, 'register_block' ] );
+	}
+
+	/**
+	 * Register the block by pointing register_block_type at the block.json.
+	 */
+	public function register_block(): void {
+		register_block_type(
+			FLAVIAN_STARTER_PATH . 'assets/blocks/featured-event',
+			[
+				'render_callback' => [ $this, 'render' ],
+			]
+		);
+	}
+
+	/**
+	 * Server-side render: pulls the most recent published event.
+	 *
+	 * @param array<string, mixed> $attributes Block attributes (unused here).
+	 * @param string               $content    Inner content (unused here).
+	 */
+	public function render( array $attributes, string $content ): string {
+		unset( $attributes, $content );
+
+		$post_type = class_exists( Event::class ) ? Event::POST_TYPE : 'flavian-starter_event';
+
+		$events = get_posts(
+			[
+				'post_type'      => $post_type,
+				'posts_per_page' => 1,
+				'post_status'    => 'publish',
+				'no_found_rows'  => true,
+			]
+		);
+
+		if ( empty( $events ) ) {
+			return '';
+		}
+
+		$event   = $events[0];
+		$excerpt = '' !== $event->post_excerpt
+			? $event->post_excerpt
+			: wp_trim_words( $event->post_content, 30 );
+
+		ob_start();
+		?>
+		<div <?php echo wp_kses_data( get_block_wrapper_attributes() ); ?>>
+			<h3 class="flavian-starter-featured-event__title">
+				<?php echo esc_html( $event->post_title ); ?>
+			</h3>
+			<div class="flavian-starter-featured-event__excerpt">
+				<?php echo wp_kses_post( wpautop( $excerpt ) ); ?>
+			</div>
+			<a class="flavian-starter-featured-event__link" href="<?php echo esc_url( (string) get_permalink( $event ) ); ?>">
+				<?php esc_html_e( 'Read more', 'flavian-starter' ); ?>
+			</a>
+		</div>
+		<?php
+		return (string) ob_get_clean();
+	}
+}

--- a/plugins/flavian-starter/src/Deactivator.php
+++ b/plugins/flavian-starter/src/Deactivator.php
@@ -11,11 +11,15 @@ namespace Flavian\Plugins\FlavianStarter;
 
 defined( 'ABSPATH' ) || exit;
 
+/**
+ * Runs once when the plugin is deactivated.
+ */
 final class Deactivator {
 
 	/**
-	 * Runs once when the plugin is deactivated. Flushes rewrite rules so the
-	 * custom post type's permalink rules disappear cleanly.
+	 * Flush rewrite rules so the custom post type's permalink rules disappear cleanly.
+	 *
+	 * @return void
 	 */
 	public static function deactivate(): void {
 		flush_rewrite_rules();

--- a/plugins/flavian-starter/src/Deactivator.php
+++ b/plugins/flavian-starter/src/Deactivator.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * Plugin deactivation handler.
+ *
+ * @package Flavian\Plugins\FlavianStarter
+ */
+
+declare( strict_types=1 );
+
+namespace Flavian\Plugins\FlavianStarter;
+
+defined( 'ABSPATH' ) || exit;
+
+final class Deactivator {
+
+	/**
+	 * Runs once when the plugin is deactivated. Flushes rewrite rules so the
+	 * custom post type's permalink rules disappear cleanly.
+	 */
+	public static function deactivate(): void {
+		flush_rewrite_rules();
+	}
+}

--- a/plugins/flavian-starter/src/Plugin.php
+++ b/plugins/flavian-starter/src/Plugin.php
@@ -1,0 +1,98 @@
+<?php
+/**
+ * Bootstrap class for Flavian Starter.
+ *
+ * @package Flavian\Plugins\FlavianStarter
+ */
+
+declare( strict_types=1 );
+
+namespace Flavian\Plugins\FlavianStarter;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Singleton bootstrap. Conditionally wires each feature based on which classes
+ * the autoloader can resolve — so removing a feature directory does not break
+ * the rest of the plugin.
+ */
+final class Plugin {
+
+	/**
+	 * Singleton instance.
+	 *
+	 * @var self|null
+	 */
+	private static ?self $instance = null;
+
+	/**
+	 * Accessor for the singleton instance.
+	 */
+	public static function instance(): self {
+		if ( null === self::$instance ) {
+			self::$instance = new self();
+		}
+		return self::$instance;
+	}
+
+	/**
+	 * Private constructor — use {@see self::instance()}.
+	 */
+	private function __construct() {}
+
+	/**
+	 * Wire feature classes into WordPress.
+	 */
+	public function boot(): void {
+		if ( class_exists( PostTypes\Event::class ) ) {
+			( new PostTypes\Event() )->register();
+		}
+		if ( class_exists( Taxonomies\EventCategory::class ) ) {
+			( new Taxonomies\EventCategory() )->register();
+		}
+		if ( class_exists( Admin\Settings::class ) ) {
+			( new Admin\Settings() )->register();
+		}
+		if ( class_exists( Blocks\FeaturedEvent::class ) ) {
+			( new Blocks\FeaturedEvent() )->register();
+		}
+
+		add_action( 'init', [ $this, 'load_textdomain' ] );
+		add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_admin_assets' ] );
+	}
+
+	/**
+	 * Load the plugin's text domain.
+	 */
+	public function load_textdomain(): void {
+		load_plugin_textdomain(
+			'flavian-starter',
+			false,
+			dirname( plugin_basename( FLAVIAN_STARTER_FILE ) ) . '/languages'
+		);
+	}
+
+	/**
+	 * Enqueue admin-only assets.
+	 *
+	 * @param string $hook Current admin page hook suffix.
+	 */
+	public function enqueue_admin_assets( string $hook ): void {
+		if ( 'settings_page_flavian-starter' !== $hook ) {
+			return;
+		}
+		wp_enqueue_style(
+			'flavian-starter-admin',
+			FLAVIAN_STARTER_URL . 'assets/css/admin.css',
+			[],
+			FLAVIAN_STARTER_VERSION
+		);
+		wp_enqueue_script(
+			'flavian-starter-admin',
+			FLAVIAN_STARTER_URL . 'assets/js/admin.js',
+			[],
+			FLAVIAN_STARTER_VERSION,
+			true
+		);
+	}
+}

--- a/plugins/flavian-starter/src/Plugin.php
+++ b/plugins/flavian-starter/src/Plugin.php
@@ -27,6 +27,8 @@ final class Plugin {
 
 	/**
 	 * Accessor for the singleton instance.
+	 *
+	 * @return self
 	 */
 	public static function instance(): self {
 		if ( null === self::$instance ) {
@@ -42,6 +44,8 @@ final class Plugin {
 
 	/**
 	 * Wire feature classes into WordPress.
+	 *
+	 * @return void
 	 */
 	public function boot(): void {
 		if ( class_exists( PostTypes\Event::class ) ) {
@@ -57,12 +61,14 @@ final class Plugin {
 			( new Blocks\FeaturedEvent() )->register();
 		}
 
-		add_action( 'init', [ $this, 'load_textdomain' ] );
-		add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_admin_assets' ] );
+		add_action( 'init', array( $this, 'load_textdomain' ) );
+		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_admin_assets' ) );
 	}
 
 	/**
 	 * Load the plugin's text domain.
+	 *
+	 * @return void
 	 */
 	public function load_textdomain(): void {
 		load_plugin_textdomain(
@@ -76,6 +82,7 @@ final class Plugin {
 	 * Enqueue admin-only assets.
 	 *
 	 * @param string $hook Current admin page hook suffix.
+	 * @return void
 	 */
 	public function enqueue_admin_assets( string $hook ): void {
 		if ( 'settings_page_flavian-starter' !== $hook ) {
@@ -84,13 +91,13 @@ final class Plugin {
 		wp_enqueue_style(
 			'flavian-starter-admin',
 			FLAVIAN_STARTER_URL . 'assets/css/admin.css',
-			[],
+			array(),
 			FLAVIAN_STARTER_VERSION
 		);
 		wp_enqueue_script(
 			'flavian-starter-admin',
 			FLAVIAN_STARTER_URL . 'assets/js/admin.js',
-			[],
+			array(),
 			FLAVIAN_STARTER_VERSION,
 			true
 		);

--- a/plugins/flavian-starter/src/PostTypes/Event.php
+++ b/plugins/flavian-starter/src/PostTypes/Event.php
@@ -11,25 +11,32 @@ namespace Flavian\Plugins\FlavianStarter\PostTypes;
 
 defined( 'ABSPATH' ) || exit;
 
+/**
+ * Registers the Event custom post type.
+ */
 final class Event {
 
 	public const POST_TYPE = 'flavian-starter_event';
 
 	/**
 	 * Hook the registration onto `init`.
+	 *
+	 * @return void
 	 */
 	public function register(): void {
-		add_action( 'init', [ $this, 'register_post_type' ] );
+		add_action( 'init', array( $this, 'register_post_type' ) );
 	}
 
 	/**
 	 * Register the post type. Public, REST-enabled, with archive at /events/.
+	 *
+	 * @return void
 	 */
 	public function register_post_type(): void {
 		register_post_type(
 			self::POST_TYPE,
-			[
-				'labels'       => [
+			array(
+				'labels'       => array(
 					'name'               => __( 'Events', 'flavian-starter' ),
 					'singular_name'      => __( 'Event', 'flavian-starter' ),
 					'add_new_item'       => __( 'Add New Event', 'flavian-starter' ),
@@ -39,14 +46,14 @@ final class Event {
 					'search_items'       => __( 'Search Events', 'flavian-starter' ),
 					'not_found'          => __( 'No events found.', 'flavian-starter' ),
 					'not_found_in_trash' => __( 'No events found in Trash.', 'flavian-starter' ),
-				],
+				),
 				'public'       => true,
 				'show_in_rest' => true,
 				'has_archive'  => true,
 				'menu_icon'    => 'dashicons-calendar-alt',
-				'supports'     => [ 'title', 'editor', 'thumbnail', 'excerpt' ],
-				'rewrite'      => [ 'slug' => 'events' ],
-			]
+				'supports'     => array( 'title', 'editor', 'thumbnail', 'excerpt' ),
+				'rewrite'      => array( 'slug' => 'events' ),
+			)
 		);
 	}
 }

--- a/plugins/flavian-starter/src/PostTypes/Event.php
+++ b/plugins/flavian-starter/src/PostTypes/Event.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * Example custom post type.
+ *
+ * @package Flavian\Plugins\FlavianStarter
+ */
+
+declare( strict_types=1 );
+
+namespace Flavian\Plugins\FlavianStarter\PostTypes;
+
+defined( 'ABSPATH' ) || exit;
+
+final class Event {
+
+	public const POST_TYPE = 'flavian-starter_event';
+
+	/**
+	 * Hook the registration onto `init`.
+	 */
+	public function register(): void {
+		add_action( 'init', [ $this, 'register_post_type' ] );
+	}
+
+	/**
+	 * Register the post type. Public, REST-enabled, with archive at /events/.
+	 */
+	public function register_post_type(): void {
+		register_post_type(
+			self::POST_TYPE,
+			[
+				'labels'       => [
+					'name'               => __( 'Events', 'flavian-starter' ),
+					'singular_name'      => __( 'Event', 'flavian-starter' ),
+					'add_new_item'       => __( 'Add New Event', 'flavian-starter' ),
+					'edit_item'          => __( 'Edit Event', 'flavian-starter' ),
+					'new_item'           => __( 'New Event', 'flavian-starter' ),
+					'view_item'          => __( 'View Event', 'flavian-starter' ),
+					'search_items'       => __( 'Search Events', 'flavian-starter' ),
+					'not_found'          => __( 'No events found.', 'flavian-starter' ),
+					'not_found_in_trash' => __( 'No events found in Trash.', 'flavian-starter' ),
+				],
+				'public'       => true,
+				'show_in_rest' => true,
+				'has_archive'  => true,
+				'menu_icon'    => 'dashicons-calendar-alt',
+				'supports'     => [ 'title', 'editor', 'thumbnail', 'excerpt' ],
+				'rewrite'      => [ 'slug' => 'events' ],
+			]
+		);
+	}
+}

--- a/plugins/flavian-starter/src/Taxonomies/EventCategory.php
+++ b/plugins/flavian-starter/src/Taxonomies/EventCategory.php
@@ -13,36 +13,43 @@ use Flavian\Plugins\FlavianStarter\PostTypes\Event;
 
 defined( 'ABSPATH' ) || exit;
 
+/**
+ * Registers the Event Category taxonomy against the Event post type.
+ */
 final class EventCategory {
 
 	public const TAXONOMY = 'flavian-starter_event_category';
 
 	/**
 	 * Hook the registration onto `init`.
+	 *
+	 * @return void
 	 */
 	public function register(): void {
-		add_action( 'init', [ $this, 'register_taxonomy' ] );
+		add_action( 'init', array( $this, 'register_taxonomy' ) );
 	}
 
 	/**
-	 * Register the taxonomy against the Event post type.
+	 * Register the taxonomy.
+	 *
+	 * @return void
 	 */
 	public function register_taxonomy(): void {
 		$object_type = class_exists( Event::class ) ? Event::POST_TYPE : 'flavian-starter_event';
 
 		register_taxonomy(
 			self::TAXONOMY,
-			[ $object_type ],
-			[
-				'labels'            => [
+			array( $object_type ),
+			array(
+				'labels'            => array(
 					'name'          => __( 'Event Categories', 'flavian-starter' ),
 					'singular_name' => __( 'Event Category', 'flavian-starter' ),
-				],
+				),
 				'hierarchical'      => true,
 				'show_in_rest'      => true,
 				'show_admin_column' => true,
-				'rewrite'           => [ 'slug' => 'event-category' ],
-			]
+				'rewrite'           => array( 'slug' => 'event-category' ),
+			)
 		);
 	}
 }

--- a/plugins/flavian-starter/src/Taxonomies/EventCategory.php
+++ b/plugins/flavian-starter/src/Taxonomies/EventCategory.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * Example custom taxonomy.
+ *
+ * @package Flavian\Plugins\FlavianStarter
+ */
+
+declare( strict_types=1 );
+
+namespace Flavian\Plugins\FlavianStarter\Taxonomies;
+
+use Flavian\Plugins\FlavianStarter\PostTypes\Event;
+
+defined( 'ABSPATH' ) || exit;
+
+final class EventCategory {
+
+	public const TAXONOMY = 'flavian-starter_event_category';
+
+	/**
+	 * Hook the registration onto `init`.
+	 */
+	public function register(): void {
+		add_action( 'init', [ $this, 'register_taxonomy' ] );
+	}
+
+	/**
+	 * Register the taxonomy against the Event post type.
+	 */
+	public function register_taxonomy(): void {
+		$object_type = class_exists( Event::class ) ? Event::POST_TYPE : 'flavian-starter_event';
+
+		register_taxonomy(
+			self::TAXONOMY,
+			[ $object_type ],
+			[
+				'labels'            => [
+					'name'          => __( 'Event Categories', 'flavian-starter' ),
+					'singular_name' => __( 'Event Category', 'flavian-starter' ),
+				],
+				'hierarchical'      => true,
+				'show_in_rest'      => true,
+				'show_admin_column' => true,
+				'rewrite'           => [ 'slug' => 'event-category' ],
+			]
+		);
+	}
+}

--- a/plugins/flavian-starter/tests/PluginTest.php
+++ b/plugins/flavian-starter/tests/PluginTest.php
@@ -16,6 +16,11 @@ use Flavian\Plugins\FlavianStarter\Plugin;
  */
 final class PluginTest extends TestCase {
 
+	/**
+	 * Plugin::instance() should return the same object across calls.
+	 *
+	 * @return void
+	 */
 	public function test_instance_returns_singleton(): void {
 		$a = Plugin::instance();
 		$b = Plugin::instance();

--- a/plugins/flavian-starter/tests/PluginTest.php
+++ b/plugins/flavian-starter/tests/PluginTest.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * Tests the bootstrap singleton.
+ *
+ * @package Flavian\Plugins\FlavianStarter\Tests
+ */
+
+declare( strict_types=1 );
+
+namespace Flavian\Plugins\FlavianStarter\Tests;
+
+use Flavian\Plugins\FlavianStarter\Plugin;
+
+/**
+ * @covers \Flavian\Plugins\FlavianStarter\Plugin
+ */
+final class PluginTest extends TestCase {
+
+	public function test_instance_returns_singleton(): void {
+		$a = Plugin::instance();
+		$b = Plugin::instance();
+		$this->assertSame( $a, $b );
+	}
+}

--- a/plugins/flavian-starter/tests/PostTypes/EventTest.php
+++ b/plugins/flavian-starter/tests/PostTypes/EventTest.php
@@ -11,6 +11,7 @@ namespace Flavian\Plugins\FlavianStarter\Tests\PostTypes;
 
 use Brain\Monkey\Actions;
 use Brain\Monkey\Functions;
+use Mockery;
 use Flavian\Plugins\FlavianStarter\PostTypes\Event;
 use Flavian\Plugins\FlavianStarter\Tests\TestCase;
 
@@ -19,24 +20,42 @@ use Flavian\Plugins\FlavianStarter\Tests\TestCase;
  */
 final class EventTest extends TestCase {
 
+	/**
+	 * The slug constant should namespace the post type with the plugin slug.
+	 *
+	 * @return void
+	 */
 	public function test_post_type_constant_uses_plugin_slug(): void {
 		$this->assertSame( 'flavian-starter_event', Event::POST_TYPE );
 	}
 
+	/**
+	 * register() should hook a callable onto the 'init' action.
+	 *
+	 * @return void
+	 */
 	public function test_register_hooks_post_type_onto_init(): void {
 		Actions\expectAdded( 'init' )
 			->once()
-			->with( \Mockery::type( 'array' ) );
+			->with( Mockery::type( 'array' ) );
 
 		( new Event() )->register();
 	}
 
+	/**
+	 * register_post_type() should pass the expected slug and args.
+	 *
+	 * @return void
+	 */
 	public function test_register_post_type_passes_expected_args(): void {
-		$captured = [];
+		$captured = array();
 
 		Functions\when( 'register_post_type' )->alias(
 			static function ( $slug, $args ) use ( &$captured ): void {
-				$captured = [ 'slug' => $slug, 'args' => $args ];
+				$captured = array(
+					'slug' => $slug,
+					'args' => $args,
+				);
 			}
 		);
 

--- a/plugins/flavian-starter/tests/PostTypes/EventTest.php
+++ b/plugins/flavian-starter/tests/PostTypes/EventTest.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * Tests for the Event custom post type registration.
+ *
+ * @package Flavian\Plugins\FlavianStarter\Tests
+ */
+
+declare( strict_types=1 );
+
+namespace Flavian\Plugins\FlavianStarter\Tests\PostTypes;
+
+use Brain\Monkey\Actions;
+use Brain\Monkey\Functions;
+use Flavian\Plugins\FlavianStarter\PostTypes\Event;
+use Flavian\Plugins\FlavianStarter\Tests\TestCase;
+
+/**
+ * @covers \Flavian\Plugins\FlavianStarter\PostTypes\Event
+ */
+final class EventTest extends TestCase {
+
+	public function test_post_type_constant_uses_plugin_slug(): void {
+		$this->assertSame( 'flavian-starter_event', Event::POST_TYPE );
+	}
+
+	public function test_register_hooks_post_type_onto_init(): void {
+		Actions\expectAdded( 'init' )
+			->once()
+			->with( \Mockery::type( 'array' ) );
+
+		( new Event() )->register();
+	}
+
+	public function test_register_post_type_passes_expected_args(): void {
+		$captured = [];
+
+		Functions\when( 'register_post_type' )->alias(
+			static function ( $slug, $args ) use ( &$captured ): void {
+				$captured = [ 'slug' => $slug, 'args' => $args ];
+			}
+		);
+
+		( new Event() )->register_post_type();
+
+		$this->assertSame( 'flavian-starter_event', $captured['slug'] );
+		$this->assertTrue( $captured['args']['public'] );
+		$this->assertTrue( $captured['args']['show_in_rest'] );
+		$this->assertContains( 'title', $captured['args']['supports'] );
+		$this->assertContains( 'editor', $captured['args']['supports'] );
+		$this->assertSame( 'events', $captured['args']['rewrite']['slug'] );
+	}
+}

--- a/plugins/flavian-starter/tests/TestCase.php
+++ b/plugins/flavian-starter/tests/TestCase.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Base test case wiring Brain Monkey setUp/tearDown.
+ * Base test case wiring Brain Monkey + Mockery into PHPUnit.
  *
  * @package Flavian\Plugins\FlavianStarter\Tests
  */
@@ -10,15 +10,38 @@ declare( strict_types=1 );
 namespace Flavian\Plugins\FlavianStarter\Tests;
 
 use Brain\Monkey;
+use Brain\Monkey\Functions;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
 use PHPUnit\Framework\TestCase as BaseTestCase;
 
+/**
+ * Shared base. MockeryPHPUnitIntegration bridges Mockery expectations
+ * (used by Brain Monkey's Actions/Functions verifiers) into PHPUnit's
+ * assertion counter so verified expectations don't trip "risky test".
+ */
 abstract class TestCase extends BaseTestCase {
 
+	use MockeryPHPUnitIntegration;
+
+	/**
+	 * Initialise Brain Monkey and stub WordPress i18n + escape helpers so
+	 * namespaced code can call __(), esc_html(), etc. without hitting
+	 * "undefined function" errors.
+	 *
+	 * @return void
+	 */
 	protected function setUp(): void {
 		parent::setUp();
 		Monkey\setUp();
+		Functions\stubTranslationFunctions();
+		Functions\stubEscapeFunctions();
 	}
 
+	/**
+	 * Tear down Brain Monkey (which closes Mockery for us).
+	 *
+	 * @return void
+	 */
 	protected function tearDown(): void {
 		Monkey\tearDown();
 		parent::tearDown();

--- a/plugins/flavian-starter/tests/TestCase.php
+++ b/plugins/flavian-starter/tests/TestCase.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * Base test case wiring Brain Monkey setUp/tearDown.
+ *
+ * @package Flavian\Plugins\FlavianStarter\Tests
+ */
+
+declare( strict_types=1 );
+
+namespace Flavian\Plugins\FlavianStarter\Tests;
+
+use Brain\Monkey;
+use PHPUnit\Framework\TestCase as BaseTestCase;
+
+abstract class TestCase extends BaseTestCase {
+
+	protected function setUp(): void {
+		parent::setUp();
+		Monkey\setUp();
+	}
+
+	protected function tearDown(): void {
+		Monkey\tearDown();
+		parent::tearDown();
+	}
+}

--- a/plugins/flavian-starter/tests/bootstrap.php
+++ b/plugins/flavian-starter/tests/bootstrap.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * PHPUnit bootstrap.
+ *
+ * Brain Monkey stands in for the WordPress runtime — no MySQL or
+ * wp-tests-lib install required. Tests against real WordPress should live in
+ * a separate tests/integration/ directory with its own bootstrap.
+ *
+ * @package Flavian\Plugins\FlavianStarter\Tests
+ */
+
+declare( strict_types=1 );
+
+defined( 'ABSPATH' ) || define( 'ABSPATH', '/tmp/wordpress/' );
+
+if ( ! defined( 'FLAVIAN_STARTER_VERSION' ) ) {
+	define( 'FLAVIAN_STARTER_VERSION', '0.0.0-test' );
+	define( 'FLAVIAN_STARTER_FILE',    dirname( __DIR__ ) . '/flavian-starter.php' );
+	define( 'FLAVIAN_STARTER_PATH',    dirname( __DIR__ ) . '/' );
+	define( 'FLAVIAN_STARTER_URL',     'http://example.test/wp-content/plugins/flavian-starter/' );
+}
+
+$autoload = __DIR__ . '/../vendor/autoload.php';
+if ( ! file_exists( $autoload ) ) {
+	fwrite( STDERR, "\nRun `composer install` inside this plugin before running tests.\n" );
+	exit( 1 );
+}
+require_once $autoload;

--- a/plugins/flavian-starter/uninstall.php
+++ b/plugins/flavian-starter/uninstall.php
@@ -11,14 +11,14 @@ defined( 'WP_UNINSTALL_PLUGIN' ) || exit;
 
 delete_option( 'flavian-starter_options' );
 
-$post_ids = get_posts(
-	[
+$flavian_post_ids = get_posts(
+	array(
 		'post_type'   => 'flavian-starter_event',
 		'numberposts' => -1,
 		'fields'      => 'ids',
 		'post_status' => 'any',
-	]
+	)
 );
-foreach ( $post_ids as $post_id ) {
-	wp_delete_post( (int) $post_id, true );
+foreach ( $flavian_post_ids as $flavian_pid ) {
+	wp_delete_post( (int) $flavian_pid, true );
 }

--- a/plugins/flavian-starter/uninstall.php
+++ b/plugins/flavian-starter/uninstall.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * Fires when Flavian Starter is deleted via the Plugins screen (not deactivated).
+ *
+ * @package Flavian\Plugins\FlavianStarter
+ */
+
+declare( strict_types=1 );
+
+defined( 'WP_UNINSTALL_PLUGIN' ) || exit;
+
+delete_option( 'flavian-starter_options' );
+
+$post_ids = get_posts(
+	[
+		'post_type'   => 'flavian-starter_event',
+		'numberposts' => -1,
+		'fields'      => 'ids',
+		'post_status' => 'any',
+	]
+);
+foreach ( $post_ids as $post_id ) {
+	wp_delete_post( (int) $post_id, true );
+}

--- a/scripts/scaffold-plugin.sh
+++ b/scripts/scaffold-plugin.sh
@@ -1,0 +1,245 @@
+#!/usr/bin/env bash
+# scripts/scaffold-plugin.sh
+#
+# Generate a new WordPress plugin under plugins/<slug>/ from the templates
+# in .claude/templates/plugin/.
+#
+# Usage:
+#   bash scripts/scaffold-plugin.sh <slug> [options]
+#
+# Options:
+#   --name "Human Name"         Default: slug title-cased
+#   --description "What it is"  Default: placeholder text
+#   --author "Author Name"      Default: $(git config user.name) or "Anonymous"
+#   --namespace "Vendor\\Name"  Default: Flavian\Plugins\<PluginClass>
+#   --no-cpt                    Omit the CPT example (src/PostTypes/)
+#   --no-taxonomy               Omit the taxonomy example (src/Taxonomies/)
+#   --no-settings               Omit the settings page (src/Admin/)
+#   --no-block                  Omit the block example (src/Blocks/ + assets/blocks/)
+#   --minimal                   Equivalent to --no-cpt --no-taxonomy --no-settings --no-block
+#   --force                     Overwrite an existing plugins/<slug>/ directory
+#   --dry-run                   Print actions but do not write any files
+#
+# Exit codes: 0 = success, 1 = validation/IO error, 2 = bad usage.
+
+set -euo pipefail
+
+PROJECT_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+TEMPLATE_DIR="$PROJECT_ROOT/.claude/templates/plugin"
+PLUGINS_DIR="$PROJECT_ROOT/plugins"
+
+# --- Reserved slugs that would collide with existing/default plugins ---
+RESERVED_SLUGS=("akismet" "hello" "index")
+
+# --- Argument parsing ---
+SLUG=""
+NAME=""
+DESCRIPTION=""
+AUTHOR=""
+NAMESPACE=""
+WITH_CPT=1
+WITH_TAXONOMY=1
+WITH_SETTINGS=1
+WITH_BLOCK=1
+FORCE=0
+DRY_RUN=0
+
+usage() {
+  sed -n '2,/^$/p' "$0" | sed 's/^# \{0,1\}//'
+  exit "${1:-2}"
+}
+
+die() {
+  printf '✗ %s\n' "$*" >&2
+  exit 1
+}
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --name)        NAME="$2"; shift 2 ;;
+    --description) DESCRIPTION="$2"; shift 2 ;;
+    --author)      AUTHOR="$2"; shift 2 ;;
+    --namespace)   NAMESPACE="$2"; shift 2 ;;
+    --no-cpt)      WITH_CPT=0; shift ;;
+    --no-taxonomy) WITH_TAXONOMY=0; shift ;;
+    --no-settings) WITH_SETTINGS=0; shift ;;
+    --no-block)    WITH_BLOCK=0; shift ;;
+    --minimal)     WITH_CPT=0; WITH_TAXONOMY=0; WITH_SETTINGS=0; WITH_BLOCK=0; shift ;;
+    --force)       FORCE=1; shift ;;
+    --dry-run)     DRY_RUN=1; shift ;;
+    -h|--help)     usage 0 ;;
+    --*)           die "Unknown flag: $1" ;;
+    *)
+      if [ -z "$SLUG" ]; then SLUG="$1"; shift
+      else die "Unexpected positional arg: $1"
+      fi
+      ;;
+  esac
+done
+
+[ -n "$SLUG" ] || usage 2
+
+# --- Slug validation ---
+if ! [[ "$SLUG" =~ ^[a-z][a-z0-9-]*$ ]]; then
+  die "Invalid slug '$SLUG'. Must match ^[a-z][a-z0-9-]*\$ (lowercase, digits, hyphens; must start with a letter)."
+fi
+
+for reserved in "${RESERVED_SLUGS[@]}"; do
+  if [ "$SLUG" = "$reserved" ]; then
+    die "Slug '$SLUG' is reserved (collides with a default WordPress plugin)."
+  fi
+done
+
+# --- Template dir sanity check ---
+[ -d "$TEMPLATE_DIR" ] || die "Template directory not found: $TEMPLATE_DIR"
+
+# --- Derive tokens ---
+# slug → PascalCase: 'flavian-starter' → 'FlavianStarter'
+slug_to_pascal() {
+  local s="$1" out=""
+  IFS='-' read -ra parts <<< "$s"
+  for p in "${parts[@]}"; do
+    out+="$(printf '%s' "${p:0:1}" | tr '[:lower:]' '[:upper:]')${p:1}"
+  done
+  printf '%s' "$out"
+}
+
+# slug → UPPER_SNAKE: 'flavian-starter' → 'FLAVIAN_STARTER'
+slug_to_const() {
+  printf '%s' "$1" | tr 'a-z-' 'A-Z_'
+}
+
+PLUGIN_CLASS="$(slug_to_pascal "$SLUG")"
+PLUGIN_CONST="$(slug_to_const "$SLUG")"
+
+if [ -z "$NAME" ]; then
+  # 'flavian-starter' → 'Flavian Starter'
+  NAME="$(printf '%s' "$SLUG" | sed -E 's/(^|-)([a-z])/\1\u\2/g' | tr '-' ' ')"
+fi
+
+if [ -z "$DESCRIPTION" ]; then
+  DESCRIPTION="A WordPress plugin scaffolded with scripts/scaffold-plugin.sh."
+fi
+
+if [ -z "$AUTHOR" ]; then
+  AUTHOR="$(git -C "$PROJECT_ROOT" config user.name 2>/dev/null || true)"
+  [ -n "$AUTHOR" ] || AUTHOR="Anonymous"
+fi
+
+if [ -z "$NAMESPACE" ]; then
+  NAMESPACE="Flavian\\Plugins\\${PLUGIN_CLASS}"
+fi
+
+VERSION="0.1.0"
+TARGET_DIR="$PLUGINS_DIR/$SLUG"
+
+# --- Pre-flight ---
+if [ -e "$TARGET_DIR" ]; then
+  if [ "$FORCE" -eq 1 ]; then
+    [ "$DRY_RUN" -eq 1 ] || rm -rf "$TARGET_DIR"
+  else
+    die "$TARGET_DIR already exists. Re-run with --force to overwrite."
+  fi
+fi
+
+# --- Token substitution helper ---
+# Escape characters that have special meaning in sed *replacement* strings:
+# backslash, ampersand, and the chosen delimiter ('|'). Critical for namespace
+# (contains backslashes) and free-text fields (author / description).
+sed_escape() {
+  printf '%s' "$1" | sed -e 's/[\\&|]/\\&/g'
+}
+
+render_file() {
+  local src="$1" dst="$2"
+  local slug_e name_e desc_e class_e const_e ns_e ns_json ns_json_e author_e version_e
+  slug_e="$(sed_escape "$SLUG")"
+  name_e="$(sed_escape "$NAME")"
+  desc_e="$(sed_escape "$DESCRIPTION")"
+  class_e="$(sed_escape "$PLUGIN_CLASS")"
+  const_e="$(sed_escape "$PLUGIN_CONST")"
+  ns_e="$(sed_escape "$NAMESPACE")"
+  # JSON-encoded namespace: each '\' becomes '\\' before sed-escaping.
+  ns_json="${NAMESPACE//\\/\\\\}"
+  ns_json_e="$(sed_escape "$ns_json")"
+  author_e="$(sed_escape "$AUTHOR")"
+  version_e="$(sed_escape "$VERSION")"
+
+  sed \
+    -e "s|{{PLUGIN_SLUG}}|${slug_e}|g" \
+    -e "s|{{PLUGIN_NAME}}|${name_e}|g" \
+    -e "s|{{PLUGIN_DESC}}|${desc_e}|g" \
+    -e "s|{{PLUGIN_CLASS}}|${class_e}|g" \
+    -e "s|{{PLUGIN_CONST}}|${const_e}|g" \
+    -e "s|{{PLUGIN_NS_JSON}}|${ns_json_e}|g" \
+    -e "s|{{PLUGIN_NS}}|${ns_e}|g" \
+    -e "s|{{TEXT_DOMAIN}}|${slug_e}|g" \
+    -e "s|{{AUTHOR}}|${author_e}|g" \
+    -e "s|{{VERSION}}|${version_e}|g" \
+    "$src" > "$dst"
+}
+
+# --- Plan ---
+printf '▸ Scaffolding plugin: %s\n' "$SLUG"
+printf '  Name:        %s\n' "$NAME"
+printf '  Description: %s\n' "$DESCRIPTION"
+printf '  Class:       %s\n' "$PLUGIN_CLASS"
+printf '  Const:       %s\n' "$PLUGIN_CONST"
+printf '  Namespace:   %s\n' "$NAMESPACE"
+printf '  Author:      %s\n' "$AUTHOR"
+printf '  Target:      %s\n' "$TARGET_DIR"
+printf '  Features:    cpt=%d taxonomy=%d settings=%d block=%d\n' \
+  "$WITH_CPT" "$WITH_TAXONOMY" "$WITH_SETTINGS" "$WITH_BLOCK"
+[ "$DRY_RUN" -eq 1 ] && printf '  Dry-run: yes\n'
+echo ""
+
+# --- Walk template tree + render ---
+COUNT=0
+while IFS= read -r src; do
+  rel="${src#$TEMPLATE_DIR/}"
+  rel="${rel%.tmpl}"
+
+  # Substitute PLUGIN_SLUG in file/dir path (only the main plugin file uses this).
+  rel="${rel//PLUGIN_SLUG/$SLUG}"
+
+  dst="$TARGET_DIR/$rel"
+
+  if [ "$DRY_RUN" -eq 1 ]; then
+    printf '  + %s\n' "$rel"
+  else
+    mkdir -p "$(dirname "$dst")"
+    render_file "$src" "$dst"
+  fi
+  COUNT=$((COUNT + 1))
+done < <(find "$TEMPLATE_DIR" -type f -name '*.tmpl' | LC_ALL=C sort)
+
+# --- Conditional feature removal ---
+remove_feature() {
+  local label="$1"; shift
+  local paths=("$@")
+  for p in "${paths[@]}"; do
+    target="$TARGET_DIR/$p"
+    if [ -e "$target" ]; then
+      [ "$DRY_RUN" -eq 1 ] || rm -rf "$target"
+      printf '  - %s (omitted: %s)\n' "$p" "$label"
+    fi
+  done
+}
+
+[ "$WITH_CPT"      -eq 0 ] && remove_feature 'cpt'      'src/PostTypes' 'tests/PostTypes'
+[ "$WITH_TAXONOMY" -eq 0 ] && remove_feature 'taxonomy' 'src/Taxonomies'
+[ "$WITH_SETTINGS" -eq 0 ] && remove_feature 'settings' 'src/Admin'
+[ "$WITH_BLOCK"    -eq 0 ] && remove_feature 'block'    'src/Blocks' 'assets/blocks'
+
+# --- Done ---
+echo ""
+if [ "$DRY_RUN" -eq 1 ]; then
+  printf '✓ Dry run: would write %d files to %s\n' "$COUNT" "$TARGET_DIR"
+else
+  printf '✓ Wrote %d files to %s\n' "$COUNT" "$TARGET_DIR"
+  printf '\nNext steps:\n'
+  printf '  cd plugins/%s\n' "$SLUG"
+  printf '  composer install\n'
+  printf '  composer test\n'
+  printf '  composer lint\n'
+fi


### PR DESCRIPTION
## Summary

Adds a token-substitution plugin generator that produces a PSR-4 autoloaded WordPress plugin in one command. Ships `plugins/flavian-starter/` as the canonical scaffold output and parallel to `themes/flavian-shop/`. Closes #19.

```bash
bash scripts/scaffold-plugin.sh my-plugin \
  --name "My Plugin" \
  --description "What it does" \
  --author "Your Name"
```

Produces a runnable plugin with proper headers, activation hooks, a CPT, a taxonomy, a Settings API page, a server-rendered block, PHPUnit tests (Brain Monkey), and a `WordPress-Extra` PHPCS ruleset. Feature flags: `--no-cpt`, `--no-taxonomy`, `--no-settings`, `--no-block`, `--minimal`, `--force`, `--dry-run`.

### What the scaffold produces

```
plugins/<slug>/
├── <slug>.php                  ← main file, headers, autoload
├── uninstall.php
├── composer.json               ← PSR-4 + dev deps
├── phpunit.xml.dist
├── .phpcs.xml.dist
├── README.md
├── src/
│   ├── Plugin.php              ← singleton; class_exists() guards per feature
│   ├── Activator.php           ← flush_rewrite_rules on activation
│   ├── Deactivator.php
│   ├── PostTypes/Event.php
│   ├── Taxonomies/EventCategory.php
│   ├── Admin/Settings.php      ← Settings API page
│   └── Blocks/FeaturedEvent.php
├── assets/
│   ├── css/admin.css, js/admin.js
│   └── blocks/featured-event/  ← block.json + index.js (no build step) + CSS
└── tests/
    ├── bootstrap.php           ← Brain Monkey
    ├── TestCase.php
    ├── PluginTest.php
    └── PostTypes/EventTest.php
```

### Decisions locked in (from scoping)

| # | Choice | Implementation |
| - | --- | --- |
| 1 | `flavian-starter` reference plugin | `plugins/flavian-starter/` |
| 2 | PSR-4 namespaces | `Flavian\Plugins\<PluginClass>`, autoload via composer |
| 3 | Include one-block example | `src/Blocks/FeaturedEvent.php` + `assets/blocks/featured-event/` (server-rendered, no JS build step) |
| 4 | Silent on activation | `Activator::activate()` only calls `flush_rewrite_rules()` — no demo content |
| 5 | Extend `plugin-developer` only, no new agents | `.claude/agents/plugin-developer.md` updated; description + body now point at scaffold and reference plugin |
| 6 | CI matrix over `plugins/flavian-*/` glob | `discover` job in `plugin-validation.yml` enumerates with `find ... -name 'flavian-*'` + `jq`; adding a new first-party plugin requires no workflow edit |
| 7 | Per-plugin composer.json | Each plugin has its own `composer.json`, `phpunit.xml.dist`, `.phpcs.xml.dist`, `vendor/` — independently testable |

### CI

`.github/workflows/plugin-validation.yml` (new) runs on PRs touching `plugins/flavian-*/`, `.claude/templates/plugin/`, or the scaffold script:

1. **scaffold-drift** — regenerates `flavian-starter` from templates, `git diff --exit-code`. Catches template/reference drift in either direction.
2. **discover** — emits a matrix of every `plugins/flavian-*/` directory.
3. **phpunit** — composer install + phpunit per plugin.
4. **phpcs** — composer install + phpcs (via `cs2pr` for inline PR annotations) per plugin.

### Implementation notes worth knowing

- **`{{PLUGIN_NS_JSON}}` token** — composer.json's PSR-4 strings need `\` per literal backslash in the namespace. The generator computes a JSON-encoded namespace and substitutes it separately from the PHP-source `{{PLUGIN_NS}}` token. Documented in `.claude/templates/plugin/README.md`.
- **No JS build step for the block** — `assets/blocks/featured-event/index.js` uses `window.wp.blocks` / `wp.element` / `wp.blockEditor` / `wp.i18n` runtime globals directly. The plugin is usable the instant `composer install` finishes; users who want JSX can add `@wordpress/scripts` themselves.
- **`class_exists()` guards in `Plugin::boot()`** — so users can `rm -rf src/PostTypes/` after scaffolding without breaking the rest of the plugin. Same pattern in `Activator`.
- **Idempotence verified locally** — running the same scaffold command twice produces byte-identical output (confirmed with `diff -r`). The CI drift check depends on this.
- **`.gitignore` carve-out** — `.claude/templates/` added to the existing unignore list; `.claude/*` defaults to ignored.

### Test plan

- [ ] `commitlint` passes on this PR.
- [ ] `plugin-validation / scaffold-drift` passes — regenerated `flavian-starter` matches committed copy.
- [ ] `plugin-validation / phpunit (flavian-starter)` passes — Brain Monkey tests in `tests/PluginTest.php` and `tests/PostTypes/EventTest.php` run green after `composer install`.
- [ ] `plugin-validation / phpcs (flavian-starter)` passes — no WordPress-Extra violations in the scaffold output.
- [ ] Visual regression workflow (#69) and the rest of CI unaffected (no theme files touched).
- [ ] Spot check: scaffold a throwaway plugin locally — `bash scripts/scaffold-plugin.sh demo --author "Demo" --force` produces a working `plugins/demo/` that passes its own `composer test`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)