### PR TITLE
chore: versioning hygiene pass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Theme validation workflow now passes on PRs that don't touch themes/plugins
 
+## [1.1.0] - 2026-05-07
+
+### Added
+
+- Canva-to-WordPress conversion pipeline: Canva FSE converter agent, autonomous Canva-to-FSE workflow skill, HTML-to-block converter, CSS export parser with design token extraction, and shared validation scripts (#8, #33)
+- Agent configuration validation: validation script, CI dry-run wrapper, GitHub Actions workflow, and bats-core test framework (#13, #37, #38)
+- Block pattern library with starter templates: hero sections, feature grids, testimonials, CTAs, pricing tiers, and bonus patterns (newsletter signup, FAQ accordion), plus FSE templates/parts and SVG previews (#12, #36)
+- Security audit agent with dependency vulnerability scanning, severity-rated report generator, and auto GitHub issue creation for critical findings (#10, #34)
+- Optimized Docker image build time with layer caching (#11, #35)
+- PHPCS CI workflow with inline PR annotations (#6, #31)
+- Automated test coverage for the Figma-to-WordPress pipeline (90 BATS tests) (#7)
+- FSE theme structure validation tests for required files (#45, #58)
+- Unit tests for `rgb_to_hex()` color conversion in `parse-canva-export.sh` (#44, #57)
+- Environment variable validation script that warns about default passwords (#46, #50)
+- WooCommerce support in the block-theme scaffold (#60)
+- Remote deployment agent for staging and production (#59)
+- Contributor Covenant Code of Conduct, pull request template, and issue template config with discussions link
+- Expanded `CONTRIBUTING.md` with development setup and PR guidelines (#47, #48)
+
+### Changed
+
+- Improved error messages in `parse-canva-export.sh` with script identification (#40, #53)
+- Reconciled agent, skill, and plugin counts across documentation
+- Added `@since` version tags to all block pattern file headers (#42, #52)
+- Added PHPDoc comment block to `flavian_enqueue_fonts()` (#39, #49)
+
+### Fixed
+
+- Theme existence validation in `activate_theme()` in `wordpress-local.sh` (#43, #56)
+- Env-validation script no longer blocks startup if `.env` is missing
+
 ## [1.0.0] - 2026-03-16
 
 ### Added
@@ -123,5 +154,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Cross-browser testing support via Playwright MCP
 - Docker-based local WordPress development environment (`LOCAL-DEVELOPMENT.md`)
 
-[Unreleased]: https://github.com/PMDevSolutions/Flavian/compare/v1.0.0...HEAD
+[Unreleased]: https://github.com/PMDevSolutions/Flavian/compare/v1.1.0...HEAD
+[1.1.0]: https://github.com/PMDevSolutions/Flavian/compare/v1.0.0...v1.1.0
 [1.0.0]: https://github.com/PMDevSolutions/Flavian/releases/tag/v1.0.0

--- a/docs/milestones-proposed.md
+++ b/docs/milestones-proposed.md
@@ -1,0 +1,37 @@
+# Milestone Description Proposals
+
+Proposed rewrites for open GitHub milestones to bring them into a canonical format:
+
+1. One-sentence summary of the release.
+2. Bullet list of 3-6 themes covered.
+3. A single `Focus:` line.
+
+These are proposals only — no GitHub milestones have been edited. Apply via the GitHub web UI or `gh api ... -X PATCH` once reviewed.
+
+---
+
+## Milestone #2 — `v2.0.0`
+
+**Status:** Open
+**Due:** 2026-07-31
+**Open issues:** 7 / **Closed issues:** 11
+
+### Current
+
+> Major release — Canva-to-WordPress pipeline, multi-site scaffolding, headless WordPress/REST API starter, Gutenberg custom block scaffolding, and expanded agent coverage. This release represents a significant expansion of Flavian's capabilities beyond the core FSE theme workflow.
+
+### Proposed
+
+> Major release expanding Flavian beyond the core FSE theme workflow with new conversion pipelines, multi-site support, and headless WordPress starters.
+>
+> - Canva-to-WordPress conversion pipeline
+> - Multi-site scaffolding and provisioning
+> - Headless WordPress / REST API starter
+> - Gutenberg custom block scaffolding
+> - Expanded agent and skill coverage
+>
+> Focus: broadening the framework's surface area from single-site FSE themes to multi-site, headless, and custom-block development patterns.
+
+### Rationale
+
+The current description mixes a summary, a feature list, and an editorial sentence in a single paragraph. The proposed version preserves every feature mentioned, splits them into scannable bullets, and replaces the editorial closing sentence with an explicit `Focus:` line so the milestone's intent is unambiguous to contributors triaging issues.


### PR DESCRIPTION
## Summary

Versioning hygiene pass: backfilled missing `v1.1.0` section in `CHANGELOG.md` and drafted canonical milestone description proposals. Several items intentionally **not applied** because Flavian's existing setup differs from the canonical Nerva pattern — see ambiguity notes below for human review.

## Latest tag

`v1.1.0` (tagged 2026-05-07). Previous tag: `v1.0.0`.

## Sub-task status

- [x] **Sub-task 1 — Reconcile package.json with latest tag — Ambiguity flagged, NOT applied.** `package.json` `version` is `0.0.0`, latest tag is `v1.1.0`. However, `package.json` explicitly documents in its `description` field: _"Source of truth for the repository version is git tags + .release-please-manifest.json, not this file."_ The `.release-please-manifest.json` correctly tracks `1.1.0`. Bumping `package.json` from `0.0.0` would contradict a deliberate project convention. **Question for reviewer:** should `package.json.version` be updated to `1.1.0` (overriding the documented convention), kept at `0.0.0` (preserving the release-please-manifest-as-source-of-truth design), or should the documented description be reworded?
- [x] **Sub-task 2 — Milestone descriptions — Applied.** One open milestone (`v2.0.0`). Current description is not in canonical format; proposal written to `docs/milestones-proposed.md`. No GitHub milestones edited.
- [x] **Sub-task 3 — CHANGELOG audit — Applied.** Backfilled `## [1.1.0] - 2026-05-07` section with Added / Changed / Fixed subsections summarized from 44 closed issues in milestone #1 (cross-referenced against `git log v1.0.0..v1.1.0`). Existing `## [Unreleased]` and `## [1.0.0]` entries left untouched. Updated comparison links at the bottom of the file to add the v1.1.0 entry. No closed milestone is missing a CHANGELOG section; no tag is missing a milestone.
- [x] **Sub-task 4 — Release config (match Nerva canonical) — NOT applied, ambiguity flagged.** Flavian uses **release-please** (configured via `.github/workflows/release-please.yml`, `release-please-config.json`, and `.release-please-manifest.json`), not `commit-and-tag-version` like Nerva. Both tools serve the same purpose (automated semver bumping from conventional commits). Adding Nerva's `release:*` scripts, the `commit-and-tag-version` devDependency, and `.versionrc.json` would create two competing release tools and likely break the existing release-please CI workflow. **Question for reviewer:** is Flavian intentionally on release-please, or should we migrate to `commit-and-tag-version` to match Nerva (which would require removing the release-please workflow and migrating `.release-please-manifest.json` state)?

## Files changed

- `CHANGELOG.md` — appended v1.1.0 section, updated bottom comparison links
- `docs/milestones-proposed.md` — new file with proposed canonical v2.0.0 milestone description

## Ambiguities for reviewer

1. **package.json version policy** — see Sub-task 1 above. Two reasonable answers; please pick one.
2. **Release tool choice** — see Sub-task 4 above. Migrating release-please → commit-and-tag-version is a non-trivial decision and outside the safe scope of a hygiene pass.
3. No discrepancies between tags and milestones detected: `v1.0.0` and `v1.1.0` tags both exist; milestone #1 (`v1.1.0`) is closed; milestone #2 (`v2.0.0`) is open and expected.

## Test plan

- [ ] Reviewer confirms package.json version policy
- [ ] Reviewer confirms release tooling direction
- [ ] Reviewer reviews v1.1.0 CHANGELOG entries for accuracy (44 closed issues summarized)
- [ ] Reviewer reviews proposed v2.0.0 milestone description in `docs/milestones-proposed.md`

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>