### PR TITLE
feat(pipeline): InDesign as a first-class Flavian workflow — agent, skill, CLI, docs (#66)

### DIFF
--- a/.claude/CUSTOM-AGENTS-GUIDE.md
+++ b/.claude/CUSTOM-AGENTS-GUIDE.md
@@ -1,7 +1,7 @@
 # Custom Agents Reference Guide
 
 **Last Updated:** 2026-05-06
-**Total Custom Agents:** 51
+**Total Custom Agents:** 53
 **Location:** `.claude/agents/`
 
 This guide categorizes all custom agents by relevance to WordPress FSE theme development.
@@ -99,6 +99,13 @@ These agents directly support WordPress block theme development:
 - **Use for:** Installing and configuring WooCommerce, importing products, wiring shop/cart/checkout/my-account pages to FSE templates, customising the bundled `flavian-shop` starter theme, scaffolding shipping zones, taxes, and payment gateways
 - **WordPress relevance:** Critical - turns the scaffold into an e-commerce-ready store
 - **Backed by:** `themes/flavian-shop/` and `scripts/wordpress-install/setup-woocommerce.sh`
+
+### **indesign-to-wordpress** (NEW)
+- **Purpose:** Convert an Adobe InDesign document (`.idml` or PDF) into a WordPress FSE block theme
+- **Use for:** Orchestrating the `@flavian/pipeline` InDesign stages (parse → map design tokens → generate patterns/templates/parts/theme.json), reviewing the generation report, and proposing concrete follow-ups (unmapped frames, font fallbacks, alt text). Non-destructive — works on a feature branch, never on `main`
+- **WordPress relevance:** Critical - turns print/layout sources into installable FSE themes
+- **Backed by:** `packages/pipeline/` (#62–#65), `bin/flavian.mjs`, and `scripts/indesign-fse/`
+- **Pairs with:** the `indesign-conversion` skill
 
 ---
 

--- a/.claude/agents/indesign-to-wordpress.md
+++ b/.claude/agents/indesign-to-wordpress.md
@@ -1,0 +1,84 @@
+---
+name: indesign-to-wordpress
+description: Orchestrates the InDesign-to-WordPress pipeline. Parses an exported .idml or PDF, maps paragraph/character styles and swatches to theme.json design tokens, generates FSE block patterns/templates/parts, reviews the generation report, and proposes concrete follow-ups. Non-destructive — works on a feature branch, never on main.
+tools: Read, Write, Edit, MultiEdit, Bash, Grep, Glob, AskUserQuestion, TaskOutput, TodoWrite, Skill
+model: opus
+permissionMode: bypassPermissions
+hooks:
+  PreToolUse:
+    - matcher: "Write|Edit|MultiEdit"
+      hooks:
+        - type: command
+          command: "./scripts/indesign-fse/validate-theme-location.sh"
+          description: "Blocks writes into wp-content/themes — themes belong at root-level themes/"
+  PostToolUse:
+    - matcher: "Write|Edit|MultiEdit"
+      hooks:
+        - type: command
+          command: "./scripts/block-markup-validator/validate-block-markup.sh"
+        - type: command
+          command: "./scripts/theme-token-auditor/audit-tokens.sh"
+        - type: command
+          command: "./scripts/wordpress/security-scan.sh"
+        - type: command
+          command: "./scripts/wordpress/check-coding-standards.sh"
+---
+
+You are the **InDesign-to-WordPress conversion specialist**. You turn an exported Adobe InDesign document (`.idml`, or a PDF fallback) into a complete, installable WordPress FSE block theme by orchestrating the `@flavian/pipeline` InDesign stages (#62–#65) and then reviewing what they produced.
+
+You are autonomous but **non-destructive**: you always work on a feature branch, never commit to `main`, and you surface the generation report's follow-ups instead of silently papering over them.
+
+## What the pipeline gives you
+
+The heavy lifting is already implemented in `packages/pipeline`. You orchestrate it; you do not re-implement it.
+
+1. **Parse** — `bin/parse-idml.mjs` (primary) or `bin/parse-pdf.mjs` (fallback) → a validated intermediate representation (IR): swatches, fonts, paragraph/character styles, stories, spreads, master spreads.
+2. **Map tokens** — `bin/map-tokens.mjs` → a `theme.json` partial merged into the base theme, DTCG design tokens, and a report (font fallbacks, out-of-gamut colors, Google fonts).
+3. **Generate** — `bin/generate-theme.mjs`, or the unified `bin/flavian.mjs pipeline indesign`, → patterns (one per spread, under the **InDesign Imports** category), templates, header/footer parts, the merged `theme.json`, `bin/import-media.sh`, and a generation report in Markdown **and** JSON.
+
+The single-command path runs all three:
+
+```bash
+flavian pipeline indesign <input.idml|input.pdf> --output themes/<slug> [--seed-content]
+# equivalently: node bin/flavian.mjs pipeline indesign ...
+```
+
+## Procedure
+
+Follow these steps in order. Use `TodoWrite` to track them.
+
+### 1. Validate input
+- Confirm the input exists and is an `.idml` or `.pdf` (or a pre-parsed IR JSON).
+- Prefer `.idml` — it carries stories, frames, styles, swatches, and masters. PDF is a lossy fallback; warn the user that PDF parses always carry fidelity warnings.
+- If neither is available, ask the user to export one from InDesign (`File → Export → InDesign Markup (.idml)`).
+
+### 2. Create a feature branch
+- `git checkout -b indesign-import/<slug>` (or a branch the user names). **Never** work on `main`.
+
+### 3. Run the pipeline
+- Run `flavian pipeline indesign <input> --output themes/<slug>`. Add `--seed-content` if the user wants draft pages seeded.
+- Honor `flavian.config.json` if present (output dir, base theme, namespace). CLI flags override config.
+- If image bytes are available (extracted PDF assets, or a packaged IDML's `Links/` folder), pass `--asset-dir <dir>` so they stage into `assets/`.
+
+### 4. Review the generation report
+Read `themes/<slug>/indesign-pipeline-report.json` (machine-readable) and `indesign-pipeline-report.md` (human-readable). From them, propose **concrete** follow-ups — never a generic "review the output":
+- **Unmapped frames** — list each by id/kind/reason; suggest whether to add content manually, re-export with the frame on a non-master layer, etc.
+- **Font fallbacks** — name each InDesign font that fell back to a web/Google family; ask the user to confirm the substitution or supply a self-hosted font.
+- **Out-of-gamut colors** — note any CMYK/LAB swatch that was clamped to sRGB, so the user knows print↔screen color will shift.
+- **Image alt text** — generated images have empty `alt`; list each staged asset and propose alt text from its surrounding story text or filename.
+- **Assets not staged** — if bytes weren't available, list the expected `assets/…` filenames and remind the user to drop them in and run `bin/import-media.sh`.
+
+### 5. Verify
+- Confirm `theme.json` reports valid in the report (`valid: true`). If not, surface the validation errors.
+- Optionally run `node scripts/indesign-fse/smoke-test.mjs` for an end-to-end sanity check on a fixture.
+- Spot-check one generated pattern: headings/paragraphs reference token slugs (`"fontSize":"…"`, `"textColor":"…"`), never inline hex/px.
+
+### 6. Hand off
+- Summarize: theme location, spreads imported, patterns created, and the prioritized follow-up list from step 4.
+- Stage and commit on the feature branch with a conventional-commit message (e.g. `feat(theme): import <name> from InDesign`). Offer to open a PR. **Do not** push to `main`.
+
+## Guardrails
+- Theme files go in **root-level `themes/<slug>/`**, never `wp-content/themes/` (the PreToolUse hook enforces this).
+- Patterns are deterministic — re-running the pipeline on the same input must not churn unrelated files. Don't hand-edit generated patterns in ways that defeat re-generation; prefer fixing the source or the pipeline.
+- Escape output and keep image URLs going through `get_theme_file_uri()` (the pipeline already does this — preserve it).
+- Prefer the `indesign-conversion` skill for the detailed conversion workflow and gotchas.

--- a/.claude/skills/README.md
+++ b/.claude/skills/README.md
@@ -11,6 +11,11 @@ This directory contains custom WordPress development skills for Claude Code, opt
    - Triggers: "convert Figma", "Figma to WordPress", "FSE conversion"
    - Role: Main workflow skill that coordinates all other skills
 
+   **indesign-conversion**
+   - Convert an Adobe InDesign document (`.idml` or PDF) into an FSE block theme
+   - Triggers: "InDesign to WordPress", "IDML", "convert InDesign", "print to web"
+   - Role: Drives the `@flavian/pipeline` InDesign pipeline; pairs with the `indesign-to-wordpress` agent
+
 2. **fse-block-theme-development**
    - theme.json syntax, template hierarchy, and FSE structure
    - Triggers: "create block theme", "add template", "theme.json"

--- a/.claude/skills/indesign-conversion/SKILL.md
+++ b/.claude/skills/indesign-conversion/SKILL.md
@@ -1,0 +1,104 @@
+---
+name: indesign-conversion
+description: Use when converting an Adobe InDesign document (.idml or PDF) into a WordPress FSE block theme. Covers prerequisites, the parse → map-tokens → generate pipeline, expected outputs, and gotchas (CMYK→sRGB shifts, missing fonts, oversized print images). Keywords: InDesign to WordPress, IDML, IDML to FSE, InDesign PDF, print to web, design tokens from InDesign
+---
+
+# InDesign Conversion
+
+## Overview
+
+This skill converts an Adobe InDesign document into a complete WordPress Full Site Editing (FSE) block theme using the `@flavian/pipeline` InDesign stages. It parses an exported `.idml` (or a PDF fallback), maps the document's paragraph/character styles and swatches into `theme.json` design tokens, and generates FSE block patterns (one per spread), templates, header/footer parts, and a merged `theme.json`.
+
+**Key principle:** the design system comes from the document. Swatches → color palette, paragraph styles → typography scale, frame geometry → spacing — then patterns reference those token slugs, never inline values.
+
+Pair this skill with the **indesign-to-wordpress** agent, which runs the steps end-to-end and reviews the generation report for follow-ups.
+
+## When to use
+
+- A client/designer hands you an InDesign layout (brochure, flyer, catalog, report) and wants it as a WordPress theme.
+- You have an exported `.idml` file, or only a PDF exported from InDesign.
+- You want a deterministic, re-runnable conversion (same input → same output, no diff churn).
+
+Do **not** use this for live Figma or Canva sources — use `figma-to-fse-autonomous-workflow` or `canva-to-fse-autonomous-workflow` instead.
+
+## Prerequisites
+
+- **An exported `.idml` (strongly preferred).** In InDesign: `File → Export → Format: InDesign Markup (IDML)`. IDML preserves stories, frames, styles, swatches, and master spreads.
+- **Or a PDF fallback.** `File → Export → Adobe PDF`. PDF reconstruction is lossy — text is rebuilt from glyph runs, styles are synthesized from font sizes, and every approximation is recorded as a fidelity warning. Use only when no `.idml` is available.
+- **Node 20+** and the workspace installed (`pnpm install`).
+- **Image bytes (optional).** Patterns reference images by a deterministic filename; to stage the actual bytes, point `--asset-dir` at the IDML package's `Links/` folder or a directory of extracted PDF assets.
+
+## Workflow
+
+1. **Branch.** `git checkout -b indesign-import/<slug>` — never convert on `main`.
+2. **Convert.** Run the unified CLI:
+   ```bash
+   flavian pipeline indesign <input.idml> --output themes/<slug>
+   # add --seed-content to also emit bin/seed-content.sh (a draft page per spread)
+   # add --asset-dir <dir> to stage real image bytes into assets/
+   ```
+   This parses, maps tokens, and generates the theme in one step.
+3. **Review the report.** Open `themes/<slug>/indesign-pipeline-report.md` (and the `.json` twin for tooling). Act on unmapped frames, font fallbacks, out-of-gamut colors, and missing alt text.
+4. **Verify.** Activate the theme locally and open the Site Editor; the imported patterns appear under **InDesign Imports** in the inserter. Confirm `theme.json` is valid (the report says so).
+5. **Seed media.** Drop image bytes into `themes/<slug>/assets/` (if not already staged) and run `bash themes/<slug>/bin/import-media.sh`.
+
+## Expected outputs
+
+```
+themes/<slug>/
+├── theme.json                      # base theme merged with the mapped tokens (schema-valid)
+├── style.css, functions.php        # theme header + bootstrap (registers the InDesign Imports category)
+├── patterns/spread-1.php …         # one block pattern per spread, category: indesign-imports
+├── templates/                      # index.html (stitches the patterns), page.html, 404.html
+├── parts/header.html, footer.html  # from master-spread chrome, or sensible defaults
+├── bin/import-media.sh             # WP-CLI media import for staged assets
+├── indesign-pipeline-report.md     # human-readable generation report
+└── indesign-pipeline-report.json   # machine-readable counterpart
+```
+
+## Frame → block mapping
+
+- Text frames → `core/heading` / `core/paragraph`, grouped in `core/group` (role from the paragraph-style name: `Heading N`, `Body`, `Caption`).
+- Image frames → `core/image`, or `core/cover` when text sits on top of the image.
+- Side-by-side frames → `core/columns`.
+- Master-spread top/bottom chrome → header/footer template parts.
+
+## Worked example (committed fixture)
+
+The pipeline ships a code fixture (no committed binaries) and an end-to-end smoke test that builds a two-spread brochure, runs the real CLI, and asserts the theme is valid:
+
+```bash
+node scripts/indesign-fse/smoke-test.mjs
+# ✓ smoke: InDesign pipeline generated a valid theme (2 spreads, theme.json v3)
+```
+
+To convert your own document end-to-end and inspect a generated pattern:
+
+```bash
+flavian pipeline indesign ./brochure.idml --output themes/brochure
+sed -n '1,20p' themes/brochure/patterns/spread-1.php
+cat themes/brochure/indesign-pipeline-report.md
+```
+
+You can also drive the stages individually (useful for debugging):
+
+```bash
+node packages/pipeline/bin/parse-idml.mjs brochure.idml > ir.json
+node packages/pipeline/bin/map-tokens.mjs ir.json --out-dir ./tokens
+node packages/pipeline/bin/generate-theme.mjs ir.json --out-dir themes/brochure
+```
+
+## Common gotchas
+
+- **CMYK/LAB → sRGB shifts.** Print color spaces don't map 1:1 to screen. The mapper converts and flags any out-of-gamut swatch in the report; expect brand colors to look slightly different on screen and confirm them with the designer.
+- **Missing / substituted fonts.** InDesign fonts that aren't web-safe fall back via `config/font-map.json` (often a Google font). The report lists every fallback — confirm each, or self-host the real font and update the font map.
+- **Oversized print images.** Print assets are often huge (300 DPI, CMYK). Resize/recompress for web and convert CMYK images to sRGB before importing, or they'll bloat the page and render with muddy color.
+- **PDF fidelity.** A PDF parse always carries warnings — text reconstructed from glyphs, synthesized styles, dropped vector art. Prefer `.idml`; treat PDF output as a starting point that needs review.
+- **Empty alt text.** Generated images have `alt=""`. Add meaningful alt text (the agent proposes some from surrounding story text) before shipping.
+- **Don't hand-edit patterns destructively.** Patterns are deterministic; re-running the pipeline regenerates them. Fix the source document or the pipeline rather than patching generated files.
+
+## Related
+
+- Agent: `indesign-to-wordpress` (orchestrates + reviews the report)
+- Docs: `docs/pipelines/indesign.md`, `docs/pipeline/indesign-output-generator.md`
+- Skills: `fse-pattern-first-architecture`, `block-pattern-creation`, `visual-qa-verification`

--- a/.github/workflows/pipeline-tests.yml
+++ b/.github/workflows/pipeline-tests.yml
@@ -25,6 +25,8 @@ jobs:
             pipeline-pkg:
               - 'packages/pipeline/**'
               - 'pnpm-workspace.yaml'
+              - 'bin/flavian.mjs'
+              - 'scripts/indesign-fse/**'
 
   test:
     needs: check-paths
@@ -75,6 +77,9 @@ jobs:
 
       - name: Run @flavian/pipeline tests
         run: pnpm --filter @flavian/pipeline test
+
+      - name: Run InDesign end-to-end smoke test
+        run: node scripts/indesign-fse/smoke-test.mjs
 
   test-status:
     runs-on: ubuntu-latest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -279,9 +279,9 @@ This project uses a lean, WordPress-optimized plugin configuration with 6 plugin
 
 ---
 
-### Custom Agents (52 Total)
+### Custom Agents (53 Total)
 
-52 specialized agents: 27 WordPress-focused development agents plus 25 generic cross-domain agents (meta/ops, business, marketing/social, engineering). Key WordPress agents include `frontend-developer`, `plugin-developer`, `test-writer-fixer`, `ui-designer`, `figma-fse-converter`, `canva-fse-converter`, `security-audit-agent`, `deployment-agent`, `woocommerce-agent`, `headless-developer`. Key generic agents include `agent-expert`, `backend-architect`, `migration-specialist`, `content-creator`, `devops-automator`.
+53 specialized agents: 28 WordPress-focused development agents plus 25 generic cross-domain agents (meta/ops, business, marketing/social, engineering). Key WordPress agents include `frontend-developer`, `plugin-developer`, `test-writer-fixer`, `ui-designer`, `figma-fse-converter`, `canva-fse-converter`, `indesign-to-wordpress`, `security-audit-agent`, `deployment-agent`, `woocommerce-agent`, `headless-developer`. Key generic agents include `agent-expert`, `backend-architect`, `migration-specialist`, `content-creator`, `devops-automator`.
 
 Agents are invoked automatically based on task context.
 
@@ -304,11 +304,11 @@ Use this guide to select the right one:
 
 ---
 
-### Custom WordPress Skills (11 Total)
+### Custom WordPress Skills (12 Total)
 
-11 WordPress-specific skills provide systematic workflows:
+12 WordPress-specific skills provide systematic workflows:
 
-**Pipeline orchestrators:** figma-to-fse-autonomous-workflow, canva-to-fse-autonomous-workflow
+**Pipeline orchestrators:** figma-to-fse-autonomous-workflow, canva-to-fse-autonomous-workflow, indesign-conversion
 
 **Theme authoring:** fse-block-theme-development, fse-pattern-first-architecture, block-pattern-creation
 
@@ -463,7 +463,7 @@ Result: themes/[theme-name]/ ready for WordPress
 - All plugins serve WordPress development
 
 **Agent Philosophy:**
-- 52 custom agents available (27 WordPress-focused + 25 generic cross-domain)
+- 53 custom agents available (28 WordPress-focused + 25 generic cross-domain)
 - Agents invoked contextually by Claude Code
 - No action required - automatic selection
 
@@ -611,4 +611,4 @@ Defaults configurable via `.env`: `WC_INSTALL_SAMPLE_DATA`, `WC_DEFAULT_THEME`, 
 ---
 
 **Last Updated:** 2026-05-06
-**Architecture Status:** ✅ Lean, WordPress-optimized configuration (6 plugins + 52 agents)
+**Architecture Status:** ✅ Lean, WordPress-optimized configuration (6 plugins + 53 agents)

--- a/README.md
+++ b/README.md
@@ -68,9 +68,10 @@ Claude generates the theme in `themes/[theme-name]/`. Activate it:
 
 Site at http://localhost:8080 · Admin at /wp-admin · Database UI at :8081.
 
-**Supported inputs:**
+**Supported inputs (pipelines):**
 - **Figma URL** — requires Professional plan (Dev Mode). See [docs/figma-to-wordpress/README.md](docs/figma-to-wordpress/README.md).
 - **Canva HTML/CSS export directory** — no account tier required. See [docs/canva-to-wordpress/README.md](docs/canva-to-wordpress/README.md).
+- **InDesign document** — an exported `.idml` (preferred) or PDF. Run `flavian pipeline indesign <input> --output themes/<slug>`. See [docs/pipelines/indesign.md](docs/pipelines/indesign.md).
 
 **More docs:** [docs/QUICK-START.md](docs/QUICK-START.md) · [LOCAL-DEVELOPMENT.md](LOCAL-DEVELOPMENT.md) · [docs/docker-troubleshooting.md](docs/docker-troubleshooting.md)
 
@@ -160,8 +161,8 @@ This template is optimized for WordPress development with Claude Code, featuring
 
 ### **Architecture Overview**
 - **Lean Plugin Setup**: 6 Claude Code plugins (5 user + 1 local)
-- **Custom Agents**: 51 specialized agents
-- **Custom Skills**: 11 workflows covering the Figma/Canva-to-FSE pipeline, security, testing, and i18n
+- **Custom Agents**: 53 specialized agents
+- **Custom Skills**: 12 workflows covering the Figma/Canva/InDesign-to-FSE pipelines, security, testing, and i18n
 - **Documentation Hub**: Comprehensive guides in `.claude/` directory
 
 ### **Installed Plugins**
@@ -175,10 +176,11 @@ This template is optimized for WordPress development with Claude Code, featuring
 ```
 
 ### **WordPress-Relevant Custom Agents** (highlights)
-Full catalog of 51 agents in [`.claude/CUSTOM-AGENTS-GUIDE.md`](.claude/CUSTOM-AGENTS-GUIDE.md). Key WordPress-specific ones:
+Full catalog of 53 agents in [`.claude/CUSTOM-AGENTS-GUIDE.md`](.claude/CUSTOM-AGENTS-GUIDE.md). Key WordPress-specific ones:
 ```
 ✅ figma-fse-converter      # Figma-to-FSE theme conversion
 ✅ canva-fse-converter      # Canva-to-FSE theme conversion
+✅ indesign-to-wordpress    # InDesign (.idml/PDF) → FSE theme conversion
 ✅ frontend-developer       # JS/CSS implementation for FSE themes
 ✅ test-writer-fixer        # PHP unit testing
 ✅ ui-designer              # Block pattern design
@@ -191,6 +193,7 @@ Full catalog of 51 agents in [`.claude/CUSTOM-AGENTS-GUIDE.md`](.claude/CUSTOM-A
 ```
 ✅ figma-to-fse-autonomous-workflow  # Orchestrator for Figma-to-FSE conversion
 ✅ canva-to-fse-autonomous-workflow  # Orchestrator for Canva-to-FSE conversion
+✅ indesign-conversion               # InDesign (.idml/PDF) → FSE conversion
 ✅ fse-block-theme-development       # theme.json, templates, FSE structure
 ✅ fse-pattern-first-architecture    # PHP patterns for images (enforced)
 ✅ block-pattern-creation            # Pattern registration and reuse

--- a/bin/flavian.mjs
+++ b/bin/flavian.mjs
@@ -1,0 +1,260 @@
+#!/usr/bin/env node
+// Flavian CLI — the first-class entry point for Flavian's conversion pipelines.
+//
+//   flavian pipeline indesign <input> [options]
+//
+// Today it exposes the InDesign pipeline (#62–#65): parse an .idml/.pdf (or a
+// pre-parsed IR JSON), map design tokens, and generate a complete FSE theme.
+// More pipelines (figma, canva) can be added as sibling subcommands.
+
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const ROOT = path.resolve(fileURLToPath(new URL('../', import.meta.url)));
+// Dynamic import() needs a file:// URL string (Windows absolute paths aren't valid specifiers).
+const PIPELINE = (p) => pathToFileURL(path.join(ROOT, 'packages/pipeline/src/indesign', p)).href;
+
+const argv = process.argv.slice(2);
+
+async function main() {
+	const [group, command, ...rest] = argv;
+
+	if (!group || group === '-h' || group === '--help' || group === 'help') {
+		printRootUsage();
+		process.exit(group ? 0 : 2);
+	}
+
+	if (group !== 'pipeline') {
+		fail(`Unknown command: ${group}`);
+		printRootUsage();
+		process.exit(2);
+	}
+
+	if (!command || command === '-h' || command === '--help') {
+		printPipelineUsage();
+		process.exit(command ? 0 : 2);
+	}
+
+	if (command !== 'indesign') {
+		fail(`Unknown pipeline: ${command}`);
+		printPipelineUsage();
+		process.exit(2);
+	}
+
+	await runIndesign(rest);
+}
+
+async function runIndesign(args) {
+	const opts = { seedContent: false, quiet: false };
+	let input;
+
+	let i = 0;
+	const value = (flag) => {
+		const next = args[i + 1];
+		if (next === undefined || next.startsWith('-')) {
+			fail(`${flag} requires a value`);
+			process.exit(2);
+		}
+		i += 1;
+		return next;
+	};
+
+	for (; i < args.length; i += 1) {
+		const arg = args[i];
+		switch (arg) {
+			case '--output': case '-o': opts.output = value(arg); break;
+			case '--config': opts.config = value(arg); break;
+			case '--slug': opts.slug = value(arg); break;
+			case '--name': opts.name = value(arg); break;
+			case '--base': opts.base = value(arg); break;
+			case '--namespace': opts.namespace = value(arg); break;
+			case '--asset-dir': opts.assetDir = value(arg); break;
+			case '--dpi': opts.dpi = Number(value(arg)); break;
+			case '--seed-content': opts.seedContent = true; break;
+			case '--no-seed-content': opts.seedContent = false; break;
+			case '--fluid': opts.fluid = true; break;
+			case '--quiet': case '-q': opts.quiet = true; break;
+			case '-h': case '--help': printIndesignUsage(); process.exit(0); break;
+			default:
+				if (!input && !arg.startsWith('-')) input = arg;
+				else { fail(`Unknown argument: ${arg}`); printIndesignUsage(); process.exit(2); }
+		}
+	}
+
+	if (!input) {
+		fail('an input is required (an .idml/.pdf file, an IR JSON, or - for stdin)');
+		printIndesignUsage();
+		process.exit(2);
+	}
+
+	// Lazy imports so `--help` never pays for loading the pipeline / ajv.
+	const { parseIdml } = await import(PIPELINE('parse-idml.js'));
+	const { parsePdf } = await import(PIPELINE('parse-pdf.js'));
+	const { generateTheme } = await import(PIPELINE('generate/index.js'));
+
+	const config = await loadConfig(opts.config);
+	const cfg = config?.pipeline?.indesign ?? {};
+
+	const ir = await loadIr(input, opts, parseIdml, parsePdf);
+
+	const result = generateTheme(ir, {
+		slug: opts.slug,
+		name: opts.name,
+		seedContent: opts.seedContent || Boolean(cfg.seedContent),
+		base: opts.base ?? cfg.baseTheme,
+		namespace: opts.namespace ?? cfg.namespace,
+		fluid: opts.fluid,
+	});
+
+	const outDir = resolveOutDir(opts.output, cfg.output, result.slug);
+	await writeTheme(result, outDir, opts.assetDir);
+
+	if (!opts.quiet) {
+		process.stderr.write(
+			[
+				`theme: ${result.name} (${result.slug}) → ${path.relative(process.cwd(), outDir) || '.'}`,
+				`files: ${result.files.length}  patterns: ${result.report.data.patterns.length}  assets: ${result.assets.length}`,
+				`theme.json valid: ${result.report.data.valid}`,
+				`reports: indesign-pipeline-report.md, indesign-pipeline-report.json`,
+				result.report.data.unmapped.length ? `unmapped IR nodes: ${result.report.data.unmapped.length}` : null,
+			].filter(Boolean).join('\n') + '\n',
+		);
+	}
+
+	process.exit(result.report.data.valid ? 0 : 1);
+}
+
+/** Resolve the theme output directory from --output, config.output, or default. */
+function resolveOutDir(outputFlag, configOutput, slug) {
+	if (outputFlag) return path.resolve(outputFlag);            // explicit theme dir
+	if (configOutput) return path.resolve(configOutput, slug);  // parent dir + slug
+	return path.resolve('themes', slug);                        // default
+}
+
+async function loadConfig(explicit) {
+	const file = explicit ?? path.resolve('flavian.config.json');
+	try {
+		return JSON.parse(await fs.readFile(file, 'utf8'));
+	} catch (err) {
+		if (explicit) throw new Error(`could not read config ${file}: ${err.message}`);
+		return null; // no default config present — fine
+	}
+}
+
+async function readStdin() {
+	const chunks = [];
+	for await (const chunk of process.stdin) chunks.push(chunk);
+	return Buffer.concat(chunks).toString('utf8');
+}
+
+async function loadIr(input, opts, parseIdml, parsePdf) {
+	const dpiOpt = opts.dpi !== undefined ? { dpi: opts.dpi } : undefined;
+	if (/\.idml$/i.test(input)) return parseIdml(input, dpiOpt);
+	if (/\.pdf$/i.test(input)) return parsePdf(input, dpiOpt);
+	const text = input === '-' ? await readStdin() : await fs.readFile(input, 'utf8');
+	return JSON.parse(text);
+}
+
+async function writeTheme(result, outDir, assetDir) {
+	await fs.mkdir(outDir, { recursive: true });
+	for (const f of result.files) {
+		const dest = path.join(outDir, f.path);
+		await fs.mkdir(path.dirname(dest), { recursive: true });
+		await fs.writeFile(dest, f.contents);
+		if (f.mode) await fs.chmod(dest, Number.parseInt(f.mode, 8)).catch(() => {});
+	}
+	if (assetDir && result.assets.length) {
+		for (const asset of result.assets) {
+			const candidates = [asset.href ? path.basename(asset.href.replace(/[?#].*$/, '')) : null, asset.name].filter(Boolean);
+			for (const candidate of candidates) {
+				const src = path.join(assetDir, candidate);
+				try {
+					await fs.access(src);
+					await fs.mkdir(path.join(outDir, 'assets'), { recursive: true });
+					await fs.copyFile(src, path.join(outDir, asset.relPath));
+					break;
+				} catch { /* try next candidate */ }
+			}
+		}
+	}
+}
+
+function fail(msg) {
+	process.stderr.write(`error: ${msg}\n`);
+}
+
+function printRootUsage() {
+	process.stderr.write(
+		[
+			'Flavian — Claude Code-powered design-to-WordPress pipelines.',
+			'',
+			'Usage: flavian <command> [options]',
+			'',
+			'Commands:',
+			'  pipeline indesign <input>   Convert an InDesign document to a WordPress FSE theme',
+			'',
+			'Run `flavian pipeline indesign --help` for pipeline options.',
+			'',
+		].join('\n'),
+	);
+}
+
+function printPipelineUsage() {
+	process.stderr.write(
+		[
+			'Usage: flavian pipeline <name> [options]',
+			'',
+			'Pipelines:',
+			'  indesign <input>   Convert an .idml/.pdf (or IR JSON) to an FSE theme',
+			'',
+			'Run `flavian pipeline indesign --help` for options.',
+			'',
+		].join('\n'),
+	);
+}
+
+function printIndesignUsage() {
+	process.stderr.write(
+		[
+			'Usage: flavian pipeline indesign <input> [options]',
+			'',
+			'Convert an InDesign document into a complete WordPress FSE theme: block',
+			'patterns (one per spread), templates, parts, a merged theme.json, asset',
+			'import scripts, and a generation report (Markdown + JSON).',
+			'',
+			'Arguments:',
+			'  <input>                An .idml or .pdf file, a pre-parsed IR JSON, or - for stdin',
+			'',
+			'Options:',
+			'  -o, --output <dir>     Theme output directory (default: themes/<slug>,',
+			'                         or <config.output>/<slug> when configured)',
+			'      --config <path>    Flavian config (default: ./flavian.config.json if present)',
+			'      --slug <str>       Theme slug (default: from the document name)',
+			'      --name <str>       Theme display name (default: from the document name)',
+			'      --base <path>      Base theme.json to merge against (default: flavian-shop)',
+			'      --namespace <str>  Derived-token slug prefix (default: id)',
+			'      --asset-dir <dir>  Source of image bytes to stage into assets/',
+			'      --dpi <n>          DPI when parsing .idml/.pdf directly (default: 96)',
+			'      --seed-content     Also emit bin/seed-content.sh',
+			'      --fluid            Emit fluid clamp() font sizes',
+			'  -q, --quiet            Suppress the stderr summary',
+			'  -h, --help             Show this help',
+			'',
+			'Config (flavian.config.json):',
+			'  { "pipeline": { "indesign": { "output", "baseTheme", "namespace", "seedContent" } } }',
+			'  CLI flags override config values. See flavian.config.example.json.',
+			'',
+			'Examples:',
+			'  flavian pipeline indesign brochure.idml',
+			'  flavian pipeline indesign brochure.pdf --output themes/brochure --seed-content',
+			'  flavian pipeline indesign - < ir.json --slug my-theme',
+			'',
+		].join('\n'),
+	);
+}
+
+main().catch((err) => {
+	fail(err.message);
+	process.exit(1);
+});

--- a/docs/milestones-proposed.md
+++ b/docs/milestones-proposed.md
@@ -25,6 +25,7 @@ These are proposals only — no GitHub milestones have been edited. Apply via th
 > Major release expanding Flavian beyond the core FSE theme workflow with new conversion pipelines, multi-site support, and headless WordPress starters.
 >
 > - Canva-to-WordPress conversion pipeline
+> - InDesign-to-WordPress conversion pipeline (IDML/PDF → FSE theme)
 > - Multi-site scaffolding and provisioning
 > - Headless WordPress / REST API starter
 > - Gutenberg custom block scaffolding

--- a/docs/pipelines/indesign.md
+++ b/docs/pipelines/indesign.md
@@ -1,0 +1,169 @@
+# InDesign → WordPress pipeline
+
+Convert an Adobe InDesign document into a complete WordPress FSE block theme:
+block patterns (one per spread), templates, header/footer parts, a schema-valid
+`theme.json`, asset-import scripts, and a generation report.
+
+This is the user-facing guide. For the internals, see the package docs:
+[IDML parser & IR](../pipeline/indesign-pdf-fidelity.md),
+[token mapper](../pipeline/indesign-token-mapper.md), and
+[output generator](../pipeline/indesign-output-generator.md).
+
+## At a glance
+
+```bash
+# One command: parse → map design tokens → generate the theme
+flavian pipeline indesign brochure.idml --output themes/brochure
+
+# (equivalently) node bin/flavian.mjs pipeline indesign brochure.idml --output themes/brochure
+```
+
+The InDesign pipeline sits alongside the [Figma](../figma-to-wordpress/README.md)
+and [Canva](../canva-to-wordpress/README.md) pipelines. Use it when your source
+of truth is a print/layout document rather than a live design tool.
+
+## 1. Export from InDesign
+
+### IDML (preferred)
+
+`File → Export…` → **Format: InDesign Markup (IDML)**.
+
+IDML is a structured package: it preserves stories (text), frames (geometry),
+paragraph/character styles, swatches, and master spreads. This is the
+high-fidelity path — use it whenever you can.
+
+If your document links images and you want them staged into the theme, also keep
+the package's `Links/` folder handy (or use `File → Package…`) and pass it via
+`--asset-dir`.
+
+### PDF (fallback)
+
+`File → Export…` → **Adobe PDF**. Use this only when you can't get an `.idml`.
+
+PDF reconstruction is **lossy by design**: text is rebuilt from positioned glyph
+runs, paragraph styles are *synthesized* from font-size buckets, vector art is
+dropped, and color is read per-run. Every approximation is recorded as a
+fidelity warning. See [PDF fidelity](../pipeline/indesign-pdf-fidelity.md) for
+the full list and the round-trip tolerances against IDML.
+
+## 2. Run the pipeline
+
+```bash
+flavian pipeline indesign <input.idml|input.pdf> [options]
+```
+
+| Option | Effect |
+| --- | --- |
+| `-o, --output <dir>` | Theme output directory (default `themes/<slug>`, or `<config.output>/<slug>`). |
+| `--config <path>` | Flavian config file (default `./flavian.config.json` if present). |
+| `--slug <str>` | Theme slug (default: from the document name). |
+| `--name <str>` | Theme display name. |
+| `--base <path>` | Base `theme.json` to merge against (default: `flavian-shop`). |
+| `--namespace <str>` | Derived-token slug prefix (default `id`). |
+| `--asset-dir <dir>` | Source of image bytes to copy into `assets/` (matched by basename). |
+| `--dpi <n>` | DPI when parsing `.idml`/`.pdf` directly (default 96). |
+| `--seed-content` | Also emit `bin/seed-content.sh` (a draft page per spread). |
+| `--fluid` | Emit fluid `clamp()` font sizes. |
+| `-q, --quiet` | Suppress the stderr summary. |
+
+Run `flavian pipeline indesign --help` for the authoritative list.
+
+### Configuration
+
+CLI flags override values from `flavian.config.json` (see
+[`flavian.config.example.json`](../../flavian.config.example.json)):
+
+```json
+{
+  "pipeline": {
+    "indesign": {
+      "output": "themes",
+      "baseTheme": "themes/flavian-shop/theme.json",
+      "namespace": "id",
+      "seedContent": false
+    }
+  }
+}
+```
+
+When `output` is set in config it is treated as the **parent** directory and the
+theme is written to `<output>/<slug>`; an explicit `--output` is used as the
+theme directory directly.
+
+## 3. Expected output
+
+```
+themes/<slug>/
+├── theme.json                      # base theme merged with the mapped tokens (schema-valid)
+├── style.css, functions.php        # theme header + bootstrap (registers the InDesign Imports category)
+├── patterns/spread-1.php …         # one block pattern per spread, category: indesign-imports
+├── templates/                      # index.html (stitches the patterns), page.html, 404.html
+├── parts/header.html, footer.html  # from master-spread chrome, or sensible defaults
+├── bin/import-media.sh             # WP-CLI media import for staged assets
+├── bin/seed-content.sh             # (with --seed-content) a draft page per spread
+├── indesign-pipeline-report.md     # human-readable generation report
+└── indesign-pipeline-report.json   # machine-readable counterpart (for tooling/CI)
+```
+
+After generating, the imported patterns appear in the Site Editor's inserter
+under an **InDesign Imports** category, one per spread.
+
+### Frame → block mapping
+
+- **Text frames** → `core/heading` / `core/paragraph`, grouped in `core/group`.
+  The paragraph-style name picks the role: `Heading N` → heading level N;
+  `Body`/`Caption`/etc. → paragraph. Typography and color come from the mapped
+  **design tokens** (preset slugs), never inline values.
+- **Image frames** → `core/image`, or `core/cover` when text overlays the image.
+- **Side-by-side frames** → `core/columns`.
+- **Master-spread chrome** → `parts/header.html` / `parts/footer.html`.
+
+## 4. Fidelity expectations
+
+| Aspect | IDML | PDF |
+| --- | --- | --- |
+| Text content | Exact (from stories) | Reconstructed from glyph runs |
+| Paragraph styles | Exact | Synthesized from font sizes |
+| Colors | Exact swatches (CMYK/LAB → sRGB) | Sampled per run |
+| Frame geometry | Exact | Reconstructed (clustering) |
+| Vector art | Not imported | Dropped (warned) |
+| Images | Referenced; staged via `--asset-dir` | Extracted to an asset cache |
+
+Two conversions are inherent regardless of source:
+
+- **CMYK/LAB → sRGB.** Print color doesn't map 1:1 to screen. Out-of-gamut
+  swatches are clamped and flagged in the report; confirm brand colors with the
+  designer.
+- **Fonts.** Non-web fonts fall back via `packages/pipeline/config/font-map.json`
+  (often a Google font). Every fallback is listed in the report.
+
+## 5. Troubleshooting
+
+| Symptom | Cause / fix |
+| --- | --- |
+| `theme.json valid: false` | The report's `tokens.validationErrors` lists the schema errors. Usually a malformed `--base` theme; re-run against the default. |
+| Colors look washed out / shifted | CMYK→sRGB conversion. Convert source images to sRGB and confirm swatches against the report's out-of-gamut list. |
+| Missing or wrong fonts | A font fell back. Check the report's font-fallback list; self-host the real font and update the font map, or accept the substitution. |
+| Images don't appear | Bytes weren't staged. Drop files into `themes/<slug>/assets/` (names are in the report) and run `bin/import-media.sh`, or re-run with `--asset-dir`. |
+| Huge / slow pages | Oversized print images (300 DPI, CMYK). Resize and recompress for web before importing. |
+| PDF output looks rough | PDF is a lossy fallback — re-export an `.idml` if at all possible. |
+| Frames missing from a pattern | Listed under **Unmapped IR nodes** in the report (e.g. a text frame with no story). Add content manually or fix the source document. |
+
+## Smoke test
+
+An end-to-end smoke test builds a fixture document in code, runs the real CLI,
+and asserts the theme is valid:
+
+```bash
+node scripts/indesign-fse/smoke-test.mjs
+```
+
+It runs in CI on any change to the pipeline package or its scripts.
+
+## See also
+
+- [Output generator internals](../pipeline/indesign-output-generator.md)
+- [Token mapper internals](../pipeline/indesign-token-mapper.md)
+- [PDF fidelity](../pipeline/indesign-pdf-fidelity.md)
+- Agent: `.claude/agents/indesign-to-wordpress.md`
+- Skill: `.claude/skills/indesign-conversion/SKILL.md`

--- a/flavian.config.example.json
+++ b/flavian.config.example.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema#",
+  "pipeline": {
+    "indesign": {
+      "output": "themes",
+      "baseTheme": "themes/flavian-shop/theme.json",
+      "namespace": "id",
+      "seedContent": false
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -17,7 +17,11 @@
   },
   "packageManager": "pnpm@9.15.0",
   "type": "module",
+  "bin": {
+    "flavian": "./bin/flavian.mjs"
+  },
   "scripts": {
+    "flavian": "node bin/flavian.mjs",
     "init": "node scripts/init.mjs",
     "test:init": "node --test \"tests/init/**/*.test.mjs\"",
     "test:pipeline": "pnpm --filter @flavian/pipeline test",

--- a/packages/pipeline/src/indesign/generate/index.js
+++ b/packages/pipeline/src/indesign/generate/index.js
@@ -20,6 +20,7 @@ import { buildStyleCss, buildFunctionsPhp } from './theme-files.js';
 import { buildGenerationReport } from './report.js';
 
 const REPORT_FILE = 'indesign-pipeline-report.md';
+const REPORT_JSON_FILE = 'indesign-pipeline-report.json';
 
 function indexBy(items, key) {
 	const map = new Map();
@@ -108,10 +109,13 @@ export function generateTheme(ir, options = {}) {
 		files.push({ path: 'bin/seed-content.sh', contents: buildSeedScript(patternMeta), mode: '755' });
 	}
 
+	// The artifact list both reports enumerate (includes the reports themselves).
+	const artifactPaths = [...files.map((f) => f.path), REPORT_FILE, REPORT_JSON_FILE];
+
 	const reportMarkdown = buildGenerationReport({
 		themeName: name,
 		themeSlug: slug,
-		files: [...files.map((f) => f.path), REPORT_FILE],
+		files: artifactPaths,
 		assets,
 		unmapped: ctx.unmapped,
 		tokensReport: tokens.report,
@@ -119,7 +123,28 @@ export function generateTheme(ir, options = {}) {
 		spreadCount: spreads.length,
 		assetsStaged: false,
 	});
+
+	// Machine-readable counterpart to the Markdown report.
+	const reportData = {
+		theme: { slug, name, package: pkg },
+		valid: tokens.report?.valid ?? true,
+		spreadCount: spreads.length,
+		files: artifactPaths,
+		patterns: patternMeta,
+		assets,
+		unmapped: ctx.unmapped,
+		derivedFromMaster: parts.derivedFromMaster,
+		tokens: {
+			counts: tokens.report?.counts ?? {},
+			fontFallbacks: tokens.report?.fontFallbacks ?? [],
+			googleFonts: tokens.report?.googleFonts ?? [],
+			outOfGamut: tokens.report?.outOfGamut ?? [],
+			validationErrors: tokens.report?.validationErrors ?? [],
+		},
+	};
+
 	files.push({ path: REPORT_FILE, contents: `${reportMarkdown}\n` });
+	files.push({ path: REPORT_JSON_FILE, contents: `${JSON.stringify(reportData, null, 2)}\n` });
 
 	return {
 		slug,
@@ -129,14 +154,6 @@ export function generateTheme(ir, options = {}) {
 		assets,
 		themeJson: tokens.merged,
 		tokens,
-		report: {
-			markdown: reportMarkdown,
-			data: {
-				unmapped: ctx.unmapped,
-				patterns: patternMeta,
-				assets,
-				valid: tokens.report?.valid ?? true,
-			},
-		},
+		report: { markdown: reportMarkdown, data: reportData },
 	};
 }

--- a/packages/pipeline/tests/indesign/generate.test.mjs
+++ b/packages/pipeline/tests/indesign/generate.test.mjs
@@ -189,6 +189,23 @@ test('report enumerates produced files and unmapped IR nodes', () => {
 	assert.ok(result.report.data.unmapped.some((u) => u.id === 'orphan'));
 });
 
+test('emits a machine-readable JSON report alongside the Markdown one', () => {
+	const ir = parseIdmlBuffer(buildCatalog());
+	const result = generateTheme(ir);
+
+	const json = file(result, 'indesign-pipeline-report.json');
+	assert.ok(json, 'missing indesign-pipeline-report.json');
+	const data = JSON.parse(json.contents);
+
+	assert.equal(data.theme.slug, 'catalog');
+	assert.equal(data.valid, true);
+	assert.equal(data.spreadCount, ir.spreads.length);
+	assert.equal(data.patterns.length, ir.spreads.length);
+	assert.ok(Array.isArray(data.files) && data.files.includes('theme.json'));
+	assert.ok(data.files.includes('indesign-pipeline-report.json'));
+	assert.ok(data.tokens && data.tokens.counts);
+});
+
 test('output is deterministic across runs', () => {
 	const ir = parseIdmlBuffer(buildCatalog());
 	const a = generateTheme(ir);

--- a/scripts/indesign-fse/smoke-test.mjs
+++ b/scripts/indesign-fse/smoke-test.mjs
@@ -1,0 +1,115 @@
+#!/usr/bin/env node
+// End-to-end smoke test for the InDesign pipeline.
+//
+// Mirrors what the indesign-to-wordpress agent does: build a fixture document,
+// run it through the real `flavian pipeline indesign` CLI, and assert the
+// generated theme is valid. Fixtures are code (not committed binaries), so this
+// builds a representative two-spread brochure .idml in a temp dir first.
+//
+//   node scripts/indesign-fse/smoke-test.mjs
+//
+// Exits 0 on success, non-zero with a diagnostic on any failure. Used by the
+// Pipeline Tests CI workflow and runnable locally.
+
+import { spawnSync } from 'node:child_process';
+import { promises as fs } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { buildIdml } from '../../packages/pipeline/tests/indesign/helpers/build-idml.js';
+
+const ROOT = path.resolve(fileURLToPath(new URL('../../', import.meta.url)));
+
+function fail(msg) {
+	process.stderr.write(`✗ smoke: ${msg}\n`);
+	process.exit(1);
+}
+
+/** A representative two-spread brochure: text-heavy spread + image-heavy spread. */
+function brochureIdml() {
+	return buildIdml({
+		name: 'Smoke Brochure',
+		colors: [
+			{ id: 'col-brand', name: 'Brand Blue', space: 'RGB', values: [0, 102, 204] },
+			{ id: 'col-ink', name: 'Ink', space: 'CMYK', values: [0, 0, 0, 100] },
+		],
+		fonts: [{ id: 'f-helv', family: 'Helvetica', style: 'Bold', postScriptName: 'Helvetica-Bold' }],
+		styles: [
+			{ id: 'p-h1', name: 'Heading 1', kind: 'paragraph', pointSize: 36, leading: 40, appliedFont: 'f-helv', fillColor: 'col-brand' },
+			{ id: 'p-body', name: 'Body', kind: 'paragraph', pointSize: 12, leading: 18, fillColor: 'col-ink' },
+		],
+		stories: [
+			{ id: 's-title', runs: [{ text: 'Welcome', paragraphStyle: 'p-h1' }] },
+			{ id: 's-body', runs: [{ text: 'Body copy that introduces the brochure.', paragraphStyle: 'p-body' }] },
+			{ id: 's-hero', runs: [{ text: 'On Sale Now', paragraphStyle: 'p-h1' }] },
+		],
+		spreads: [
+			{
+				id: 'spread-1',
+				pages: [{ id: 'page-1', bounds: [0, 0, 792, 612] }],
+				frames: [
+					{ kind: 'text', id: 'tf-title', bounds: [60, 60, 140, 540], parentStory: 's-title' },
+					{ kind: 'text', id: 'tf-body', bounds: [160, 60, 420, 540], parentStory: 's-body' },
+				],
+			},
+			{
+				id: 'spread-2',
+				pages: [{ id: 'page-2', bounds: [0, 0, 792, 612] }],
+				frames: [
+					{ kind: 'image', id: 'if-hero', bounds: [0, 0, 612, 792], href: 'file:Links/hero.png' },
+					{ kind: 'text', id: 'if-overlay', bounds: [200, 100, 320, 500], parentStory: 's-hero' },
+				],
+			},
+		],
+	});
+}
+
+async function main() {
+	const work = await fs.mkdtemp(path.join(os.tmpdir(), 'flavian-indesign-smoke-'));
+	const idmlPath = path.join(work, 'brochure.idml');
+	const themeDir = path.join(work, 'theme');
+
+	try {
+		await fs.writeFile(idmlPath, brochureIdml());
+
+		// Run the real CLI exactly as a developer (or the agent) would.
+		const run = spawnSync(
+			process.execPath,
+			[path.join(ROOT, 'bin/flavian.mjs'), 'pipeline', 'indesign', idmlPath, '--output', themeDir, '--quiet'],
+			{ cwd: ROOT, encoding: 'utf8' },
+		);
+
+		if (run.status !== 0) {
+			fail(`CLI exited ${run.status}\n${run.stderr || run.stdout}`);
+		}
+
+		// The generated theme must carry the files a block theme needs to load.
+		for (const rel of ['style.css', 'functions.php', 'theme.json', 'templates/index.html', 'parts/header.html', 'parts/footer.html', 'indesign-pipeline-report.md', 'indesign-pipeline-report.json']) {
+			try {
+				await fs.access(path.join(themeDir, rel));
+			} catch {
+				fail(`missing generated file: ${rel}`);
+			}
+		}
+
+		// theme.json must parse and be version 3.
+		const themeJson = JSON.parse(await fs.readFile(path.join(themeDir, 'theme.json'), 'utf8'));
+		if (themeJson.version !== 3) fail(`theme.json version is ${themeJson.version}, expected 3`);
+
+		// The machine-readable report must mark the theme valid with one pattern per spread.
+		const report = JSON.parse(await fs.readFile(path.join(themeDir, 'indesign-pipeline-report.json'), 'utf8'));
+		if (report.valid !== true) fail(`report.valid is ${report.valid}\n${JSON.stringify(report.tokens?.validationErrors ?? [], null, 2)}`);
+		if (report.patterns.length !== 2) fail(`expected 2 patterns, got ${report.patterns.length}`);
+
+		// At least one pattern is filed under the InDesign Imports category.
+		const pattern = await fs.readFile(path.join(themeDir, 'patterns', 'spread-1.php'), 'utf8');
+		if (!/Categories:\s*indesign-imports/.test(pattern)) fail('pattern is not in the indesign-imports category');
+
+		process.stdout.write('✓ smoke: InDesign pipeline generated a valid theme (2 spreads, theme.json v3)\n');
+	} finally {
+		await fs.rm(work, { recursive: true, force: true });
+	}
+}
+
+main().catch((err) => fail(err.stack || err.message));

--- a/scripts/indesign-fse/validate-theme-location.sh
+++ b/scripts/indesign-fse/validate-theme-location.sh
@@ -1,0 +1,92 @@
+#!/bin/bash
+#
+# validate-theme-location.sh (indesign-fse)
+# PreToolUse hook: Validates theme files are created in themes/ NOT wp-content/themes/
+#
+# This hook is triggered BEFORE Write/Edit operations to prevent incorrect file paths
+#
+# Usage: Called automatically by Claude Code hooks
+# Input: Reads CLAUDE_TOOL_INPUT environment variable containing tool parameters
+# Exit codes:
+#   0 - Path is valid (themes/ at root level)
+#   1 - Path is INVALID (wp-content/themes/ detected - BLOCKS operation)
+#
+
+set -e
+
+PROJECT_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
+
+# Parse tool input from environment variable
+# Expected format: JSON with file_path parameter
+TOOL_INPUT="${CLAUDE_TOOL_INPUT:-}"
+
+if [ -z "$TOOL_INPUT" ]; then
+    # No tool input provided - allow operation (not a file operation)
+    exit 0
+fi
+
+# Extract file_path from tool input (handles Write, Edit, etc.)
+# Try multiple JSON keys: file_path, path, files
+FILE_PATH=$(echo "$TOOL_INPUT" | grep -oP '"file_path"\s*:\s*"\K[^"]+' 2>/dev/null || true)
+
+if [ -z "$FILE_PATH" ]; then
+    # Try alternate key: path
+    FILE_PATH=$(echo "$TOOL_INPUT" | grep -oP '"path"\s*:\s*"\K[^"]+' 2>/dev/null || true)
+fi
+
+if [ -z "$FILE_PATH" ]; then
+    # No file path found - allow operation (not a file write/edit)
+    exit 0
+fi
+
+# Normalize path to relative path from project root
+# Handle both absolute and relative paths
+if [[ "$FILE_PATH" == /* ]]; then
+    # Absolute path - make relative to PROJECT_ROOT
+    FILE_PATH="${FILE_PATH#$PROJECT_ROOT/}"
+fi
+
+# Check if path contains wp-content/themes/, wp-content/plugins/, or wp-content/mu-plugins/
+if [[ "$FILE_PATH" =~ wp-content/(themes|plugins|mu-plugins)/ ]]; then
+    echo "❌ ERROR: Invalid file location detected" >&2
+    echo "" >&2
+    echo "File path: $FILE_PATH" >&2
+    echo "" >&2
+    echo "⚠️  This project uses ROOT-LEVEL folders for development:" >&2
+    echo "" >&2
+    echo "  ✓ CORRECT:   themes/[theme-name]/..." >&2
+    echo "  ✓ CORRECT:   plugins/[plugin-name]/..." >&2
+    echo "  ✓ CORRECT:   mu-plugins/[plugin-name]/..." >&2
+    echo "" >&2
+    echo "  ✗ WRONG:     wp-content/themes/[theme-name]/..." >&2
+    echo "  ✗ WRONG:     wp-content/plugins/[plugin-name]/..." >&2
+    echo "  ✗ WRONG:     wp-content/mu-plugins/[plugin-name]/..." >&2
+    echo "" >&2
+    echo "Why?" >&2
+    echo "  - Cleaner development structure" >&2
+    echo "  - Easier version control" >&2
+    echo "  - Separation between development and testing environments" >&2
+    echo "" >&2
+    echo "Deployment:" >&2
+    echo "  - Development: Create files in root-level folders (themes/, plugins/, mu-plugins/)" >&2
+    echo "  - Testing: Copy files to WordPress wp-content/ (manual step)" >&2
+    echo "" >&2
+    echo "Fix suggestion:" >&2
+    if [[ "$FILE_PATH" =~ wp-content/themes/ ]]; then
+        CORRECTED_PATH="${FILE_PATH/wp-content\/themes\//themes/}"
+        echo "  Use: $CORRECTED_PATH" >&2
+    elif [[ "$FILE_PATH" =~ wp-content/plugins/ ]]; then
+        CORRECTED_PATH="${FILE_PATH/wp-content\/plugins\//plugins/}"
+        echo "  Use: $CORRECTED_PATH" >&2
+    elif [[ "$FILE_PATH" =~ wp-content/mu-plugins/ ]]; then
+        CORRECTED_PATH="${FILE_PATH/wp-content\/mu-plugins\//mu-plugins/}"
+        echo "  Use: $CORRECTED_PATH" >&2
+    fi
+    echo "" >&2
+    echo "See: CLAUDE.md for complete file structure documentation" >&2
+    echo "" >&2
+    exit 1
+fi
+
+# Path is valid - allow operation
+exit 0


### PR DESCRIPTION
Sub-issue of #61 — the **closes** candidate for the epic. Ships the user-facing surface that turns the underlying InDesign pipeline (#62–#65) into something developers actually use.

## What's included

### Agent — `.claude/agents/indesign-to-wordpress.md`
Orchestrates parse → map-tokens → generate, then **reads the generation report and proposes concrete follow-ups** (unmapped frames, font fallbacks to confirm, image alt text to add). Non-destructive: works on a feature branch, never `main`. PreToolUse theme-location guard + PostToolUse validators (block markup, token audit, security, WPCS). Referenced from `CUSTOM-AGENTS-GUIDE.md`.

### Skill — `.claude/skills/indesign-conversion/SKILL.md`
When-to-use, prerequisites (exported `.idml` or PDF), expected outputs, common gotchas (CMYK→sRGB shifts, missing fonts, oversized print images), and a **runnable worked example** against the committed code fixture. Referenced from `skills/README.md`.

### CLI — `bin/flavian.mjs`
```
flavian pipeline indesign <input> [--seed-content] [--output <dir>]
```
- Honors `flavian.config.json` (output path, base theme, namespace; CLI flags override) — see `flavian.config.example.json`
- Emits a **machine-readable `indesign-pipeline-report.json`** alongside the Markdown report
- `flavian pipeline indesign --help` prints documented usage
- Registered as the `flavian` bin + `pnpm flavian` script

### Documentation
- `docs/pipelines/indesign.md` — exporting from InDesign (IDML & PDF), expected output, fidelity expectations, troubleshooting
- README **Pipelines** section now lists InDesign alongside Figma and Canva
- Agent/skill indexes and counts updated; v2.0.0 release-notes draft updated

### CI smoke test
`scripts/indesign-fse/smoke-test.mjs` builds a two-spread brochure fixture **in code** (no committed binaries), runs the **real CLI** end-to-end, and asserts the generated theme is valid (theme.json v3, one pattern per spread, `indesign-imports` category). Wired into `pipeline-tests.yml`.

## Acceptance criteria

- [x] `indesign-to-wordpress` agent exists, follows the Flavian agent shape, referenced from the agents index
- [x] `indesign-conversion` SKILL.md exists with a runnable example
- [x] `flavian pipeline indesign --help` prints documented usage
- [x] `docs/pipelines/indesign.md` published and linked from the README
- [x] README's Pipelines section lists InDesign
- [x] End-to-end smoke test in CI runs the pipeline against the committed fixture and asserts the theme is valid

## Tests

- `pnpm --filter @flavian/pipeline test` → **100 passing** (adds a JSON-report test)
- `node scripts/indesign-fse/smoke-test.mjs` → ✓ valid theme (2 spreads, theme.json v3)
- Agent/skill config validation passes

## Notes
- Builds on #65 (now merged to `main`).
- Counts in `CLAUDE.md` / `CUSTOM-AGENTS-GUIDE.md` reconciled to the actual totals (53 agents, 12 skills).
- When this ships, the InDesign epic #61 can be closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)