### PR TITLE
test(pipeline): commit InDesign sample fixtures exercised in CI — closes epic #61

### DIFF
--- a/.github/workflows/pipeline-tests.yml
+++ b/.github/workflows/pipeline-tests.yml
@@ -27,6 +27,7 @@ jobs:
               - 'pnpm-workspace.yaml'
               - 'bin/flavian.mjs'
               - 'scripts/indesign-fse/**'
+              - 'tests/fixtures/indesign/**'
 
   test:
     needs: check-paths
@@ -80,6 +81,9 @@ jobs:
 
       - name: Run InDesign end-to-end smoke test
         run: node scripts/indesign-fse/smoke-test.mjs
+
+      - name: Run InDesign fixture tests (.idml + PDF → FSE theme)
+        run: node --test tests/fixtures/indesign/fixtures.test.mjs
 
   test-status:
     runs-on: ubuntu-latest

--- a/docs/pipelines/indesign.md
+++ b/docs/pipelines/indesign.md
@@ -149,16 +149,28 @@ Two conversions are inherent regardless of source:
 | PDF output looks rough | PDF is a lossy fallback — re-export an `.idml` if at all possible. |
 | Frames missing from a pattern | Listed under **Unmapped IR nodes** in the report (e.g. a text frame with no story). Add content manually or fix the source document. |
 
-## Smoke test
+## Sample fixtures
 
-An end-to-end smoke test builds a fixture document in code, runs the real CLI,
-and asserts the theme is valid:
+The canonical sample document — a two-spread **Spring Brochure** — lives under
+[`tests/fixtures/indesign/`](../../tests/fixtures/indesign/) as code (no
+committed binaries). Materialize it to real files to try the pipeline:
 
 ```bash
-node scripts/indesign-fse/smoke-test.mjs
+node tests/fixtures/indesign/emit.mjs /tmp/fix
+flavian pipeline indesign /tmp/fix/brochure.idml --output themes/brochure
+flavian pipeline indesign /tmp/fix/brochure.pdf  --output themes/brochure-pdf
 ```
 
-It runs in CI on any change to the pipeline package or its scripts.
+## Smoke & fixture tests
+
+End-to-end tests build the fixtures in code, run them through the full pipeline,
+and assert a valid theme — for both the `.idml` (primary) and PDF (fallback)
+paths. Both run in CI on any change to the pipeline package or its scripts.
+
+```bash
+node scripts/indesign-fse/smoke-test.mjs                # real CLI, IDML path
+node --test tests/fixtures/indesign/fixtures.test.mjs   # IDML + PDF → theme
+```
 
 ## See also
 

--- a/tests/fixtures/indesign/README.md
+++ b/tests/fixtures/indesign/README.md
@@ -1,0 +1,53 @@
+# InDesign pipeline fixtures
+
+The canonical sample document for the [InDesign → WordPress pipeline](../../../docs/pipelines/indesign.md),
+the **Spring Brochure**: a two-spread layout with a text-heavy cover (headline +
+body) and an image-heavy spread (a full-bleed hero with an overlaid headline),
+plus master-spread footer chrome.
+
+## Fixtures are code, not blobs
+
+There are no binary `.idml` / `.pdf` files committed here. The brochure is
+defined once as a readable spec in [`brochure.mjs`](brochure.mjs) and
+materialized into both input formats on demand:
+
+- `buildBrochureIdml()` → the primary, high-fidelity IDML package (stories,
+  frames, paragraph styles, swatches, a master spread).
+- `buildBrochurePdf()` → the same logical brochure exported as a PDF (the lossy
+  fallback path).
+
+This keeps the repo free of opaque binaries, makes the fixture diffable, and
+lets the IDML and PDF stay in sync because they derive from one description.
+
+## Files
+
+| File | Purpose |
+| --- | --- |
+| `brochure.mjs` | The canonical fixture spec + `buildBrochureIdml()` / `buildBrochurePdf()`. |
+| `emit.mjs` | CLI: writes `brochure.idml` and `brochure.pdf` to disk. |
+| `fixtures.test.mjs` | End-to-end test: both formats → a valid FSE theme (run in CI). |
+
+## Materialize the files
+
+To get real files to run the pipeline against:
+
+```bash
+node tests/fixtures/indesign/emit.mjs /tmp/fix
+flavian pipeline indesign /tmp/fix/brochure.idml --output themes/brochure
+flavian pipeline indesign /tmp/fix/brochure.pdf  --output themes/brochure-pdf
+```
+
+The emitted bytes are deterministic — re-running overwrites with identical
+content.
+
+## Tests
+
+`fixtures.test.mjs` runs the full pipeline (parse → map tokens → generate) for
+both the IDML and PDF fixtures and asserts each yields a schema-valid
+`theme.json`, one block pattern per spread under the **InDesign Imports**
+category, and a populated palette/typography scale. It runs in CI via the
+**Pipeline Tests** workflow:
+
+```bash
+node --test "tests/fixtures/indesign/**/*.test.mjs"
+```

--- a/tests/fixtures/indesign/brochure.mjs
+++ b/tests/fixtures/indesign/brochure.mjs
@@ -1,0 +1,122 @@
+// Canonical "Spring Brochure" InDesign fixture — defined as code, not committed
+// as a binary blob (the pipeline's standing convention: fixtures are readable
+// specs, materialized on demand).
+//
+// The same logical two-spread brochure is expressed in both input formats so the
+// end-to-end tests can exercise the primary path (IDML) and the lossy fallback
+// (PDF) against one design:
+//
+//   Spread 1 (text-heavy cover): a "Welcome" headline + a body paragraph.
+//   Spread 2 (image-heavy):      a full-bleed hero image with an "On Sale Now"
+//                                headline overlaid on it.
+//
+// `emit.mjs` writes these to disk (brochure.idml / brochure.pdf) for manual runs
+// of `flavian pipeline indesign …`; `fixtures.test.mjs` runs them through the
+// whole pipeline in CI.
+
+import { buildIdml } from '../../../packages/pipeline/tests/indesign/helpers/build-idml.js';
+import { buildPdf } from '../../../packages/pipeline/tests/indesign/helpers/build-pdf.js';
+
+export const BROCHURE_NAME = 'Spring Brochure';
+
+/** A solid-color raw-RGB image (width×height×3 bytes) for the PDF hero. */
+function solidRgb(width, height, [r, g, b]) {
+	const data = new Uint8Array(width * height * 3);
+	for (let i = 0; i < width * height; i += 1) {
+		data[i * 3] = r;
+		data[i * 3 + 1] = g;
+		data[i * 3 + 2] = b;
+	}
+	return { width, height, data };
+}
+
+/**
+ * The primary, high-fidelity path: a full IDML package with stories, frames,
+ * paragraph styles, swatches, and a master spread.
+ * @returns {Uint8Array}
+ */
+export function buildBrochureIdml() {
+	return buildIdml({
+		name: BROCHURE_NAME,
+		colors: [
+			{ id: 'col-brand', name: 'Brand Blue', space: 'RGB', values: [0, 102, 204] },
+			{ id: 'col-ink', name: 'Ink', space: 'CMYK', values: [0, 0, 0, 100] },
+		],
+		fonts: [
+			{ id: 'f-helv', family: 'Helvetica', style: 'Bold', postScriptName: 'Helvetica-Bold' },
+			{ id: 'f-helv-reg', family: 'Helvetica', style: 'Regular', postScriptName: 'Helvetica' },
+		],
+		styles: [
+			{ id: 'p-h1', name: 'Heading 1', kind: 'paragraph', pointSize: 36, leading: 40, appliedFont: 'f-helv', fillColor: 'col-brand' },
+			{ id: 'p-body', name: 'Body', kind: 'paragraph', pointSize: 12, leading: 18, appliedFont: 'f-helv-reg', fillColor: 'col-ink' },
+			{ id: 'p-foot', name: 'Footer', kind: 'paragraph', pointSize: 9, leading: 12, appliedFont: 'f-helv-reg', fillColor: 'col-ink' },
+		],
+		stories: [
+			{ id: 's-title', runs: [{ text: 'Welcome', paragraphStyle: 'p-h1' }] },
+			{ id: 's-body', runs: [{ text: 'Carefully sourced, honestly priced. Browse our spring collection.', paragraphStyle: 'p-body' }] },
+			{ id: 's-hero', runs: [{ text: 'On Sale Now', paragraphStyle: 'p-h1' }] },
+			{ id: 's-foot', runs: [{ text: 'Spring Brochure', paragraphStyle: 'p-foot' }] },
+		],
+		masters: [
+			{
+				id: 'master-a',
+				name: 'A-Master',
+				pages: [{ id: 'mp-1', bounds: [0, 0, 792, 612] }],
+				frames: [{ kind: 'text', id: 'mf-foot', bounds: [760, 60, 786, 540], parentStory: 's-foot' }],
+			},
+		],
+		spreads: [
+			{
+				id: 'spread-cover',
+				appliedMaster: 'master-a',
+				pages: [{ id: 'page-1', bounds: [0, 0, 792, 612] }],
+				frames: [
+					{ kind: 'text', id: 'tf-title', bounds: [60, 60, 150, 540], parentStory: 's-title' },
+					{ kind: 'text', id: 'tf-body', bounds: [170, 60, 320, 540], parentStory: 's-body' },
+				],
+			},
+			{
+				id: 'spread-hero',
+				appliedMaster: 'master-a',
+				pages: [{ id: 'page-2', bounds: [0, 0, 792, 612] }],
+				frames: [
+					{ kind: 'image', id: 'if-hero', bounds: [0, 0, 612, 792], href: 'file:Links/hero.png' },
+					{ kind: 'text', id: 'if-overlay', bounds: [240, 100, 330, 500], parentStory: 's-hero' },
+				],
+			},
+		],
+	});
+}
+
+/**
+ * The lossy fallback path: the same logical brochure exported as a PDF. Text is
+ * positioned in base-14 fonts; the hero is a placed RGB image. The parser
+ * reconstructs spreads/frames/styles from this and emits fidelity warnings.
+ * @returns {Uint8Array}
+ */
+export function buildBrochurePdf() {
+	const toUnit = ([r, g, b]) => [r / 255, g / 255, b / 255];
+	return buildPdf({
+		title: BROCHURE_NAME,
+		pages: [
+			{
+				width: 612,
+				height: 792,
+				texts: [
+					{ text: 'Welcome', x: 60, y: 96, size: 36, font: 'Helvetica-Bold', color: toUnit([0, 102, 204]) },
+					{ text: 'Carefully sourced, honestly priced. Browse our spring collection.', x: 60, y: 150, size: 12, font: 'Helvetica', color: toUnit([0, 0, 0]) },
+				],
+			},
+			{
+				width: 612,
+				height: 792,
+				images: [
+					{ x: 0, y: 0, width: 612, height: 792, rgb: solidRgb(16, 16, [0, 102, 204]) },
+				],
+				texts: [
+					{ text: 'On Sale Now', x: 80, y: 420, size: 36, font: 'Helvetica-Bold', color: toUnit([255, 255, 255]) },
+				],
+			},
+		],
+	});
+}

--- a/tests/fixtures/indesign/emit.mjs
+++ b/tests/fixtures/indesign/emit.mjs
@@ -1,0 +1,29 @@
+#!/usr/bin/env node
+// Materialize the canonical InDesign fixtures to disk:
+//
+//   node tests/fixtures/indesign/emit.mjs [out-dir]
+//
+// Writes brochure.idml and brochure.pdf (defaults to this directory). Handy for
+// running the pipeline against a real file, e.g.:
+//
+//   node tests/fixtures/indesign/emit.mjs /tmp/fix
+//   flavian pipeline indesign /tmp/fix/brochure.idml --output themes/brochure
+//
+// The bytes are deterministic — re-emitting overwrites with identical content.
+
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { buildBrochureIdml, buildBrochurePdf } from './brochure.mjs';
+
+const outDir = process.argv[2] ? path.resolve(process.argv[2]) : path.dirname(fileURLToPath(import.meta.url));
+
+await fs.mkdir(outDir, { recursive: true });
+const idmlPath = path.join(outDir, 'brochure.idml');
+const pdfPath = path.join(outDir, 'brochure.pdf');
+
+await fs.writeFile(idmlPath, buildBrochureIdml());
+await fs.writeFile(pdfPath, buildBrochurePdf());
+
+process.stdout.write(`wrote ${path.relative(process.cwd(), idmlPath)}\nwrote ${path.relative(process.cwd(), pdfPath)}\n`);

--- a/tests/fixtures/indesign/fixtures.test.mjs
+++ b/tests/fixtures/indesign/fixtures.test.mjs
@@ -1,0 +1,66 @@
+// End-to-end: the canonical Spring Brochure fixture runs through the full
+// InDesign pipeline (parse → map tokens → generate) for BOTH input formats and
+// produces a working FSE theme. This is the epic-level acceptance check (#61):
+// a representative .idml and a representative exported PDF both yield a valid
+// theme with at least one block pattern per spread and a populated theme.json.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { parseIdmlBuffer } from '../../../packages/pipeline/src/indesign/parse-idml.js';
+import { parsePdfBuffer } from '../../../packages/pipeline/src/indesign/parse-pdf.js';
+import { generateTheme } from '../../../packages/pipeline/src/indesign/generate/index.js';
+import { buildBrochureIdml, buildBrochurePdf, BROCHURE_NAME } from './brochure.mjs';
+
+/** Assert a generated theme is valid, has a pattern per spread, and real tokens. */
+function assertWorkingTheme(result, ir) {
+	assert.equal(result.report.data.valid, true, JSON.stringify(result.tokens.report.validationErrors));
+
+	const patterns = result.files.filter((f) => /^patterns\/spread-\d+\.php$/.test(f.path));
+	assert.ok(ir.spreads.length >= 1, 'fixture should have at least one spread');
+	assert.equal(patterns.length, ir.spreads.length, 'one pattern per spread');
+	for (const p of patterns) assert.match(p.contents, /Categories: indesign-imports/);
+
+	// theme.json is populated with a palette and a typography scale.
+	const themeJson = JSON.parse(result.files.find((f) => f.path === 'theme.json').contents);
+	assert.equal(themeJson.version, 3);
+	assert.ok(themeJson.settings.color.palette.length > 0, 'theme.json has colors');
+	assert.ok((themeJson.settings.typography.fontSizes ?? []).length > 0, 'theme.json has font sizes');
+
+	// Both reports are emitted.
+	assert.ok(result.files.some((f) => f.path === 'indesign-pipeline-report.md'));
+	assert.ok(result.files.some((f) => f.path === 'indesign-pipeline-report.json'));
+}
+
+test('IDML fixture → valid FSE theme (primary path)', () => {
+	const ir = parseIdmlBuffer(buildBrochureIdml());
+	assert.equal(ir.meta.name, BROCHURE_NAME);
+	assert.equal(ir.spreads.length, 2);
+
+	const result = generateTheme(ir);
+	assertWorkingTheme(result, ir);
+
+	// Master-spread chrome produced a header or footer from the document.
+	assert.equal(result.report.data.derivedFromMaster, true);
+});
+
+test('PDF fixture → valid FSE theme (fallback path, with fidelity warnings)', async () => {
+	const ir = await parsePdfBuffer(buildBrochurePdf());
+	assert.ok(ir.spreads.length >= 1);
+
+	const result = generateTheme(ir);
+	assertWorkingTheme(result, ir);
+
+	// A PDF parse is lossy by definition — it always carries fidelity warnings.
+	assert.ok((ir.warnings ?? []).length > 0, 'PDF parse should record fidelity warnings');
+});
+
+test('both input formats import the same brochure (source-agnostic)', async () => {
+	const fromIdml = generateTheme(parseIdmlBuffer(buildBrochureIdml()));
+	const fromPdf = generateTheme(await parsePdfBuffer(buildBrochurePdf()));
+
+	// Same logical document → same spread/pattern count from either source.
+	const patterns = (r) => r.files.filter((f) => /^patterns\/spread-\d+\.php$/.test(f.path)).length;
+	assert.equal(patterns(fromIdml), patterns(fromPdf));
+	assert.equal(patterns(fromIdml), 2);
+});


### PR DESCRIPTION
Closes the InDesign-to-WordPress epic (#61). All sub-issues (#62–#66) are already merged to `main`; this PR resolves the **one remaining epic acceptance criterion**:

> Sample fixtures (.idml and exported PDF) are committed under `tests/fixtures/indesign/` and exercised in CI.

## Approach — fixtures as code, not blobs

Per the pipeline's standing convention (and the parser/smoke tests), the canonical sample document — a two-spread **Spring Brochure** (text-heavy cover + image-heavy hero with master-spread footer chrome) — is a readable spec materialized into **both** input formats on demand, rather than committed binaries:

| File | Purpose |
|---|---|
| `tests/fixtures/indesign/brochure.mjs` | The spec + `buildBrochureIdml()` / `buildBrochurePdf()` |
| `tests/fixtures/indesign/emit.mjs` | CLI: writes `brochure.idml` + `brochure.pdf` to disk |
| `tests/fixtures/indesign/fixtures.test.mjs` | End-to-end test (runs in CI) |
| `tests/fixtures/indesign/README.md` | Documents the fixtures + no-blobs rationale |

## What's exercised in CI

`fixtures.test.mjs` runs the **full pipeline** (parse → map tokens → generate) for both formats and asserts each yields:
- a schema-valid `theme.json` (version 3, populated palette + typography scale)
- one block pattern per spread under the **InDesign Imports** category
- both report files (`.md` + `.json`)

Plus a source-agnostic check that the `.idml` and PDF import the **same** logical brochure (same spread/pattern count). Wired into `pipeline-tests.yml` (`test-indesign-pkg` job) with `tests/fixtures/indesign/**` added to the path filter.

## Verification

```
pnpm --filter @flavian/pipeline test          → 100 passing
node --test tests/fixtures/indesign/fixtures.test.mjs → 3 passing (IDML + PDF + equivalence)
node scripts/indesign-fse/smoke-test.mjs      → ✓ valid theme
```

Also verified the emitted files run through the real CLI end-to-end:
`node tests/fixtures/indesign/emit.mjs` → `flavian pipeline indesign brochure.idml` / `brochure.pdf` → valid themes.

## Epic acceptance criteria — all met

- [x] `.idml` → working FSE theme (≥1 pattern/spread + theme.json)
- [x] PDF → equivalent output with documented fidelity caveats
- [x] Patterns render in the Site Editor on the happy path
- [x] `indesign-to-wordpress` agent in README + `.claude/agents/`
- [x] `flavian pipeline indesign <input>` documented in `docs/`
- [x] **Sample fixtures committed under `tests/fixtures/indesign/` and exercised in CI** ← this PR

Once merged, **#61 can be closed.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)