### PR TITLE
ci: get the pipeline & docker workflows running green (5 pre-existing breakages)

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -18,8 +18,18 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Lint commits with commitlint
-        uses: wagoid/commitlint-github-action@v6
+      # pnpm via Corepack + the repo's own @commitlint/cli, instead of the
+      # wagoid marketplace action, which isn't on the allowed-actions list.
+      - name: Enable Corepack (pnpm)
+        run: corepack enable
+
+      - uses: actions/setup-node@v4
         with:
-          configFile: .commitlintrc.json
-          failOnWarnings: false
+          node-version: 20
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Lint commits with commitlint
+        run: pnpm exec commitlint --config .commitlintrc.json --from ${{ github.event.pull_request.base.sha }} --to ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/init-wizard.yml
+++ b/.github/workflows/init-wizard.yml
@@ -26,9 +26,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 9
+      # pnpm via Corepack — pnpm/action-setup isn't on the allowed-actions list.
+      - name: Enable Corepack (pnpm)
+        run: corepack enable
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/init-wizard.yml
+++ b/.github/workflows/init-wizard.yml
@@ -32,7 +32,10 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          # 22, not 20: the test:init script uses `node --test "<glob>"`, and
+          # test-runner glob support landed in Node 21. (The init wizard has no
+          # Node-20 floor — only the pipeline package pins to 20.)
+          node-version: 22
           cache: pnpm
 
       - name: Install dependencies

--- a/.github/workflows/lighthouse-ci.yml
+++ b/.github/workflows/lighthouse-ci.yml
@@ -44,11 +44,9 @@ jobs:
         with:
           node-version: "20"
 
-      - name: Set up pnpm
-        uses: pnpm/action-setup@v4
-        with:
-          version: "9.15.0"
-          run_install: false
+      # pnpm via Corepack — pnpm/action-setup isn't on the allowed-actions list.
+      - name: Enable Corepack (pnpm)
+        run: corepack enable
 
       - name: Restore pnpm store
         uses: actions/cache@v4
@@ -83,13 +81,11 @@ jobs:
       - name: Seed deterministic content
         run: bash tests/visual/seed.sh
 
+      # lhci CLI (already a devDependency) instead of the treosh marketplace
+      # action, which isn't on this repo's allowed-actions list.
       - name: Run Lighthouse CI
         id: lhci
-        uses: treosh/lighthouse-ci-action@v12
-        with:
-          configPath: ./lighthouserc.json
-          uploadArtifacts: true
-          temporaryPublicStorage: true
+        run: pnpm exec lhci autorun --config=./lighthouserc.json --upload.target=temporary-public-storage
 
       - name: Annotate failing budgets
         if: always()

--- a/.github/workflows/lighthouse-ci.yml
+++ b/.github/workflows/lighthouse-ci.yml
@@ -73,6 +73,20 @@ jobs:
             sleep 2
           done
 
+      # A responding container only means the install wizard is up — WordPress
+      # core still has to be installed before WooCommerce can be bootstrapped.
+      - name: Install WordPress core
+        run: |
+          docker compose exec -T wordpress wp core is-installed --allow-root 2>/dev/null \
+            || docker compose exec -T wordpress wp core install \
+                 --url="http://localhost:8080" \
+                 --title="Flavian CI" \
+                 --admin_user=admin \
+                 --admin_password=admin \
+                 --admin_email=admin@example.com \
+                 --skip-email \
+                 --allow-root
+
       - name: Install WooCommerce (no sample data)
         env:
           WC_INSTALL_SAMPLE_DATA: "false"

--- a/.github/workflows/pipeline-tests.yml
+++ b/.github/workflows/pipeline-tests.yml
@@ -28,6 +28,7 @@ jobs:
               - 'bin/flavian.mjs'
               - 'scripts/indesign-fse/**'
               - 'tests/fixtures/indesign/**'
+              - '.github/workflows/pipeline-tests.yml'
 
   test:
     needs: check-paths

--- a/.github/workflows/pipeline-tests.yml
+++ b/.github/workflows/pipeline-tests.yml
@@ -64,9 +64,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 9.15.0
+      # pnpm via Corepack (bundled with Node) — the pnpm/action-setup
+      # marketplace action isn't on this repo's allowed-actions list.
+      - name: Enable Corepack (pnpm)
+        run: corepack enable
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -45,10 +45,9 @@ jobs:
         with:
           node-version: '20'
 
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v4
-        with:
-          version: 9
+      # pnpm via Corepack — pnpm/action-setup isn't on the allowed-actions list.
+      - name: Enable Corepack (pnpm)
+        run: corepack enable
 
       - name: Install Composer dependencies
         run: composer install --no-interaction --prefer-dist --quiet

--- a/.github/workflows/visual-regression.yml
+++ b/.github/workflows/visual-regression.yml
@@ -53,11 +53,9 @@ jobs:
         with:
           node-version: "20"
 
-      - name: Set up pnpm
-        uses: pnpm/action-setup@v4
-        with:
-          version: "9.15.0"
-          run_install: false
+      # pnpm via Corepack — pnpm/action-setup isn't on the allowed-actions list.
+      - name: Enable Corepack (pnpm)
+        run: corepack enable
 
       - name: Restore pnpm store
         uses: actions/cache@v4

--- a/.github/workflows/visual-regression.yml
+++ b/.github/workflows/visual-regression.yml
@@ -85,6 +85,20 @@ jobs:
             sleep 2
           done
 
+      # A responding container only means the install wizard is up — WordPress
+      # core still has to be installed before WooCommerce can be bootstrapped.
+      - name: Install WordPress core
+        run: |
+          docker compose exec -T wordpress wp core is-installed --allow-root 2>/dev/null \
+            || docker compose exec -T wordpress wp core install \
+                 --url="http://localhost:8080" \
+                 --title="Flavian CI" \
+                 --admin_user=admin \
+                 --admin_password=admin \
+                 --admin_email=admin@example.com \
+                 --skip-email \
+                 --allow-root
+
       - name: Install WooCommerce (no sample data)
         env:
           WC_INSTALL_SAMPLE_DATA: "false"

--- a/Dockerfile
+++ b/Dockerfile
@@ -56,11 +56,14 @@ COPY --from=php-extensions /usr/local/etc/php/conf.d/ /usr/local/etc/php/conf.d/
 COPY --from=wp-cli-builder /wp-cli.phar /usr/local/bin/wp
 RUN chmod +x /usr/local/bin/wp
 
-# Install runtime dependencies only (smaller than build dependencies)
+# Install runtime dependencies only (smaller than build dependencies).
+# Note: libzip5 (not libzip4) — the libzip soname bumped to .so.5 in Debian 13
+# (trixie), the base of wordpress:php8.3-apache. The other runtime libs kept
+# their names across bookworm→trixie.
 RUN apt-get update && apt-get install -y --no-install-recommends \
     less \
     mariadb-client \
-    libzip4 \
+    libzip5 \
     libpng16-16 \
     libjpeg62-turbo \
     libfreetype6 \

--- a/lighthouserc.json
+++ b/lighthouserc.json
@@ -1,5 +1,5 @@
 {
-  "$comment": "Lighthouse CI config. See https://github.com/GoogleChrome/lighthouse-ci/blob/main/docs/configuration.md. Mobile preset is the Lighthouse default — keeping it implicit. Resource budgets live in tests/lighthouse/budgets.json so they can be tuned without touching CI config.",
+  "$comment": "Lighthouse CI config. See https://github.com/GoogleChrome/lighthouse-ci/blob/main/docs/configuration.md. Mobile preset is the Lighthouse default — keeping it implicit. Resource budgets live in tests/lighthouse/budgets.json; Lighthouse still consumes them for the report. NOTE: the `performance-budget`/`timing-budget` *audit* assertions were dropped — those meta-audits aren't emitted by Lighthouse 12 (the bundled version), so asserting on them fails unconditionally with 'not a known audit'. Budget regressions are caught via the category + CLS assertions below; re-add budget assertions only with a LH12-compatible mechanism.",
   "ci": {
     "collect": {
       "url": [
@@ -16,8 +16,6 @@
     },
     "assert": {
       "assertions": {
-        "performance-budget": ["error", { "maxLength": 0 }],
-        "timing-budget":      ["error", { "maxLength": 0 }],
         "categories:performance":    ["error", { "minScore": 0.70 }],
         "categories:accessibility":  ["error", { "minScore": 0.90 }],
         "categories:best-practices": ["warn",  { "minScore": 0.90 }],

--- a/packages/pipeline/package.json
+++ b/packages/pipeline/package.json
@@ -15,7 +15,7 @@
     "flavian-generate-theme": "./bin/generate-theme.mjs"
   },
   "scripts": {
-    "test": "node --test \"tests/**/*.test.mjs\""
+    "test": "node --test"
   },
   "dependencies": {
     "fast-xml-parser": "^5.7.0",


### PR DESCRIPTION
Takes the repo from "no pipeline/docker workflow can even start" to a fully green CI suite. Five independent, pre-existing breakages — none introduced by the InDesign epic; all surfaced while confirming the InDesign fixture test actually runs in CI (#61). Each fix is validated (CI for the test/lint jobs; CI + local Docker for the heavy workflows).

| # | Breakage | Fix |
|---|---|---|
| 1 | 6 workflows `startup_failure` — repo Actions policy whitelists only `actions/*`, `shivammathur/setup-php@*`, `dorny/paths-filter@*` | Swap disallowed actions: `pnpm/action-setup`→Corepack, `wagoid/commitlint-github-action`→`@commitlint/cli`, `treosh/lighthouse-ci-action`→vendored `@lhci/cli` |
| 2 | Tests never executed on Node 20 — `node --test "<glob>"` needs Node 21+ | Pipeline `test`→ no-args `node --test`; init-wizard→Node 22 |
| 3 | Docker build fails on Debian trixie — `libzip4` renamed | `libzip4`→`libzip5` (verified vs trixie base; full build runs locally) |
| 4 | WooCommerce installer bails "WordPress is not installed" — a 200 from the install wizard ≠ installed | Add idempotent `wp core install` step before the WooCommerce step in both docker workflows |
| 5 | `lhci` fails every run: `"timing-budget" is not a known audit` — LH12 doesn't emit budget meta-audits | Drop the two budget meta-audit assertions; real gates (performance/accessibility/CLS) stay and pass |

## Result — every check green
- **`test-indesign-pkg`** (Pipeline Tests): runs the InDesign fixture test (`.idml` + PDF) on Node 20 ✅ — satisfies epic #61's "exercised in CI" criterion
- **visual-regression**: boot → WP install → WooCommerce → seed → capture → diff ✅
- **lighthouse-ci**: lhci runs on all 4 URLs, assertions pass ✅
- init-wizard, commitlint, security-audit, theme-validation, WPCS ✅

## Not changed
`release-please.yml` still uses `googleapis/release-please-action@v4` (disallowed; it only runs on push to main so it's not a PR check). Allowlist that one official action in **Settings → Actions → General**, or convert it to the `release-please` CLI in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)