### PR TITLE
docs: document the versioning / release-please convention

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -91,6 +91,24 @@ PRs with invalid commit messages will fail the `commitlint` check.
 See [docs/RELEASING.md](docs/RELEASING.md) for how these commits become tagged
 releases.
 
+## Versioning
+
+The `version` field in `package.json` is intentionally pinned to `0.0.0` and is
+**not** the repository version — **do not edit it by hand**. The source of truth
+for the released version is the latest `vX.Y.Z` git tag together with
+[`.release-please-manifest.json`](.release-please-manifest.json).
+
+Versioning is automated by [release-please](https://github.com/googleapis/release-please).
+The [Conventional Commit](#commit-message-format) types above drive the semver
+bump; release-please opens a **Release PR** that updates the manifest and
+`CHANGELOG.md`, and merging that PR creates the `vX.Y.Z` tag and GitHub Release.
+Because the project uses release-please's `simple` release type, the bump is
+recorded in `.release-please-manifest.json` rather than `package.json` — which
+is exactly why `package.json` stays at `0.0.0`.
+
+See [docs/RELEASING.md](docs/RELEASING.md) for the full flow, the version-bump
+rules, and overrides (e.g. the `Release-As:` footer).
+
 ## Coding Standards
 
 - Follow [WordPress PHP Coding Standards](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/)

--- a/README.md
+++ b/README.md
@@ -75,6 +75,8 @@ Site at http://localhost:8080 · Admin at /wp-admin · Database UI at :8081.
 
 **More docs:** [docs/QUICK-START.md](docs/QUICK-START.md) · [LOCAL-DEVELOPMENT.md](LOCAL-DEVELOPMENT.md) · [docs/docker-troubleshooting.md](docs/docker-troubleshooting.md)
 
+> **Versioning:** `package.json` declares `0.0.0` on purpose — the real version lives in git tags + `.release-please-manifest.json`. See [Versioning](CONTRIBUTING.md#versioning) in CONTRIBUTING.md.
+
 <details>
 <summary>Alternative: use as a wp-content directory in an existing WordPress install</summary>
 


### PR DESCRIPTION
Closes the "document the `0.0.0` versioning convention" task (v2.0.0 milestone).

## Problem
`package.json` declares `"version": "0.0.0"`. The field's `description` explains it's intentional (source of truth = git tags + `.release-please-manifest.json`), but that convention wasn't documented anywhere a contributor looks first.

## Changes
- **CONTRIBUTING.md** — new **Versioning** section (right after *Commit Message Format*): the `version` field is pinned to `0.0.0` on purpose and must not be hand-edited; the real version lives in git tags + `.release-please-manifest.json`; release-please's `simple` release type records the bump in the manifest, not `package.json` (which is *why* it stays `0.0.0`). Links onward to `docs/RELEASING.md` for the full flow.
- **README.md** — a short pointer next to the docs links (the README has no badge row) so a contributor who notices `0.0.0` is sent straight to the section.

## Acceptance criteria
- [x] Section in CONTRIBUTING.md titled "Versioning" explaining the release-please flow
- [x] Note in README.md near the badges *(none exist)* pointing to the section
- [~] Match wording used by Aurelius and Nerva — see note below

## Note on matching Aurelius / Nerva
I checked both. **Aurelius** documents a "Release Process" using `commit-and-tag-version` (`.versionrc.json`), where `package.json`'s version **is** kept in sync — the opposite of Flavian's `0.0.0` placeholder. **Nerva** has no versioning section yet. So there's no verbatim wording to match, and matching it literally would be inaccurate (different tool, different package.json behavior). I mirrored Aurelius's **structure and "don't hand-edit the version" guidance** while accurately describing Flavian's release-please flow. If the three repos later standardize on one tool/wording, this section should be reconciled then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)