### PR TITLE
docs: document versioning convention; sync package.json version via release-please

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -91,6 +91,44 @@ PRs with invalid commit messages will fail the `commitlint` check.
 See [docs/RELEASING.md](docs/RELEASING.md) for how these commits become tagged
 releases.
 
+## Versioning
+
+Flavian's version is **owned by release-please, not hand-edited.**
+
+The source of truth for the current version is:
+
+- **Git tags** (`vX.Y.Z`) — the canonical, immutable record of every release.
+- **[`.release-please-manifest.json`](.release-please-manifest.json)** — the
+  single line release-please reads to know "what version are we on" when it
+  computes the next bump.
+
+The `"version"` field in `package.json` mirrors the released version for tooling
+that expects it there. release-please keeps it in sync automatically via the
+`extra-files` entry in
+[`release-please-config.json`](release-please-config.json), so **do not bump it
+by hand** in a feature PR — let release-please own every version change.
+
+We use [release-please](https://github.com/googleapis/release-please) with the
+`simple` release type. The flow:
+
+1. You merge Conventional Commits to `main` (see
+   [Commit Message Format](#commit-message-format) above). The `type` decides
+   the bump — `fix:` → patch, `feat:` → minor, `!`/`BREAKING CHANGE:` → major.
+2. release-please opens (and keeps updating) a single **Release PR** titled
+   `chore(main): release X.Y.Z`, containing the bumped manifest, the synced
+   `package.json` version, and a generated `CHANGELOG.md` entry.
+3. A maintainer merges that Release PR. Only then does release-please cut the
+   `vX.Y.Z` git tag and GitHub Release. The Release PR is the human gate — no
+   tag is created until it is merged.
+
+The full mechanics, override footers (`Release-As:`), pre-release handling, and
+the list of files involved are in [docs/RELEASING.md](docs/RELEASING.md).
+
+> **Note:** Sibling frameworks [Aurelius](https://github.com/PMDevSolutions/Aurelius)
+> and [Nerva](https://github.com/PMDevSolutions/Nerva) follow the same
+> release-please convention. This section is intended to stay aligned with their
+> wording once their conventions are documented.
+
 ## Coding Standards
 
 - Follow [WordPress PHP Coding Standards](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/)

--- a/README.md
+++ b/README.md
@@ -251,6 +251,13 @@ Full catalog of 53 agents in [`.claude/CUSTOM-AGENTS-GUIDE.md`](.claude/CUSTOM-A
 - **Test Locally**: Use Local by Flywheel, XAMPP, MAMP, or Docker for development
 - **Version Control**: This template includes comprehensive `.gitignore` for WordPress
 
+> **Versioning:** the repository version is tracked in git tags +
+> `.release-please-manifest.json` (source of truth) and mirrored into
+> `package.json` by [release-please](https://github.com/googleapis/release-please).
+> Don't bump versions by hand. See
+> [CONTRIBUTING.md → Versioning](CONTRIBUTING.md#versioning) for the convention and
+> [docs/RELEASING.md](docs/RELEASING.md) for the full release flow.
+
 ## Resources
 
 - [WordPress Developer Handbook](https://developer.wordpress.org/)

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -66,8 +66,11 @@ theme `style.css` headers.
 
 ## Files involved
 
-- `release-please-config.json` — section mapping, release type, package config.
+- `release-please-config.json` — section mapping, release type, package config,
+  and the `extra-files` entry that mirrors the version into `package.json`.
 - `.release-please-manifest.json` — current version state.
+- `package.json` — `version` field is kept in sync with the manifest by
+  release-please; never hand-edited.
 - `.github/workflows/release-please.yml` — opens / updates the Release PR and
   tags on merge.
 - `.github/workflows/commitlint.yml` — lints PR commit messages.

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "flavian",
-  "version": "0.0.0",
+  "version": "1.1.0",
   "private": true,
-  "description": "Claude Code-integrated WordPress development template. Source of truth for the repository version is git tags + .release-please-manifest.json, not this file.",
+  "description": "Claude Code-integrated WordPress development template. The repository version is tracked in git tags + .release-please-manifest.json (source of truth) and mirrored into the version field above by release-please.",
   "license": "MIT",
   "homepage": "https://github.com/PMDevSolutions/Flavian",
   "repository": {

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -8,7 +8,14 @@
   "packages": {
     ".": {
       "package-name": "flavian",
-      "changelog-path": "CHANGELOG.md"
+      "changelog-path": "CHANGELOG.md",
+      "extra-files": [
+        {
+          "type": "json",
+          "path": "package.json",
+          "jsonpath": "$.version"
+        }
+      ]
     }
   },
   "changelog-sections": [


### PR DESCRIPTION
## Problem

`package.json` declared `"version": "0.0.0"`, and the convention that the version is owned by release-please (git tags + `.release-please-manifest.json`) wasn't documented anywhere a contributor looks first. Closes #79.

## Changes

- **`CONTRIBUTING.md`** — new **Versioning** section explaining the release-please flow, the source of truth, and "don't bump the version by hand."
- **`README.md`** — a pointer note (no badges exist in this README, so it sits in the Development Best Practices → Version Control area) linking to the Versioning section and `docs/RELEASING.md`.
- **`package.json`** — version set from `0.0.0` to `1.1.0` to match the manifest, per maintainer decision.
- **`release-please-config.json`** — added an `extra-files` entry so release-please **keeps `package.json`'s `version` in sync automatically** on every release. This is what makes the `1.1.0` value sustainable instead of a hand-maintained mirror that drifts.
- **`docs/RELEASING.md`** — added `package.json` to the "Files involved" list and noted the `extra-files` sync.

## Note on the `0.0.0` → `1.1.0` change

The original issue framed `0.0.0` as an intentional sentinel. The decision here was to instead carry the real version in `package.json` and have release-please own keeping it in sync (the `simple` release type does **not** touch `package.json` by default, hence the `extra-files` config). On the next release PR, release-please will bump both the manifest and `package.json` together.

## Outstanding

The issue also asks to match the wording used by **Aurelius** and **Nerva** "once their conventions are documented." Those sibling repos aren't documented yet; the Versioning section includes a note flagging the intended alignment as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)