### PR TITLE
feat(headless): headless WordPress / REST API starter — CI smoke test + CORS hardening

### DIFF
--- a/.github/workflows/headless-e2e.yml
+++ b/.github/workflows/headless-e2e.yml
@@ -1,0 +1,112 @@
+name: headless-e2e
+
+# Smoke test for the headless WordPress / REST API starter (v2.0.0, issue #81).
+# Boots WordPress in Docker, runs setup-headless.sh (WPGraphQL + headless mode),
+# then asserts the REST API, CORS policy, REST hardening, WPGraphQL endpoint, the
+# scaffold-frontend.sh output, and that nothing logs a PHP fatal. The scaffold
+# half (Part A) runs even on changes that don't boot WordPress.
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: headless-e2e-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  check-paths:
+    runs-on: ubuntu-latest
+    outputs:
+      should-run: ${{ steps.filter.outputs.headless }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            headless:
+              - 'mu-plugins/flavian-headless.php'
+              - 'scripts/wordpress-install/setup-headless.sh'
+              - 'scripts/scaffold-frontend.sh'
+              - '.claude/templates/frontend/**'
+              - 'tests/headless-e2e/**'
+              - '.github/workflows/headless-e2e.yml'
+              - 'docker-compose.yml'
+              - 'Dockerfile'
+
+  e2e:
+    needs: check-paths
+    if: needs.check-paths.outputs.should-run == 'true'
+    runs-on: ubuntu-latest
+    name: Headless API + CORS + scaffold smoke test
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Prepare .env for docker compose
+        run: cp .env.example .env
+
+      - name: Boot WordPress stack
+        run: |
+          docker compose up -d wordpress db
+          for i in $(seq 1 90); do
+            if curl --silent --fail --max-time 2 http://localhost:8080/ >/dev/null 2>&1; then
+              echo "WordPress responding."
+              break
+            fi
+            sleep 2
+          done
+
+      - name: Install WordPress core
+        run: |
+          docker compose exec -T wordpress wp core is-installed --allow-root 2>/dev/null \
+            || docker compose exec -T wordpress wp core install \
+                 --url="http://localhost:8080" \
+                 --title="Flavian CI" \
+                 --admin_user=admin \
+                 --admin_password=admin \
+                 --admin_email=admin@example.com \
+                 --skip-email \
+                 --allow-root
+
+      # Installs WPGraphQL + companions, enables headless mode, sets the preview
+      # secret and pretty permalinks. Tolerates optional-plugin install failures.
+      - name: Configure headless mode
+        run: bash scripts/wordpress-install/setup-headless.sh --frontend-url http://localhost:3000
+
+      # The hard gate: scaffold output is coherent, the REST/GraphQL APIs respond,
+      # CORS only mirrors the configured origin, the users route is hardened away,
+      # and nothing logs a PHP fatal. Fails the PR on regression.
+      - name: Run headless smoke test
+        run: node --test tests/headless-e2e/*.test.mjs
+
+  # Stable required check: always runs so branch protection can require
+  # "headless-e2e status" without blocking PRs that don't touch headless paths
+  # (mirrors canva-e2e.yml / pipeline-tests.yml).
+  status:
+    runs-on: ubuntu-latest
+    needs: [check-paths, e2e]
+    if: always()
+    name: headless-e2e status
+    steps:
+      - name: Report status
+        run: |
+          if [ "${{ needs.check-paths.outputs.should-run }}" != "true" ]; then
+            echo "No headless pipeline/template/test changes — skipping e2e."
+            exit 0
+          fi
+          if [ "${{ needs.e2e.result }}" != "success" ]; then
+            echo "headless-e2e smoke test failed."
+            exit 1
+          fi
+          echo "headless-e2e smoke test passed."

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -567,10 +567,13 @@ docker compose --profile headless up headless-installer
 
 # Scaffold a Next.js 14 frontend under frontend/<slug>/
 bash scripts/scaffold-frontend.sh my-app --name "My Site"
+
+# Smoke test (boots WP, asserts REST/CORS/hardening/GraphQL/scaffold + no fatals)
+pnpm test:headless-e2e
 ```
-Mu-plugin: `mu-plugins/flavian-headless.php` (toggled by `flavian_headless_mode` option).
+Mu-plugin: `mu-plugins/flavian-headless.php` (toggled by `flavian_headless_mode` option; gates REST CORS to the frontend allowlist).
 Frontend templates: `.claude/templates/frontend/nextjs/`.
-Full guide: `docs/headless-wordpress/README.md`.
+CI: `.github/workflows/headless-e2e.yml`. Full guide: `docs/headless-wordpress/README.md`.
 
 **WooCommerce (e-commerce scaffold):**
 ```bash

--- a/docs/headless-wordpress/README.md
+++ b/docs/headless-wordpress/README.md
@@ -10,6 +10,7 @@ Run WordPress as a content API (REST + WPGraphQL) and consume it from a decouple
 | Compose profile | `docker-compose.yml` → `headless-installer` | Wraps the installer in a one-shot container. Run with `docker compose --profile headless up headless-installer`. |
 | Mu-plugin | `mu-plugins/flavian-headless.php` | CORS, preview-URL rewriting, REST hardening, REST `preview_secret_match` field. Toggled by `flavian_headless_mode` option. |
 | Scaffold script | `scripts/scaffold-frontend.sh` | Generates `frontend/<slug>/` from `.claude/templates/frontend/nextjs/`. |
+| Smoke test | `tests/headless-e2e/` + `.github/workflows/headless-e2e.yml` | CI proof that the scaffold output, REST API, CORS allowlist, REST hardening, and WPGraphQL all work. |
 | Agent | `.claude/agents/headless-developer.md` | Domain expert; invoke for headless workflows. |
 
 ## Five-minute setup
@@ -49,6 +50,36 @@ pnpm install && pnpm dev
 - **REST**: `http://localhost:8080/wp-json/wp/v2/`
 - **GraphQL**: `http://localhost:8080/graphql`
 - **GraphiQL IDE**: `http://localhost:8080/wp-admin/admin.php?page=graphiql-ide`
+
+## Smoke test
+
+A CI smoke test (`.github/workflows/headless-e2e.yml`) guards the headless
+contract on every PR that touches the mu-plugin, installer, frontend templates,
+or scaffold script. It boots WordPress in Docker, runs `setup-headless.sh`, then
+asserts:
+
+- `scaffold-frontend.sh` emits a coherent Next.js consumer (file tree, valid
+  `package.json`, `.env.local.example` keys, no unrendered `{{TOKENS}}`)
+- the REST API responds and the `/wp/v2/users` route is hardened away
+- CORS mirrors **only** the configured frontend origin — an unconfigured origin
+  gets no credentialed grant, even on `/wp-json/` (the mu-plugin replaces
+  WordPress core's permissive `rest_send_cors_headers()`)
+- WPGraphQL answers a query
+- nothing logs a PHP fatal while exercising any of it
+
+Run it locally against a booted stack:
+
+```bash
+docker compose up -d wordpress db
+docker compose exec -T wordpress wp core install --url=http://localhost:8080 \
+  --title="Flavian" --admin_user=admin --admin_password=admin \
+  --admin_email=admin@example.com --skip-email --allow-root
+bash scripts/wordpress-install/setup-headless.sh
+pnpm test:headless-e2e
+```
+
+The scaffold half (Part A) runs even without Docker; the API half (Part B)
+skips cleanly with a message when the stack isn't reachable.
 
 ## Disabling headless mode
 

--- a/mu-plugins/flavian-headless.php
+++ b/mu-plugins/flavian-headless.php
@@ -50,27 +50,15 @@ function preview_secret(): string {
 }
 
 /**
- * Emit CORS headers for the configured frontend origin.
+ * Origins allowed to make credentialed cross-origin requests.
  *
- * Wide-open headers would defeat the purpose; we mirror the configured
- * frontend origin (or echo the Origin header when it matches one of a small
- * allowlist) and let WP's standard REST/GraphQL responses pass through.
+ * The configured frontend plus localhost:3000 for local dev. Apps that need
+ * more origins can extend this on the `flavian_headless_allowed_origins` filter.
  *
- * @return void
+ * @return string[]
  */
-function send_cors_headers(): void {
-	if ( ! is_enabled() ) {
-		return;
-	}
-
-	$origin = isset( $_SERVER['HTTP_ORIGIN'] )
-		? esc_url_raw( wp_unslash( $_SERVER['HTTP_ORIGIN'] ) )
-		: '';
-	if ( '' === $origin ) {
-		return;
-	}
-
-	$allowed = array_filter(
+function allowed_origins(): array {
+	$origins = array_filter(
 		array_unique(
 			array(
 				frontend_url(),
@@ -79,7 +67,41 @@ function send_cors_headers(): void {
 		)
 	);
 
-	if ( ! in_array( $origin, $allowed, true ) ) {
+	/**
+	 * Filter the CORS origin allowlist for headless mode.
+	 *
+	 * @param string[] $origins Allowed origins (no trailing slash).
+	 */
+	return (array) apply_filters( 'flavian_headless_allowed_origins', $origins );
+}
+
+/**
+ * The request Origin, sanitized, or '' when absent.
+ *
+ * @return string
+ */
+function request_origin(): string {
+	return isset( $_SERVER['HTTP_ORIGIN'] )
+		? esc_url_raw( wp_unslash( $_SERVER['HTTP_ORIGIN'] ) )
+		: '';
+}
+
+/**
+ * Emit CORS headers for the configured frontend origin.
+ *
+ * Wide-open headers would defeat the purpose; we mirror the configured
+ * frontend origin (or echo the Origin header when it matches the allowlist)
+ * and let WP's standard REST/GraphQL responses pass through.
+ *
+ * @return void
+ */
+function send_cors_headers(): void {
+	if ( ! is_enabled() ) {
+		return;
+	}
+
+	$origin = request_origin();
+	if ( '' === $origin || ! in_array( $origin, allowed_origins(), true ) ) {
 		return;
 	}
 
@@ -98,6 +120,44 @@ function send_cors_headers(): void {
 	}
 }
 add_action( 'init', __NAMESPACE__ . '\\send_cors_headers' );
+
+/**
+ * Lock the REST API's CORS headers to the allowlist.
+ *
+ * WordPress core's default `rest_send_cors_headers()` reflects *any* Origin
+ * back with `Access-Control-Allow-Credentials: true`. For a headless install
+ * that hands the REST API to a known frontend, that's exactly the wide-open
+ * behavior we want to avoid — so we swap core's handler for an allowlisted one.
+ * Disallowed origins get no ACAO/ACAC and therefore no credentialed access.
+ *
+ * @return void
+ */
+function restrict_rest_cors(): void {
+	if ( ! is_enabled() ) {
+		return;
+	}
+	remove_filter( 'rest_pre_serve_request', 'rest_send_cors_headers' );
+	add_filter( 'rest_pre_serve_request', __NAMESPACE__ . '\\send_rest_cors_headers' );
+}
+add_action( 'rest_api_init', __NAMESPACE__ . '\\restrict_rest_cors', 15 );
+
+/**
+ * Allowlisted replacement for core's rest_send_cors_headers().
+ *
+ * @param bool $served Whether the request has already been served.
+ * @return bool Unmodified $served (this is a pass-through filter).
+ */
+function send_rest_cors_headers( $served ) {
+	$origin = request_origin();
+	if ( '' !== $origin && in_array( $origin, allowed_origins(), true ) ) {
+		header( 'Access-Control-Allow-Origin: ' . $origin );
+		header( 'Access-Control-Allow-Methods: OPTIONS, GET, POST, PUT, PATCH, DELETE' );
+		header( 'Access-Control-Allow-Credentials: true' );
+		header( 'Access-Control-Allow-Headers: Authorization, Content-Type, X-WP-Nonce' );
+		header( 'Vary: Origin', false );
+	}
+	return $served;
+}
 
 /**
  * Rewrite the admin "Preview" link to the frontend's /api/preview route.

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "test:init": "node --test \"tests/init/**/*.test.mjs\"",
     "test:pipeline": "pnpm --filter @flavian/pipeline test",
     "test:canva-e2e": "node --test tests/canva-e2e/*.test.mjs",
+    "test:headless-e2e": "node --test tests/headless-e2e/*.test.mjs",
     "visual:capture": "node tests/visual/capture.mjs",
     "visual:diff": "node scripts/visual-diff.js --batch tests/visual/actual tests/visual/baselines --output-dir tests/visual/diffs --threshold 0.005 --json > tests/visual/report.json && node tests/visual/print-report.mjs tests/visual/report.json",
     "visual:update": "bash scripts/visual-update-baselines.sh",

--- a/tests/headless-e2e/headless.test.mjs
+++ b/tests/headless-e2e/headless.test.mjs
@@ -1,0 +1,190 @@
+// Headless WordPress — smoke test (v2.0.0 milestone, issue #81).
+//
+// Part A (always runs): proves scaffold-frontend.sh emits a coherent Next.js
+//   consumer from the committed template — no Docker required.
+// Part B (needs the Docker WP stack): enables headless mode via wp-cli, then
+//   asserts the contract the mu-plugin + installer promise:
+//     - REST API responds
+//     - CORS mirrors the configured frontend origin (and ONLY that origin)
+//     - the users endpoint is hardened away
+//     - WPGraphQL answers (skipped cleanly if the plugin isn't installed)
+//     - no PHP fatals are logged while exercising any of it
+//   Skipped with a clear message when the stack isn't reachable.
+
+import { test, describe, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import { existsSync, readFileSync, rmSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+import {
+	ROOT,
+	BASE_URL,
+	FRONTEND_ORIGIN,
+	run,
+	wp,
+	dockerExec,
+	wpReachable,
+	httpGet,
+	graphql,
+} from './lib.mjs';
+
+const SCAFFOLD_SLUG = 'headless-smoke';
+const SCAFFOLD_DIR = resolve(ROOT, 'frontend', SCAFFOLD_SLUG);
+const MU_PLUGIN = '/var/www/html/wp-content/mu-plugins/flavian-headless.php';
+
+// ---------------------------------------------------------------------------
+// Part A — scaffold-frontend.sh produces a coherent consumer (no Docker)
+// ---------------------------------------------------------------------------
+
+describe('scaffold-frontend.sh emits a working Next.js consumer', () => {
+	before(() => {
+		// Clean slate, then scaffold into frontend/<slug>/ (the only output dir
+		// the script supports). Removed again in after().
+		rmSync(SCAFFOLD_DIR, { recursive: true, force: true });
+		run('bash', ['scripts/scaffold-frontend.sh', SCAFFOLD_SLUG, '--name', 'Headless Smoke', '--force']);
+	});
+
+	after(() => {
+		rmSync(SCAFFOLD_DIR, { recursive: true, force: true });
+	});
+
+	test('writes the expected file tree', () => {
+		const expected = [
+			'package.json',
+			'next.config.mjs',
+			'.env.local.example',
+			'src/lib/wp-client.ts',
+			'src/lib/queries.ts',
+			'src/app/page.tsx',
+			'src/app/posts/[slug]/page.tsx',
+			'src/app/api/preview/route.ts',
+			'src/app/api/exit-preview/route.ts',
+		];
+		for (const rel of expected) {
+			assert.ok(existsSync(resolve(SCAFFOLD_DIR, rel)), `missing scaffolded file: ${rel}`);
+		}
+	});
+
+	test('package.json is valid JSON with the slug substituted', () => {
+		const pkg = JSON.parse(readFileSync(resolve(SCAFFOLD_DIR, 'package.json'), 'utf8'));
+		assert.equal(pkg.name, SCAFFOLD_SLUG, 'APP_SLUG token should be substituted into name');
+		assert.ok(pkg.dependencies?.next, 'next should be a dependency');
+	});
+
+	test('.env.local.example documents the WP wiring the frontend needs', () => {
+		const env = readFileSync(resolve(SCAFFOLD_DIR, '.env.local.example'), 'utf8');
+		for (const key of ['WORDPRESS_URL', 'WORDPRESS_GRAPHQL_URL', 'WORDPRESS_PREVIEW_SECRET']) {
+			assert.match(env, new RegExp(`^${key}=`, 'm'), `.env.local.example should declare ${key}`);
+		}
+	});
+
+	test('no unsubstituted template tokens leak into the output', () => {
+		const pkg = readFileSync(resolve(SCAFFOLD_DIR, 'package.json'), 'utf8');
+		assert.doesNotMatch(pkg, /\{\{[A-Z_]+\}\}/, 'all {{TOKENS}} should be rendered');
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Part B — headless contract against the live Docker WordPress stack
+// ---------------------------------------------------------------------------
+
+const reachable = wpReachable();
+
+describe('headless WordPress exposes a hardened content API', {
+	skip: reachable
+		? false
+		: `Docker WordPress stack not reachable at ${BASE_URL} — boot it with \`docker compose up -d wordpress db\` + install core to run the API checks`,
+}, () => {
+	before(() => {
+		// Make the suite self-sufficient: turn headless mode on and point CORS at
+		// FRONTEND_ORIGIN regardless of whether setup-headless.sh already ran.
+		wp(['option', 'update', 'flavian_headless_mode', '1']);
+		wp(['option', 'update', 'flavian_headless_frontend_url', FRONTEND_ORIGIN]);
+		wp(['option', 'update', 'flavian_headless_preview_secret', 'smoke-secret-0123456789']);
+
+		// Pretty permalinks are required for REST + WPGraphQL routes.
+		wp(['option', 'update', 'permalink_structure', '/%postname%/']);
+		wp(['rewrite', 'flush', '--hard']);
+
+		// Capture PHP issues to a log instead of the response, then start clean.
+		wp(['config', 'set', 'WP_DEBUG', 'true', '--raw']);
+		wp(['config', 'set', 'WP_DEBUG_LOG', 'true', '--raw']);
+		wp(['config', 'set', 'WP_DEBUG_DISPLAY', 'false', '--raw']);
+		dockerExec('rm -f wp-content/debug.log');
+
+		// A published post makes the REST collection non-trivial. Best-effort.
+		try {
+			wp(['post', 'create', '--post_title=Headless smoke post', '--post_status=publish', '--porcelain']);
+		} catch {
+			/* a seeded post is nice-to-have, not required */
+		}
+	});
+
+	test('mu-plugin has no PHP syntax errors', () => {
+		// `php -l` exits non-zero on a parse error, which throws here.
+		dockerExec(`php -l ${MU_PLUGIN}`);
+	});
+
+	test('REST API returns the posts collection', async () => {
+		const res = await httpGet('/wp-json/wp/v2/posts');
+		assert.equal(res.status, 200, 'REST /wp/v2/posts should return HTTP 200');
+		const body = await res.json();
+		assert.ok(Array.isArray(body), 'posts endpoint should return a JSON array');
+	});
+
+	test('CORS mirrors the configured frontend origin', async () => {
+		const res = await httpGet('/wp-json/', { origin: FRONTEND_ORIGIN });
+		assert.equal(
+			res.headers.get('access-control-allow-origin'),
+			FRONTEND_ORIGIN,
+			'allowed origin should be echoed back',
+		);
+		assert.equal(res.headers.get('access-control-allow-credentials'), 'true');
+		assert.match(res.headers.get('vary') ?? '', /Origin/i, 'Vary: Origin must be set for caches');
+	});
+
+	test('REST API does NOT grant credentialed CORS to an unconfigured origin', async () => {
+		// WordPress core's default rest_send_cors_headers() reflects any origin
+		// with credentials:true; restrict_rest_cors() in the mu-plugin replaces it.
+		const res = await httpGet('/wp-json/', { origin: 'http://evil.example' });
+		assert.notEqual(
+			res.headers.get('access-control-allow-origin'),
+			'http://evil.example',
+			'an unallowed origin must never be reflected on the REST API',
+		);
+		assert.notEqual(
+			res.headers.get('access-control-allow-credentials'),
+			'true',
+			'credentialed CORS must never be granted to an unallowed origin',
+		);
+	});
+
+	test('CORS preflight (OPTIONS) short-circuits with 204', async () => {
+		const res = await httpGet('/wp-json/', { origin: FRONTEND_ORIGIN, method: 'OPTIONS' });
+		assert.equal(res.status, 204, 'preflight from an allowed origin should return 204');
+	});
+
+	test('users endpoint is hardened away (no author enumeration)', async () => {
+		const res = await httpGet('/wp-json/wp/v2/users');
+		assert.equal(res.status, 404, 'the /wp/v2/users route should be removed in headless mode');
+	});
+
+	test('WPGraphQL answers a query', async (t) => {
+		const res = await graphql('{ generalSettings { title } }');
+		if (res.status === 404) {
+			t.skip('WPGraphQL not installed — run setup-headless.sh to enable the /graphql endpoint');
+			return;
+		}
+		assert.equal(res.status, 200, 'GraphQL endpoint should return HTTP 200');
+		const body = await res.json();
+		assert.equal(typeof body?.data?.generalSettings?.title, 'string', 'expected generalSettings.title');
+	});
+
+	test('no PHP fatals or parse errors were logged while exercising the API', async () => {
+		// Re-hit a couple of endpoints so any lazy hook fires before we read the log.
+		await httpGet('/wp-json/wp/v2/posts', { origin: FRONTEND_ORIGIN });
+		await httpGet('/');
+		const log = dockerExec('test -f wp-content/debug.log && cat wp-content/debug.log || true');
+		assert.doesNotMatch(log, /PHP (Fatal|Parse) error/i, `debug.log contains a fatal:\n${log}`);
+	});
+});

--- a/tests/headless-e2e/lib.mjs
+++ b/tests/headless-e2e/lib.mjs
@@ -1,0 +1,93 @@
+// Helpers for the headless WordPress smoke test.
+//
+// Two execution surfaces (mirrors tests/canva-e2e/lib.mjs):
+//   - Host shell (bash) for the deterministic scaffold-frontend.sh check.
+//   - The running Docker WordPress stack (`docker compose exec ... wp`) for the
+//     API / CORS / hardening checks, plus host-side `fetch` against :8080.
+//
+// Everything is best-effort about the environment: callers use wpReachable() to
+// decide whether the Docker-dependent suite can run, and skip cleanly otherwise.
+
+import { execFileSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+/** Repo root (two levels up from tests/headless-e2e/). */
+export const ROOT = resolve(__dirname, '..', '..');
+
+/** Host-reachable WordPress origin (Docker maps container :80 → host :8080). */
+export const BASE_URL = process.env.HEADLESS_E2E_BASE_URL ?? 'http://localhost:8080';
+
+/** Origin the mu-plugin is configured to allow (set in the test's before()). */
+export const FRONTEND_ORIGIN = process.env.HEADLESS_E2E_FRONTEND_ORIGIN ?? 'http://localhost:3000';
+
+/** Run a host command, returning trimmed stdout. Throws on non-zero exit. */
+export function run(cmd, args, opts = {}) {
+	return execFileSync(cmd, args, {
+		cwd: ROOT,
+		encoding: 'utf8',
+		stdio: ['ignore', 'pipe', 'pipe'],
+		...opts,
+	}).trim();
+}
+
+/** Run `wp <args> --allow-root` inside the wordpress container. */
+export function wp(args, opts = {}) {
+	return run(
+		'docker',
+		['compose', 'exec', '-T', 'wordpress', 'wp', ...args, '--allow-root'],
+		opts,
+	);
+}
+
+/** Run an arbitrary command inside the wordpress container's web root. */
+export function dockerExec(shellCmd, opts = {}) {
+	return run('docker', ['compose', 'exec', '-T', 'wordpress', 'sh', '-lc', shellCmd], opts);
+}
+
+/**
+ * True if the Docker WordPress stack is up and core is installed.
+ * Never throws — returns false on any error so the suite can skip cleanly.
+ */
+export function wpReachable() {
+	try {
+		wp(['core', 'is-installed']);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+/**
+ * Fetch with a short timeout so a hung container fails the test instead of
+ * hanging CI. Returns the Response (caller inspects status/headers/body).
+ */
+export async function httpGet(path, { origin, method = 'GET' } = {}) {
+	const headers = {};
+	if (origin) headers.Origin = origin;
+	const controller = new AbortController();
+	const timer = setTimeout(() => controller.abort(), 15_000);
+	try {
+		return await fetch(BASE_URL + path, { method, headers, signal: controller.signal });
+	} finally {
+		clearTimeout(timer);
+	}
+}
+
+/** POST a GraphQL query to /graphql. Returns the Response. */
+export async function graphql(query, variables = {}) {
+	const controller = new AbortController();
+	const timer = setTimeout(() => controller.abort(), 15_000);
+	try {
+		return await fetch(BASE_URL + '/graphql', {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json', Origin: FRONTEND_ORIGIN },
+			body: JSON.stringify({ query, variables }),
+			signal: controller.signal,
+		});
+	} finally {
+		clearTimeout(timer);
+	}
+}


### PR DESCRIPTION
## Description

Closes the final acceptance criterion of the v2.0.0 **headless WordPress / REST API starter** — a **CI smoke test** — and fixes a real CORS security gap that writing the test uncovered.

### What's here

**1. `test(headless)` — end-to-end CI smoke test**
- `tests/headless-e2e/` (Node `node --test` runner, mirrors `tests/canva-e2e/`):
  - **Part A (no Docker):** `scaffold-frontend.sh` emits a coherent Next.js consumer — file tree, valid `package.json` with the slug substituted, required `.env.local.example` keys, and no unrendered `{{TOKENS}}`.
  - **Part B (live Docker WP):** REST API responds; CORS mirrors **only** the configured frontend origin; `/wp/v2/users` is hardened away (no author enumeration); WPGraphQL answers; no PHP fatals are logged. Skips cleanly with a message when the stack isn't reachable.
- `.github/workflows/headless-e2e.yml`: boots WordPress → `setup-headless.sh` → runs the test. Path-filtered, with a stable `headless-e2e status` check for branch protection (same shape as `canva-e2e.yml`).
- `pnpm test:headless-e2e` script + docs.

**2. `fix(headless)` — gate REST API CORS to the frontend allowlist**
The test's "unconfigured origin" assertion failed on first run: `/wp-json/` was reflecting `http://evil.example` back with `Access-Control-Allow-Credentials: true`. That's WordPress **core's** default `rest_send_cors_headers()`, which reflects *any* Origin — defeating the mu-plugin's allowlist on the exact endpoints a headless frontend uses. `flavian-headless.php` now replaces core's handler on `rest_api_init` (`restrict_rest_cors`) with an allowlisted version, so disallowed origins get **no** credentialed CORS grant. The allowlist is extracted into a filterable `allowed_origins()` helper (`flavian_headless_allowed_origins`).

## Related Issue

Closes #81

## Type of Change

- [x] Bug fix (REST CORS hardening — security)
- [x] New feature (CI smoke test)
- [x] Documentation update
- [ ] Chore
- [ ] Breaking change

## Checklist

- [ ] PHPCS passes — could not run locally (no PHP on the dev host); enforced by the `phpcs.yml` workflow. Code follows WordPress-Extra/WordPress-Docs conventions (docblocks, Yoda conditions, strict `in_array`, escaped output).
- [x] Tests pass — **12/12** assertions pass against a live Dockerized WordPress.
- [x] Docker environment works — booted `wordpress`+`db`, installed core, ran `setup-headless.sh`, exercised the full suite.
- [x] Documentation updated — `docs/headless-wordpress/README.md` (smoke-test section + "what's in the box") and the CLAUDE.md headless block.

## Verification

```
$ node --test tests/headless-e2e/*.test.mjs
✔ scaffold-frontend.sh emits a working Next.js consumer (4/4)
✔ headless WordPress exposes a hardened content API (8/8)
ℹ tests 12  ℹ pass 12  ℹ fail 0
```

Manual confirmation of the fix:
- `/wp-json/` + `Origin: http://localhost:3000` → `Access-Control-Allow-Origin: http://localhost:3000`, `Access-Control-Allow-Credentials: true`
- `/wp-json/` + `Origin: http://evil.example` → **no** `Access-Control-Allow-Origin` / `Access-Control-Allow-Credentials`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
