### PR TITLE
feat(blocks): Gutenberg custom block scaffolder (v2.0.0)

### DIFF
--- a/.claude/commands/scaffold-block.md
+++ b/.claude/commands/scaffold-block.md
@@ -1,0 +1,83 @@
+---
+allowed-tools: Bash(bash scripts/scaffold-block.sh:*), Bash(pnpm run scaffold:block:*), Bash(node:*), Read, Edit, AskUserQuestion
+argument-hint: <block-name> [--namespace ns] [--attributes "name:type[:default],..."] [--dynamic]
+description: Scaffold a Gutenberg custom block (block.json, edit/save JS, optional render callback, PHPUnit stub)
+---
+
+# Scaffold a Gutenberg Custom Block
+
+Generate a self-contained, activatable custom block plugin under
+`plugins/<block-name>/` using `scripts/scaffold-block.sh`. No build step is
+required — the generated `index.js` uses the WordPress runtime globals and
+`index.asset.php` declares the package dependencies.
+
+## Arguments provided
+
+**$ARGUMENTS**
+
+## Inputs (collect these before generating)
+
+The generator accepts three core inputs from the v2.0.0 milestone. If any are
+missing from `$ARGUMENTS` and cannot be sensibly defaulted, ask the user with
+`AskUserQuestion`:
+
+1. **Block name** (required, positional) — kebab-case slug, e.g. `pricing-table`.
+2. **Namespace** (`--namespace`, default `flavian`) — becomes the block.json
+   `name` as `<namespace>/<block-name>`.
+3. **Supported attributes** (`--attributes`) — comma-separated
+   `name:type[:default]`. Types: `string`, `number`, `boolean`, `array`,
+   `object`. Example: `heading:string:Our Plans,count:number:3,featured:boolean`.
+
+Optional: `--dynamic` (server-rendered `render.php`; otherwise a static
+`save()`), `--title`, `--description`, `--category`, `--icon`, `--keywords`,
+`--text-domain`, `--author`, `--php-namespace`, `--version`, `--dest`,
+`--force`, `--dry-run`.
+
+## Steps
+
+1. **Parse `$ARGUMENTS`.** Identify the block name, namespace, and attributes.
+   Decide static vs dynamic: choose `--dynamic` when the block's output depends
+   on PHP/server data (latest posts, current user, options); otherwise leave it
+   static. If the choice is ambiguous, ask.
+
+2. **Preview with `--dry-run`** so the user can confirm the file list:
+
+   ```bash
+   bash scripts/scaffold-block.sh <block-name> --namespace <ns> \
+     --attributes "<spec>" [--dynamic] --dry-run
+   ```
+
+3. **Generate** by re-running without `--dry-run` (or via
+   `pnpm run scaffold:block <block-name> -- --namespace <ns> ...`).
+
+4. **Report** the created tree and the generated block name
+   `<namespace>/<block-name>`.
+
+5. **Offer the smoke test** (requires the Docker stack running):
+
+   ```bash
+   docker compose up -d wordpress db
+   bash scripts/smoke-block.sh <block-name> --namespace <ns>
+   ```
+
+   This scaffolds, validates assets, activates the plugin, asserts the block is
+   registered, and renders it on a throwaway page.
+
+## Outputs
+
+```
+plugins/<block-name>/
+├── <block-name>.php                  # Plugin header + register_block_type()
+├── blocks/<block-name>/
+│   ├── block.json                    # Metadata, attributes, supports
+│   ├── index.js                      # edit() + save() (no build step)
+│   ├── index.asset.php               # Script dependencies + version
+│   ├── editor.css / style.css        # Styles
+│   └── render.php                    # Dynamic render callback (--dynamic only)
+├── tests/<BlockClass>Test.php        # PHPUnit stub
+├── tests/bootstrap.php               # Lightweight WP stubs
+├── phpunit.xml.dist
+└── README.md
+```
+
+See `docs/blocks/README.md` for the full reference.

--- a/.github/workflows/block-validation.yml
+++ b/.github/workflows/block-validation.yml
@@ -1,0 +1,77 @@
+name: block-validation
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - "scripts/scaffold-block.sh"
+      - "scripts/smoke-block.sh"
+      - "tests/unit/scaffold-block.bats"
+      - ".claude/commands/scaffold-block.md"
+      - "docs/blocks/**"
+      - ".github/workflows/block-validation.yml"
+  push:
+    branches: [main]
+    paths:
+      - "scripts/scaffold-block.sh"
+      - "scripts/smoke-block.sh"
+      - "tests/unit/scaffold-block.bats"
+      - ".github/workflows/block-validation.yml"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: block-validation-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  # 1. Structural tests for the generator output (bats + node).
+  bats:
+    name: Scaffolder bats tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout with submodules
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - name: Run scaffold-block bats suite
+        run: ./tests/libs/bats-core/bin/bats tests/unit/scaffold-block.bats
+
+  # 2. Generate a block, lint every emitted PHP file, and run the PHPUnit stub.
+  php:
+    name: Generated block · PHP lint + PHPUnit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: "8.2"
+          tools: phpunit
+          coverage: none
+      - name: Scaffold a dynamic block
+        run: |
+          bash scripts/scaffold-block.sh ci-block \
+            --namespace flavian \
+            --attributes "heading:string:Hi,count:number:2,featured:boolean,items:array" \
+            --dynamic --dest "$RUNNER_TEMP/blk"
+      - name: Scaffold a static block
+        run: |
+          bash scripts/scaffold-block.sh ci-static \
+            --namespace flavian \
+            --attributes "message:string:Hello,dismissible:boolean" \
+            --dest "$RUNNER_TEMP/blk"
+      - name: php -l every generated PHP file
+        run: |
+          fail=0
+          while IFS= read -r f; do
+            php -l "$f" || fail=1
+          done < <(find "$RUNNER_TEMP/blk" -name '*.php')
+          exit "$fail"
+      - name: Run the generated PHPUnit stubs
+        run: |
+          ( cd "$RUNNER_TEMP/blk/ci-block"  && phpunit )
+          ( cd "$RUNNER_TEMP/blk/ci-static" && phpunit )

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -588,6 +588,30 @@ docker compose --profile woocommerce up woocommerce-installer
 Bundled WooCommerce-ready FSE theme: `themes/flavian-shop/`.
 Defaults configurable via `.env`: `WC_INSTALL_SAMPLE_DATA`, `WC_DEFAULT_THEME`, `WC_DEFAULT_CURRENCY`, `WC_DEFAULT_COUNTRY`.
 
+**Gutenberg custom block scaffolding:**
+```bash
+# Slash command: /scaffold-block  (or pnpm run scaffold:block)
+# Generates a self-contained, activatable block plugin under plugins/<name>/
+# (no build step — runtime globals + index.asset.php deps).
+
+# Static block (save() serializes markup)
+bash scripts/scaffold-block.sh hero-card --namespace flavian \
+  --attributes "heading:string:Welcome,centered:boolean:true"
+
+# Dynamic block (server-rendered render.php)
+bash scripts/scaffold-block.sh latest-events --namespace flavian \
+  --attributes "count:number:3" --dynamic
+
+# Full E2E smoke test (scaffold → activate → render; needs the Docker stack)
+docker compose up -d wordpress db
+bash scripts/smoke-block.sh            # or: pnpm run smoke:block
+```
+Inputs: block name (positional), `--namespace`, `--attributes "name:type[:default]"`
+(types: string, number, boolean, array, object), `--dynamic`.
+Outputs: `block.json`, `index.js` (edit+save), `index.asset.php`, styles,
+`render.php` (dynamic only), a PHPUnit stub, and `phpunit.xml.dist`.
+Full guide: `docs/blocks/README.md`. Tests: `tests/unit/scaffold-block.bats`.
+
 **Visual QA & Quality Scripts:**
 ```bash
 ./scripts/visual-diff.js [actual] [expected]     # Pixel-level screenshot comparison

--- a/docs/blocks/README.md
+++ b/docs/blocks/README.md
@@ -1,0 +1,181 @@
+# Gutenberg Custom Block Scaffolding
+
+Generate a complete, **activatable** custom Gutenberg block with one command.
+The generator emits a self-contained block plugin under `plugins/<block-name>/`
+that works the moment it's activated — **no build step required**.
+
+> Milestone: **v2.0.0 — Gutenberg custom block scaffolding.**
+
+- Slash command: `/scaffold-block`
+- Script: `scripts/scaffold-block.sh`
+- pnpm: `pnpm run scaffold:block`
+- Smoke test: `scripts/smoke-block.sh` (`pnpm run smoke:block`)
+
+---
+
+## Quick start
+
+```bash
+# Static block (markup serialized by save())
+bash scripts/scaffold-block.sh hero-card \
+  --namespace flavian \
+  --attributes "heading:string:Welcome,subheading:string,centered:boolean:true"
+
+# Dynamic block (server-rendered via render.php)
+bash scripts/scaffold-block.sh latest-events \
+  --namespace flavian \
+  --attributes "count:number:3,showImage:boolean:true" \
+  --dynamic
+
+# Preview only — write nothing
+bash scripts/scaffold-block.sh hero-card --attributes "heading:string" --dry-run
+```
+
+Via pnpm (note the `--` so pnpm forwards the flags):
+
+```bash
+pnpm run scaffold:block hero-card -- --namespace flavian --attributes "heading:string"
+```
+
+---
+
+## Inputs
+
+| Input | Flag | Required | Default | Notes |
+|-------|------|----------|---------|-------|
+| Block name | *(positional)* | ✅ | — | kebab-case slug, e.g. `pricing-table`. Becomes the plugin dir + block slug. |
+| Namespace | `--namespace` | — | `flavian` | block.json `name` is `<namespace>/<block-name>`. |
+| Attributes | `--attributes` | — | *(none)* | Comma-separated `name:type[:default]`. See below. |
+| Render mode | `--dynamic` / `--static` | — | `--static` | `--dynamic` adds `render.php` and a `"render"` field in block.json. |
+| Title | `--title` | — | title-cased name | Human-readable block title. |
+| Description | `--description` | — | placeholder | block.json + plugin header description. |
+| Category | `--category` | — | `widgets` | Block inserter category. |
+| Icon | `--icon` | — | `block-default` | Dashicon name. |
+| Keywords | `--keywords` | — | block name | Comma-separated inserter keywords. |
+| Text domain | `--text-domain` | — | block slug | i18n text domain. |
+| Author | `--author` | — | `git config user.name` | Plugin header author. |
+| PHP namespace | `--php-namespace` | — | `<Namespace>\Blocks\<Class>` | `@package` tag + test namespace. |
+| Version | `--version` | — | `0.1.0` | block.json + asset version. |
+| Destination | `--dest` | — | `plugins` | Parent dir for the generated plugin. |
+| — | `--force` | — | — | Overwrite an existing target directory. |
+| — | `--dry-run` | — | — | Print the plan/files, write nothing. |
+
+### Attribute spec
+
+`--attributes "name:type[:default]"`, comma-separated. Supported types and how
+each is wired into the generated code:
+
+| Type | block.json default | Editor control (index.js) | Static `save()` | Dynamic `render.php` |
+|------|--------------------|---------------------------|-----------------|----------------------|
+| `string` | `""` | `TextControl` | `<p>` with value | escaped `<p>` |
+| `number` | `0` | numeric `TextControl` | `<p>` with value | escaped `<p>` |
+| `boolean` | `false` | `ToggleControl` | conditional `<p>` | `if ( ! empty(...) )` block |
+| `array` | `[]` | *(edit in code)* | *(skipped)* | placeholder comment |
+| `object` | `{}` | *(edit in code)* | *(skipped)* | placeholder comment |
+
+Defaults are optional. Examples: `heading:string`, `count:number:3`,
+`featured:boolean:true`, `items:array`.
+
+> Attribute **names** should be valid identifiers (camelCase recommended), since
+> they become JavaScript object keys and PHP array keys.
+
+---
+
+## Outputs
+
+```
+plugins/<block-name>/
+├── <block-name>.php                  # Plugin header + register_block_type()
+├── blocks/<block-name>/
+│   ├── block.json                    # Metadata, attributes, supports
+│   ├── index.js                      # edit() + save() — runtime globals, no build
+│   ├── index.asset.php               # Script dependencies + version
+│   ├── editor.css                    # Editor-only styles
+│   ├── style.css                     # Front-end styles
+│   └── render.php                    # Dynamic render callback (--dynamic only)
+├── tests/
+│   ├── <BlockClass>Test.php          # PHPUnit stub
+│   └── bootstrap.php                 # Lightweight WP function stubs
+├── phpunit.xml.dist
+└── README.md
+```
+
+### Why no build step?
+
+`index.js` references the WordPress runtime globals (`wp.blocks`, `wp.element`,
+`wp.blockEditor`, `wp.components`, `wp.i18n`) directly, and `index.asset.php`
+declares those packages as dependencies so WordPress enqueues them in the right
+order. This mirrors the reference plugin's `featured-event` block and means the
+output is activatable immediately — no `npm install`, no webpack. If you later
+want JSX/ESM, swap in `@wordpress/scripts` and point `editorScript` at the
+build output.
+
+### Static vs dynamic
+
+- **Static** (default): `save()` serializes attribute values into the post
+  content. Attributes without a `source` persist in the block delimiter comment,
+  so they round-trip even when not present in the saved markup.
+- **Dynamic** (`--dynamic`): `save()` returns `null` and WordPress renders the
+  block on every request via `render.php` (declared through the `"render"` field
+  in block.json). Use this when output depends on server state (recent posts,
+  the current user, options).
+
+---
+
+## Smoke test
+
+`scripts/smoke-block.sh` runs the full acceptance path against the project's
+Docker WordPress stack: **scaffold → validate assets → activate → assert the
+block is registered → render it on a throwaway page**.
+
+```bash
+# Start the stack (if not already running)
+docker compose up -d wordpress db
+
+# Run the smoke test (defaults: block "smoke-callout", namespace "flavian")
+bash scripts/smoke-block.sh
+# or: pnpm run smoke:block
+
+# Inspect the artifacts instead of cleaning them up
+bash scripts/smoke-block.sh my-block --namespace acme --keep
+```
+
+Expected tail:
+
+```
+─── Smoke summary: 8 passed, 0 failed ───
+```
+
+The script cleans up after itself (deactivates the plugin, deletes the test
+page, removes `plugins/<block>/`) unless you pass `--keep`.
+
+---
+
+## Manual verification
+
+```bash
+# 1. Scaffold
+bash scripts/scaffold-block.sh pricing-table --namespace acme \
+  --attributes "heading:string:Our Plans,count:number:3,featured:boolean" --dynamic
+
+# 2. Run the generated PHPUnit stub (needs phpunit on PATH or in the container)
+( cd plugins/pricing-table && phpunit )
+
+# 3. Activate and confirm registration
+wp plugin activate pricing-table
+wp eval 'var_dump( WP_Block_Type_Registry::get_instance()->is_registered( "acme/pricing-table" ) );'
+
+# 4. Insert the block in the editor (search "Pricing Table") and view the page.
+```
+
+---
+
+## Related
+
+- `scripts/scaffold-plugin.sh` — scaffold a full plugin (CPT, taxonomy, settings
+  page, and a block) when you need more than a single block.
+- `.claude/templates/plugin/` — reference plugin templates, including the
+  `featured-event` dynamic block this generator's conventions follow.
+- `tests/unit/scaffold-block.bats` — structural tests for the generator output.
+- CLAUDE.md → *File Location Requirements* — why blocks live under root-level
+  `plugins/`, not `wp-content/plugins/`.

--- a/package.json
+++ b/package.json
@@ -39,7 +39,9 @@
     "lint:commits:last": "commitlint --from=HEAD~1 --to=HEAD",
     "test:visual": "pnpm visual:diff",
     "test:lighthouse": "pnpm lighthouse:run",
-    "playwright:install": "playwright install --with-deps chromium"
+    "playwright:install": "playwright install --with-deps chromium",
+    "scaffold:block": "bash scripts/scaffold-block.sh",
+    "smoke:block": "bash scripts/smoke-block.sh"
   },
   "devDependencies": {
     "@clack/prompts": "^0.7.0",

--- a/scripts/scaffold-block.sh
+++ b/scripts/scaffold-block.sh
@@ -1,0 +1,874 @@
+#!/usr/bin/env bash
+# scripts/scaffold-block.sh
+#
+# Generate a self-contained, activatable Gutenberg custom block plugin under
+# plugins/<block>/ (no build step required — uses the WordPress runtime
+# globals declared in index.asset.php).
+#
+# Usage:
+#   bash scripts/scaffold-block.sh <block-name> [options]
+#
+# Inputs (per the v2.0.0 "Gutenberg custom block scaffolding" milestone):
+#   <block-name>                 Block slug (kebab-case). Positional, required.
+#   --namespace "vendor"         Block namespace → block.json "name" is
+#                                "<namespace>/<block-name>". Default: flavian
+#   --attributes "spec"          Supported attributes, comma-separated, each
+#                                "name:type[:default]". Types: string, number,
+#                                boolean, array, object.
+#                                e.g. "heading:string:Hello,count:number:3,featured:boolean"
+#
+# Options:
+#   --dynamic                    Generate a server-side render callback
+#                                (blocks/<block>/render.php). Default: static.
+#   --title "Human Title"        Default: title-cased block name.
+#   --description "What it is"    Default: placeholder text.
+#   --category "widgets"         Block category. Default: widgets.
+#   --icon "block-default"       Dashicon name. Default: block-default.
+#   --keywords "a,b,c"           Search keywords. Default: block name.
+#   --text-domain "slug"         i18n text domain. Default: block slug.
+#   --author "Name"              Default: git user.name or "Anonymous".
+#   --php-namespace "Vendor\\X"  PHP @package. Default: <Namespace>\Blocks\<Class>.
+#   --version "0.1.0"            Default: 0.1.0.
+#   --dest "plugins"             Parent directory for the generated plugin.
+#                                Default: plugins (repo root-level convention).
+#   --force                      Overwrite an existing target directory.
+#   --dry-run                    Print the plan/files but write nothing.
+#   -h, --help                   Show this help.
+#
+# Outputs (plugins/<block>/):
+#   <block>.php                       Plugin header + register_block_type()
+#   blocks/<block>/block.json         Block metadata + attributes + supports
+#   blocks/<block>/index.js           edit() + save() (no build, runtime globals)
+#   blocks/<block>/index.asset.php    Script dependencies + version
+#   blocks/<block>/editor.css         Editor-only styles
+#   blocks/<block>/style.css          Front-end styles
+#   blocks/<block>/render.php         Dynamic render callback (--dynamic only)
+#   tests/<Class>Test.php             PHPUnit test stub
+#   tests/bootstrap.php               Lightweight WP function stubs for tests
+#   phpunit.xml.dist                  PHPUnit config
+#   README.md                         Usage + smoke-test notes
+#
+# Exit codes: 0 = success, 1 = validation/IO error, 2 = bad usage.
+
+set -euo pipefail
+
+PROJECT_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+
+# --- Defaults ---
+BLOCK_SLUG=""
+NAMESPACE="flavian"
+ATTR_SPEC=""
+DYNAMIC=0
+TITLE=""
+DESCRIPTION=""
+CATEGORY="widgets"
+ICON="block-default"
+KEYWORDS=""
+TEXT_DOMAIN=""
+AUTHOR=""
+PHP_NAMESPACE=""
+VERSION="0.1.0"
+DEST="plugins"
+FORCE=0
+DRY_RUN=0
+
+usage() {
+  sed -n '2,/^$/p' "$0" | sed 's/^# \{0,1\}//'
+  exit "${1:-2}"
+}
+
+die() {
+  printf '\xe2\x9c\x97 %s\n' "$*" >&2
+  exit 1
+}
+
+# --- Argument parsing ---
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --namespace)     NAMESPACE="$2"; shift 2 ;;
+    --attributes)    ATTR_SPEC="$2"; shift 2 ;;
+    --dynamic)       DYNAMIC=1; shift ;;
+    --static)        DYNAMIC=0; shift ;;
+    --title)         TITLE="$2"; shift 2 ;;
+    --description)   DESCRIPTION="$2"; shift 2 ;;
+    --category)      CATEGORY="$2"; shift 2 ;;
+    --icon)          ICON="$2"; shift 2 ;;
+    --keywords)      KEYWORDS="$2"; shift 2 ;;
+    --text-domain)   TEXT_DOMAIN="$2"; shift 2 ;;
+    --author)        AUTHOR="$2"; shift 2 ;;
+    --php-namespace) PHP_NAMESPACE="$2"; shift 2 ;;
+    --version)       VERSION="$2"; shift 2 ;;
+    --dest)          DEST="$2"; shift 2 ;;
+    --force)         FORCE=1; shift ;;
+    --dry-run)       DRY_RUN=1; shift ;;
+    -h|--help)       usage 0 ;;
+    --*)             die "Unknown flag: $1" ;;
+    *)
+      if [ -z "$BLOCK_SLUG" ]; then BLOCK_SLUG="$1"; shift
+      else die "Unexpected positional arg: $1"
+      fi
+      ;;
+  esac
+done
+
+[ -n "$BLOCK_SLUG" ] || usage 2
+
+# --- Slug + namespace validation ---
+if ! [[ "$BLOCK_SLUG" =~ ^[a-z][a-z0-9-]*$ ]]; then
+  die "Invalid block name '$BLOCK_SLUG'. Must match ^[a-z][a-z0-9-]*\$ (lowercase, digits, hyphens; start with a letter)."
+fi
+if ! [[ "$NAMESPACE" =~ ^[a-z][a-z0-9-]*$ ]]; then
+  die "Invalid namespace '$NAMESPACE'. Must match ^[a-z][a-z0-9-]*\$ (block.json names allow lowercase, digits, hyphens)."
+fi
+
+# --- Helpers ---
+# 'pricing-table' → 'PricingTable'
+slug_to_pascal() {
+  local s="$1" out="" p
+  IFS='-' read -ra parts <<< "$s"
+  for p in "${parts[@]}"; do
+    out+="$(printf '%s' "${p:0:1}" | tr '[:lower:]' '[:upper:]')${p:1}"
+  done
+  printf '%s' "$out"
+}
+
+# 'pricing-table' → 'Pricing Table' ; 'showImage' → 'Show Image'
+humanize() {
+  printf '%s' "$1" \
+    | sed -E 's/([a-z0-9])([A-Z])/\1 \2/g; s/[-_]+/ /g' \
+    | sed -E 's/\b(.)/\U\1/g'
+}
+
+# Escape sed *replacement* special chars: backslash, ampersand, delimiter '|'.
+sed_escape() {
+  printf '%s' "$1" | sed -e 's/[\\&|]/\\&/g'
+}
+
+# Replace a token line in $2 with the multiline content in env var SNIP.
+inject_multiline() {
+  local token="$1" file="$2" tmp
+  tmp="$(mktemp)"
+  TOKEN="$token" awk '
+    BEGIN { t = ENVIRON["TOKEN"]; s = ENVIRON["SNIP"] }
+    index($0, t) { printf "%s\n", s; next }
+    { print }
+  ' "$file" > "$tmp"
+  mv "$tmp" "$file"
+}
+
+# --- Derive identifiers ---
+BLOCK_CLASS="$(slug_to_pascal "$BLOCK_SLUG")"
+NAMESPACE_PASCAL="$(slug_to_pascal "$NAMESPACE")"
+CSS_BASE="wp-block-${NAMESPACE}-${BLOCK_SLUG}"   # WP wrapper class
+PLUGIN_SLUG="$BLOCK_SLUG"
+
+[ -n "$TITLE" ]       || TITLE="$(humanize "$BLOCK_SLUG")"
+[ -n "$DESCRIPTION" ] || DESCRIPTION="A custom block scaffolded with scripts/scaffold-block.sh."
+[ -n "$TEXT_DOMAIN" ] || TEXT_DOMAIN="$BLOCK_SLUG"
+[ -n "$KEYWORDS" ]    || KEYWORDS="$BLOCK_SLUG"
+[ -n "$PHP_NAMESPACE" ] || PHP_NAMESPACE="${NAMESPACE_PASCAL}\\Blocks\\${BLOCK_CLASS}"
+PLUGIN_NAME="$TITLE"
+if [ -z "$AUTHOR" ]; then
+  AUTHOR="$(git -C "$PROJECT_ROOT" config user.name 2>/dev/null || true)"
+  [ -n "$AUTHOR" ] || AUTHOR="Anonymous"
+fi
+
+# Resolve dest (absolute or relative to repo root)
+case "$DEST" in
+  /*) DEST_DIR="$DEST" ;;
+  *)  DEST_DIR="$PROJECT_ROOT/$DEST" ;;
+esac
+TARGET_DIR="$DEST_DIR/$PLUGIN_SLUG"
+BLOCK_DIR="$TARGET_DIR/blocks/$BLOCK_SLUG"
+
+# --- Parse attributes into parallel arrays ---
+ATTR_NAMES=()
+ATTR_TYPES=()
+ATTR_DEFAULTS=()      # JSON-encoded default, "" sentinel means "unset → empty"
+VALID_TYPES="string number boolean array object"
+
+if [ -n "$ATTR_SPEC" ]; then
+  IFS=',' read -ra _specs <<< "$ATTR_SPEC"
+  for spec in "${_specs[@]}"; do
+    spec="$(printf '%s' "$spec" | sed -E 's/^[[:space:]]+//; s/[[:space:]]+$//')"
+    [ -n "$spec" ] || continue
+    aname="${spec%%:*}"
+    if [ "$aname" = "$spec" ]; then
+      atype="string"; araw=""
+    else
+      rest="${spec#*:}"
+      atype="${rest%%:*}"
+      if [ "$atype" = "$rest" ]; then araw=""; else araw="${rest#*:}"; fi
+    fi
+    if ! [[ "$aname" =~ ^[a-zA-Z_][a-zA-Z0-9_]*$ ]]; then
+      die "Invalid attribute name '$aname'. Use a valid identifier (letters, digits, underscore; camelCase recommended)."
+    fi
+    case " $VALID_TYPES " in
+      *" $atype "*) ;;
+      *) die "Invalid attribute type '$atype' for '$aname'. Allowed: $VALID_TYPES." ;;
+    esac
+    # JSON-encode the default by type.
+    case "$atype" in
+      string)
+        if [ -n "$araw" ]; then adef="\"$(printf '%s' "$araw" | sed 's/"/\\"/g')\""; else adef="\"\""; fi ;;
+      number)
+        if [ -n "$araw" ]; then
+          [[ "$araw" =~ ^-?[0-9]+(\.[0-9]+)?$ ]] || die "Default for number attribute '$aname' must be numeric, got '$araw'."
+          adef="$araw"
+        else adef="0"; fi ;;
+      boolean)
+        case "$araw" in
+          ""|false|0) adef="false" ;;
+          true|1)     adef="true" ;;
+          *) die "Default for boolean attribute '$aname' must be true/false, got '$araw'." ;;
+        esac ;;
+      array)  adef="[]" ;;
+      object) adef="{}" ;;
+    esac
+    ATTR_NAMES+=("$aname")
+    ATTR_TYPES+=("$atype")
+    ATTR_DEFAULTS+=("$adef")
+  done
+fi
+ATTR_COUNT=${#ATTR_NAMES[@]}
+
+# --- Pre-flight ---
+[ -d "$DEST_DIR" ] || { [ "$DRY_RUN" -eq 1 ] || mkdir -p "$DEST_DIR"; }
+if [ -e "$TARGET_DIR" ]; then
+  if [ "$FORCE" -eq 1 ]; then
+    [ "$DRY_RUN" -eq 1 ] || rm -rf "$TARGET_DIR"
+  else
+    die "$TARGET_DIR already exists. Re-run with --force to overwrite."
+  fi
+fi
+
+# --- Build JSON keywords array ---
+build_json_array() {
+  local csv="$1" out="[" first=1 item
+  IFS=',' read -ra _items <<< "$csv"
+  for item in "${_items[@]}"; do
+    item="$(printf '%s' "$item" | sed -E 's/^[[:space:]]+//; s/[[:space:]]+$//')"
+    [ -n "$item" ] || continue
+    [ "$first" -eq 1 ] || out+=", "
+    out+="\"$(printf '%s' "$item" | sed 's/"/\\"/g')\""
+    first=0
+  done
+  out+="]"
+  printf '%s' "$out"
+}
+KEYWORDS_JSON="$(build_json_array "$KEYWORDS")"
+
+# ===========================================================================
+# Snippet generators (produce multiline strings; no trailing newline)
+# ===========================================================================
+
+# Emits the full '    "attributes": { ... },' line(s) so the surrounding key
+# prefix survives the whole-line inject_multiline replacement.
+gen_attributes_block() {
+  if [ "$ATTR_COUNT" -eq 0 ]; then printf '    "attributes": {},'; return; fi
+  local i body="" sep=""
+  for ((i=0; i<ATTR_COUNT; i++)); do
+    body+="${sep}        \"${ATTR_NAMES[$i]}\": {
+            \"type\": \"${ATTR_TYPES[$i]}\",
+            \"default\": ${ATTR_DEFAULTS[$i]}
+        }"
+    sep=",
+"
+  done
+  printf '    "attributes": {\n%s\n    },' "$body"
+}
+
+gen_edit_controls() {
+  if [ "$ATTR_COUNT" -eq 0 ]; then
+    printf "\t\t\t\t\t\tel( 'p', null, __( 'This block has no editable settings.', '%s' ) )" "$TEXT_DOMAIN"
+    return
+  fi
+  local i name type label out="" sep="" has=0
+  for ((i=0; i<ATTR_COUNT; i++)); do
+    name="${ATTR_NAMES[$i]}"; type="${ATTR_TYPES[$i]}"; label="$(humanize "$name")"
+    case "$type" in
+      string)
+        out+="${sep}\t\t\t\t\t\tel( TextControl, {
+\t\t\t\t\t\t\tlabel: __( '${label}', '${TEXT_DOMAIN}' ),
+\t\t\t\t\t\t\tvalue: attributes.${name},
+\t\t\t\t\t\t\tonChange: function ( value ) {
+\t\t\t\t\t\t\t\tsetAttributes( { ${name}: value } );
+\t\t\t\t\t\t\t},
+\t\t\t\t\t\t} )"
+        sep=",\n"; has=1 ;;
+      number)
+        out+="${sep}\t\t\t\t\t\tel( TextControl, {
+\t\t\t\t\t\t\tlabel: __( '${label}', '${TEXT_DOMAIN}' ),
+\t\t\t\t\t\t\ttype: 'number',
+\t\t\t\t\t\t\tvalue: String( attributes.${name} ),
+\t\t\t\t\t\t\tonChange: function ( value ) {
+\t\t\t\t\t\t\t\tsetAttributes( { ${name}: parseFloat( value ) || 0 } );
+\t\t\t\t\t\t\t},
+\t\t\t\t\t\t} )"
+        sep=",\n"; has=1 ;;
+      boolean)
+        out+="${sep}\t\t\t\t\t\tel( ToggleControl, {
+\t\t\t\t\t\t\tlabel: __( '${label}', '${TEXT_DOMAIN}' ),
+\t\t\t\t\t\t\tchecked: !! attributes.${name},
+\t\t\t\t\t\t\tonChange: function ( value ) {
+\t\t\t\t\t\t\t\tsetAttributes( { ${name}: value } );
+\t\t\t\t\t\t\t},
+\t\t\t\t\t\t} )"
+        sep=",\n"; has=1 ;;
+      *) : ;; # array/object: no auto control
+    esac
+  done
+  if [ "$has" -eq 0 ]; then
+    printf "\t\t\t\t\t\tel( 'p', null, __( 'Edit %s / %s attributes in code.', '%s' ) )" "array" "object" "$TEXT_DOMAIN"
+    return
+  fi
+  printf '%b' "$out"
+}
+
+# Emits the full '\t\tsave: <fn>' line so the 'save:' key survives the
+# whole-line inject_multiline replacement.
+gen_save_function() {
+  if [ "$DYNAMIC" -eq 1 ]; then
+    printf '\t\tsave: function () {\n\t\t\treturn null;\n\t\t}'
+    return
+  fi
+  # Static: serialize scalar attributes into markup.
+  local i name type out="" sep="" has=0
+  for ((i=0; i<ATTR_COUNT; i++)); do
+    name="${ATTR_NAMES[$i]}"; type="${ATTR_TYPES[$i]}"
+    case "$type" in
+      string|number)
+        out+="${sep}\t\t\t\tel( 'p', { className: '${CSS_BASE}__${name}' }, String( attributes.${name} ) )"
+        sep=",\n"; has=1 ;;
+      boolean)
+        out+="${sep}\t\t\t\tattributes.${name} ? el( 'p', { className: '${CSS_BASE}__${name}' }, '${name}' ) : null"
+        sep=",\n"; has=1 ;;
+      *) : ;;
+    esac
+  done
+  [ "$has" -eq 1 ] || out="\t\t\t\tnull"
+  printf '\t\tsave: function ( props ) {\n\t\t\tvar attributes = props.attributes;\n\t\t\tvar blockProps = useBlockProps.save();\n\t\t\treturn el(\n\t\t\t\t%bdiv%b,\n\t\t\t\tblockProps,\n%b\n\t\t\t);\n\t\t}' "'" "'" "$(printf '%b' "$out")"
+}
+
+gen_render_body() {
+  if [ "$ATTR_COUNT" -eq 0 ]; then
+    printf '\t<?php echo wp_kses_post( $content ); ?>'
+    return
+  fi
+  local i name type label out="" first=1
+  for ((i=0; i<ATTR_COUNT; i++)); do
+    name="${ATTR_NAMES[$i]}"; type="${ATTR_TYPES[$i]}"; label="$(humanize "$name")"
+    [ "$first" -eq 1 ] || out+="\n"
+    case "$type" in
+      string|number)
+        out+="\t<p class=\"${CSS_BASE}__${name}\"><?php echo esc_html( (string) ( \$attributes['${name}'] ?? '' ) ); ?></p>" ;;
+      boolean)
+        out+="\t<?php if ( ! empty( \$attributes['${name}'] ) ) : ?>\n\t\t<p class=\"${CSS_BASE}__${name}\"><?php esc_html_e( '${label}', '${TEXT_DOMAIN}' ); ?></p>\n\t<?php endif; ?>" ;;
+      *)
+        out+="\t<?php /* '${name}' (${type}) — render in code as needed. */ ?>" ;;
+    esac
+    first=0
+  done
+  printf '%b' "$out"
+}
+
+gen_test_attr_assertions() {
+  if [ "$ATTR_COUNT" -eq 0 ]; then
+    printf '\t\t$this->assertIsArray( $this->block_json()[%battributes%b] ?? array() );' "'" "'"
+    return
+  fi
+  local i out="" first=1
+  for ((i=0; i<ATTR_COUNT; i++)); do
+    [ "$first" -eq 1 ] || out+="\n"
+    out+="\t\t\$this->assertArrayHasKey( '${ATTR_NAMES[$i]}', \$attributes );"
+    first=0
+  done
+  printf '%b' "$out"
+}
+
+# Emits the closing '}' of the preceding method first (it shares the token's
+# line), then — for dynamic blocks only — the render test method.
+gen_test_render_method() {
+  if [ "$DYNAMIC" -eq 0 ]; then printf '\t}'; return; fi
+  local i sample="" name type val
+  for ((i=0; i<ATTR_COUNT; i++)); do
+    name="${ATTR_NAMES[$i]}"; type="${ATTR_TYPES[$i]}"
+    case "$type" in
+      string)  val="'Sample'" ;;
+      number)  val="1" ;;
+      boolean) val="true" ;;
+      array)   val="array()" ;;
+      object)  val="array()" ;;
+    esac
+    sample+="\t\t\t'${name}' => ${val},\n"
+  done
+  printf '\t}\n\n\t/**\n\t * The render template should emit the block wrapper element.\n\t *\n\t * @return void\n\t */\n\tpublic function test_render_emits_wrapper_markup(): void {\n\t\t$attributes = array(\n%b\t\t);\n\t\t$content = %b%b;\n\t\t$block   = null;\n\n\t\tob_start();\n\t\trequire dirname( __DIR__ ) . %b/blocks/%s/render.php%b;\n\t\t$html = (string) ob_get_clean();\n\n\t\t$this->assertStringContainsString( %b<div%b, $html );\n\t}' \
+    "$sample" "'" "'" "'" "$BLOCK_SLUG" "'" "'" "'"
+}
+
+# The block.json style/render line. Injected as a full-line replacement so the
+# (multiline) dynamic "render" field never has to pass through sed.
+if [ "$DYNAMIC" -eq 1 ]; then
+  RENDER_FIELD='    "style": "file:./style.css",
+    "render": "file:./render.php"'
+else
+  RENDER_FIELD='    "style": "file:./style.css"'
+fi
+
+# ===========================================================================
+# Plan output
+# ===========================================================================
+printf '\xe2\x96\xb8 Scaffolding block: %s/%s\n' "$NAMESPACE" "$BLOCK_SLUG"
+printf '  Title:        %s\n' "$TITLE"
+printf '  Mode:         %s\n' "$([ "$DYNAMIC" -eq 1 ] && echo 'dynamic (server-rendered)' || echo 'static (save markup)')"
+printf '  Attributes:   %d\n' "$ATTR_COUNT"
+printf '  PHP package:  %s\n' "$PHP_NAMESPACE"
+printf '  Text domain:  %s\n' "$TEXT_DOMAIN"
+printf '  Target:       %s\n' "$TARGET_DIR"
+[ "$DRY_RUN" -eq 1 ] && printf '  Dry-run:      yes\n'
+echo ""
+
+# List of files to be produced.
+FILES=(
+  "$PLUGIN_SLUG.php"
+  "blocks/$BLOCK_SLUG/block.json"
+  "blocks/$BLOCK_SLUG/index.js"
+  "blocks/$BLOCK_SLUG/index.asset.php"
+  "blocks/$BLOCK_SLUG/editor.css"
+  "blocks/$BLOCK_SLUG/style.css"
+)
+[ "$DYNAMIC" -eq 1 ] && FILES+=("blocks/$BLOCK_SLUG/render.php")
+FILES+=(
+  "tests/${BLOCK_CLASS}Test.php"
+  "tests/bootstrap.php"
+  "phpunit.xml.dist"
+  "README.md"
+)
+
+if [ "$DRY_RUN" -eq 1 ]; then
+  for f in "${FILES[@]}"; do printf '  + %s\n' "$f"; done
+  echo ""
+  printf '\xe2\x9c\x93 Dry run: would write %d files to %s\n' "${#FILES[@]}" "$TARGET_DIR"
+  exit 0
+fi
+
+mkdir -p "$BLOCK_DIR" "$TARGET_DIR/tests"
+
+# Apply all scalar token replacements to a file, in place.
+sub() {
+  local file="$1" tmp
+  tmp="$(mktemp)"
+  sed \
+    -e "s|{{NAMESPACE}}|$(sed_escape "$NAMESPACE")|g" \
+    -e "s|{{BLOCK_SLUG}}|$(sed_escape "$BLOCK_SLUG")|g" \
+    -e "s|{{BLOCK_CLASS}}|$(sed_escape "$BLOCK_CLASS")|g" \
+    -e "s|{{CSS_BASE}}|$(sed_escape "$CSS_BASE")|g" \
+    -e "s|{{TITLE}}|$(sed_escape "$TITLE")|g" \
+    -e "s|{{PLUGIN_NAME}}|$(sed_escape "$PLUGIN_NAME")|g" \
+    -e "s|{{DESCRIPTION}}|$(sed_escape "$DESCRIPTION")|g" \
+    -e "s|{{CATEGORY}}|$(sed_escape "$CATEGORY")|g" \
+    -e "s|{{ICON}}|$(sed_escape "$ICON")|g" \
+    -e "s|{{KEYWORDS_JSON}}|$(sed_escape "$KEYWORDS_JSON")|g" \
+    -e "s|{{TEXT_DOMAIN}}|$(sed_escape "$TEXT_DOMAIN")|g" \
+    -e "s|{{AUTHOR}}|$(sed_escape "$AUTHOR")|g" \
+    -e "s|{{VERSION}}|$(sed_escape "$VERSION")|g" \
+    -e "s|{{PHP_NAMESPACE}}|$(sed_escape "$PHP_NAMESPACE")|g" \
+    "$file" > "$tmp"
+  mv "$tmp" "$file"
+}
+
+# --- block.json ---
+cat > "$BLOCK_DIR/block.json" <<'TPL'
+{
+    "$schema": "https://schemas.wp.org/trunk/block.json",
+    "apiVersion": 3,
+    "name": "{{NAMESPACE}}/{{BLOCK_SLUG}}",
+    "version": "{{VERSION}}",
+    "title": "{{TITLE}}",
+    "category": "{{CATEGORY}}",
+    "icon": "{{ICON}}",
+    "description": "{{DESCRIPTION}}",
+    "keywords": {{KEYWORDS_JSON}},
+    "supports": {
+        "html": false,
+        "anchor": true
+    },
+    "textdomain": "{{TEXT_DOMAIN}}",
+{{ATTRIBUTES_BLOCK}}
+    "editorScript": "file:./index.js",
+    "editorStyle": "file:./editor.css",
+{{RENDER_FIELD}}
+}
+TPL
+SNIP="$(gen_attributes_block)" inject_multiline '{{ATTRIBUTES_BLOCK}}' "$BLOCK_DIR/block.json"
+SNIP="$RENDER_FIELD" inject_multiline '{{RENDER_FIELD}}' "$BLOCK_DIR/block.json"
+sub "$BLOCK_DIR/block.json"
+
+# --- index.js ---
+cat > "$BLOCK_DIR/index.js" <<'TPL'
+/* global window */
+/**
+ * Editor registration for the {{TITLE}} block.
+ *
+ * No build step: the dependencies declared in index.asset.php
+ * (wp-blocks, wp-element, wp-block-editor, wp-components, wp-i18n) guarantee
+ * the WordPress runtime globals are loaded before this script runs.
+ *
+ * @package {{PHP_NAMESPACE}}
+ */
+( function ( wp ) {
+	'use strict';
+
+	var blocks      = wp.blocks;
+	var element     = wp.element;
+	var blockEditor = wp.blockEditor;
+	var components  = wp.components;
+	var i18n        = wp.i18n;
+
+	var registerBlockType = blocks.registerBlockType;
+	var useBlockProps     = blockEditor.useBlockProps;
+	var InspectorControls = blockEditor.InspectorControls;
+	var PanelBody         = components.PanelBody;
+	var TextControl       = components.TextControl;
+	var ToggleControl     = components.ToggleControl;
+	var Fragment          = element.Fragment;
+	var el                = element.createElement;
+	var __                = i18n.__;
+
+	registerBlockType( '{{NAMESPACE}}/{{BLOCK_SLUG}}', {
+		edit: function ( props ) {
+			var attributes    = props.attributes;
+			var setAttributes = props.setAttributes;
+			var blockProps    = useBlockProps( { className: '{{CSS_BASE}}__editor' } );
+
+			return el(
+				Fragment,
+				null,
+				el(
+					InspectorControls,
+					null,
+					el(
+						PanelBody,
+						{ title: __( 'Settings', '{{TEXT_DOMAIN}}' ), initialOpen: true },
+{{EDIT_CONTROLS}}
+					)
+				),
+				el(
+					'div',
+					blockProps,
+					el( 'strong', null, __( '{{TITLE}}', '{{TEXT_DOMAIN}}' ) )
+				)
+			);
+		},
+{{SAVE_FUNCTION}}
+	} );
+}( window.wp ) );
+TPL
+SNIP="$(gen_edit_controls)" inject_multiline '{{EDIT_CONTROLS}}' "$BLOCK_DIR/index.js"
+SNIP="$(gen_save_function)" inject_multiline '{{SAVE_FUNCTION}}' "$BLOCK_DIR/index.js"
+sub "$BLOCK_DIR/index.js"
+
+# --- index.asset.php (script deps + version; lets WP enqueue wp-* packages) ---
+cat > "$BLOCK_DIR/index.asset.php" <<'TPL'
+<?php
+/**
+ * Script dependencies + version for the {{TITLE}} block editor script.
+ *
+ * Mirrors what @wordpress/scripts would emit, so the no-build index.js gets
+ * its WordPress package dependencies enqueued in the right order.
+ *
+ * @package {{PHP_NAMESPACE}}
+ */
+
+return array(
+	'dependencies' => array( 'wp-blocks', 'wp-element', 'wp-block-editor', 'wp-components', 'wp-i18n' ),
+	'version'      => '{{VERSION}}',
+);
+TPL
+sub "$BLOCK_DIR/index.asset.php"
+
+# --- editor.css ---
+cat > "$BLOCK_DIR/editor.css" <<'TPL'
+/* {{TITLE}} — editor-only styles */
+
+.{{CSS_BASE}}__editor {
+	padding: 1rem;
+	border: 1px dashed #c3c4c7;
+	border-radius: 4px;
+	background: #f6f7f7;
+	color: #50575e;
+}
+TPL
+sub "$BLOCK_DIR/editor.css"
+
+# --- style.css ---
+cat > "$BLOCK_DIR/style.css" <<'TPL'
+/* {{TITLE}} — front-end styles */
+
+.{{CSS_BASE}} {
+	padding: 1.5rem;
+	border: 1px solid #e0e0e0;
+	border-radius: 4px;
+	background: #fff;
+}
+TPL
+sub "$BLOCK_DIR/style.css"
+
+# --- render.php (dynamic only) ---
+if [ "$DYNAMIC" -eq 1 ]; then
+  cat > "$BLOCK_DIR/render.php" <<'TPL'
+<?php
+/**
+ * Server-side render for the {{TITLE}} block.
+ *
+ * Invoked by WordPress via the "render" field in block.json. These variables
+ * are in scope:
+ *   - array    $attributes Block attributes.
+ *   - string   $content    Inner block HTML.
+ *   - WP_Block $block      Block instance.
+ *
+ * @package {{PHP_NAMESPACE}}
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+$wrapper_attributes = get_block_wrapper_attributes();
+?>
+<div <?php echo wp_kses_data( $wrapper_attributes ); ?>>
+{{RENDER_BODY}}
+</div>
+TPL
+  SNIP="$(gen_render_body)" inject_multiline '{{RENDER_BODY}}' "$BLOCK_DIR/render.php"
+  sub "$BLOCK_DIR/render.php"
+fi
+
+# --- Plugin main file ---
+cat > "$TARGET_DIR/$PLUGIN_SLUG.php" <<'TPL'
+<?php
+/**
+ * Plugin Name:       {{PLUGIN_NAME}}
+ * Description:       {{DESCRIPTION}}
+ * Version:           {{VERSION}}
+ * Requires at least: 6.4
+ * Requires PHP:      8.0
+ * Author:            {{AUTHOR}}
+ * License:           GPL-2.0-or-later
+ * License URI:       https://www.gnu.org/licenses/gpl-2.0.html
+ * Text Domain:       {{TEXT_DOMAIN}}
+ *
+ * @package {{PHP_NAMESPACE}}
+ */
+
+declare( strict_types=1 );
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Register the {{TITLE}} block from its block.json metadata.
+ *
+ * register_block_type() reads block.json (attributes, scripts, styles and, for
+ * dynamic blocks, the render template), so no further wiring is required.
+ *
+ * @return void
+ */
+add_action(
+	'init',
+	static function (): void {
+		register_block_type( __DIR__ . '/blocks/{{BLOCK_SLUG}}' );
+	}
+);
+TPL
+sub "$TARGET_DIR/$PLUGIN_SLUG.php"
+
+# --- PHPUnit test stub ---
+cat > "$TARGET_DIR/tests/${BLOCK_CLASS}Test.php" <<'TPL'
+<?php
+/**
+ * Tests for the {{TITLE}} block.
+ *
+ * @package {{PHP_NAMESPACE}}\Tests
+ */
+
+declare( strict_types=1 );
+
+namespace {{PHP_NAMESPACE}}\Tests;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @coversNothing
+ */
+final class {{BLOCK_CLASS}}Test extends TestCase {
+
+	/**
+	 * Load and decode the block's block.json.
+	 *
+	 * @return array<string, mixed>
+	 */
+	private function block_json(): array {
+		$path = dirname( __DIR__ ) . '/blocks/{{BLOCK_SLUG}}/block.json';
+		$this->assertFileExists( $path );
+		$data = json_decode( (string) file_get_contents( $path ), true );
+		$this->assertIsArray( $data );
+		return $data;
+	}
+
+	/**
+	 * block.json should declare the namespaced block name.
+	 *
+	 * @return void
+	 */
+	public function test_block_json_declares_expected_name(): void {
+		$this->assertSame( '{{NAMESPACE}}/{{BLOCK_SLUG}}', $this->block_json()['name'] );
+	}
+
+	/**
+	 * block.json should declare every supported attribute.
+	 *
+	 * @return void
+	 */
+	public function test_block_json_declares_supported_attributes(): void {
+		$attributes = $this->block_json()['attributes'] ?? array();
+{{TEST_ATTR_ASSERTIONS}}
+	}{{TEST_RENDER_METHOD}}
+}
+TPL
+SNIP="$(gen_test_attr_assertions)" inject_multiline '{{TEST_ATTR_ASSERTIONS}}' "$TARGET_DIR/tests/${BLOCK_CLASS}Test.php"
+SNIP="$(gen_test_render_method)" inject_multiline '{{TEST_RENDER_METHOD}}' "$TARGET_DIR/tests/${BLOCK_CLASS}Test.php"
+sub "$TARGET_DIR/tests/${BLOCK_CLASS}Test.php"
+
+# --- Test bootstrap (lightweight WP stubs; no Composer needed) ---
+cat > "$TARGET_DIR/tests/bootstrap.php" <<'TPL'
+<?php
+/**
+ * Minimal PHPUnit bootstrap for the {{TITLE}} block.
+ *
+ * Stubs the handful of WordPress functions the render template touches so the
+ * test stub runs without a full WordPress test harness. Replace with the WP
+ * PHPUnit suite (or Brain Monkey) as the block grows.
+ *
+ * @package {{PHP_NAMESPACE}}\Tests
+ */
+
+declare( strict_types=1 );
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/' );
+}
+
+if ( ! function_exists( 'esc_html' ) ) {
+	function esc_html( $text ) {
+		return htmlspecialchars( (string) $text, ENT_QUOTES );
+	}
+}
+
+if ( ! function_exists( 'esc_html_e' ) ) {
+	function esc_html_e( $text, $domain = 'default' ) {
+		echo htmlspecialchars( (string) $text, ENT_QUOTES );
+	}
+}
+
+if ( ! function_exists( 'esc_attr' ) ) {
+	function esc_attr( $text ) {
+		return htmlspecialchars( (string) $text, ENT_QUOTES );
+	}
+}
+
+if ( ! function_exists( 'wp_kses_data' ) ) {
+	function wp_kses_data( $data ) {
+		return (string) $data;
+	}
+}
+
+if ( ! function_exists( 'wp_kses_post' ) ) {
+	function wp_kses_post( $data ) {
+		return (string) $data;
+	}
+}
+
+if ( ! function_exists( 'get_block_wrapper_attributes' ) ) {
+	function get_block_wrapper_attributes( $extra = array() ) {
+		return 'class="{{CSS_BASE}}"';
+	}
+}
+TPL
+sub "$TARGET_DIR/tests/bootstrap.php"
+
+# --- phpunit.xml.dist ---
+cat > "$TARGET_DIR/phpunit.xml.dist" <<'TPL'
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         bootstrap="tests/bootstrap.php"
+         colors="true"
+         failOnWarning="true"
+         failOnRisky="true">
+    <testsuites>
+        <testsuite name="{{TEXT_DOMAIN}}">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>
+TPL
+sub "$TARGET_DIR/phpunit.xml.dist"
+
+# --- README ---
+cat > "$TARGET_DIR/README.md" <<'TPL'
+# {{TITLE}}
+
+Custom Gutenberg block `{{NAMESPACE}}/{{BLOCK_SLUG}}`, scaffolded with
+`scripts/scaffold-block.sh`.
+
+## What's inside
+
+```
+{{BLOCK_SLUG}}/
+├── {{BLOCK_SLUG}}.php              # Plugin header + register_block_type()
+├── blocks/{{BLOCK_SLUG}}/
+│   ├── block.json                 # Metadata, attributes, supports
+│   ├── index.js                   # edit() + save() (no build step)
+│   ├── index.asset.php            # Script dependencies + version
+│   ├── editor.css                 # Editor-only styles
+│   ├── style.css                  # Front-end styles
+│   └── render.php                 # Dynamic render (dynamic blocks only)
+├── tests/
+│   ├── {{BLOCK_CLASS}}Test.php     # PHPUnit stub
+│   └── bootstrap.php              # Lightweight WP stubs
+├── phpunit.xml.dist
+└── README.md
+```
+
+No build step is required — `index.js` uses the WordPress runtime globals and
+`index.asset.php` declares the package dependencies.
+
+## Smoke test
+
+```bash
+# 1. Copy to a WordPress install (root-level → wp-content per CLAUDE.md)
+cp -r . /path/to/wordpress/wp-content/plugins/{{BLOCK_SLUG}}
+
+# 2. Activate
+wp plugin activate {{BLOCK_SLUG}}
+
+# 3. Confirm registration
+wp eval 'var_dump( WP_Block_Type_Registry::get_instance()->is_registered( "{{NAMESPACE}}/{{BLOCK_SLUG}}" ) );'
+
+# 4. Insert the block on a page and view it on the front end.
+```
+
+## Tests
+
+```bash
+phpunit            # uses phpunit.xml.dist
+```
+TPL
+sub "$TARGET_DIR/README.md"
+
+# --- Done ---
+echo ""
+printf '\xe2\x9c\x93 Wrote %d files to %s\n' "${#FILES[@]}" "$TARGET_DIR"
+printf '\nNext steps:\n'
+printf '  # Copy to your WordPress install and activate:\n'
+printf '  cp -r %s <wp>/wp-content/plugins/%s\n' "$TARGET_DIR" "$PLUGIN_SLUG"
+printf '  wp plugin activate %s\n' "$PLUGIN_SLUG"
+printf '  # Run the test stub:\n'
+printf '  ( cd %s && phpunit )\n' "$TARGET_DIR"

--- a/scripts/smoke-block.sh
+++ b/scripts/smoke-block.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+# scripts/smoke-block.sh
+#
+# End-to-end smoke test for the Gutenberg block scaffolder. Proves the full
+# acceptance path: scaffold a block → "build" (validate no-build assets) →
+# activate in WordPress → render it on a test page.
+#
+# Requires the project's Docker stack to be running:
+#   docker compose up -d wordpress db
+#
+# Usage:
+#   bash scripts/smoke-block.sh [block-name] [--namespace ns] [--keep]
+#
+# Defaults: block-name "smoke-callout", namespace "flavian".
+# --keep leaves the scaffolded plugin + test page in place for inspection.
+#
+# Exit codes: 0 = all checks passed, 1 = a check failed, 2 = bad usage / no stack.
+
+set -euo pipefail
+
+PROJECT_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$PROJECT_ROOT"
+
+BLOCK="smoke-callout"
+NAMESPACE="flavian"
+KEEP=0
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --namespace) NAMESPACE="$2"; shift 2 ;;
+    --keep)      KEEP=1; shift ;;
+    -h|--help)   sed -n '2,/^$/p' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+    --*)         echo "Unknown flag: $1" >&2; exit 2 ;;
+    *)           BLOCK="$1"; shift ;;
+  esac
+done
+
+FQ_NAME="${NAMESPACE}/${BLOCK}"
+PASS=0
+FAIL=0
+PAGE_ID=""
+
+# wp-cli inside the running container. -T disables TTY so it works in CI.
+wp() {
+  MSYS_NO_PATHCONV=1 docker compose exec -T wordpress wp --allow-root "$@"
+}
+
+step()  { printf '\n\xe2\x96\xb8 %s\n' "$*"; }
+ok()    { printf '  \xe2\x9c\x93 %s\n' "$*"; PASS=$((PASS+1)); }
+bad()   { printf '  \xe2\x9c\x97 %s\n' "$*" >&2; FAIL=$((FAIL+1)); }
+
+cleanup() {
+  [ "$KEEP" -eq 1 ] && { printf '\n(--keep) leaving plugins/%s and page %s in place\n' "$BLOCK" "$PAGE_ID"; return; }
+  step "Cleanup"
+  wp plugin deactivate "$BLOCK" >/dev/null 2>&1 || true
+  [ -n "$PAGE_ID" ] && wp post delete "$PAGE_ID" --force >/dev/null 2>&1 || true
+  rm -rf "$PROJECT_ROOT/plugins/$BLOCK"
+  printf '  removed plugins/%s and test page\n' "$BLOCK"
+}
+trap cleanup EXIT
+
+# --- Pre-flight: stack must be up ---
+if ! wp core version >/dev/null 2>&1; then
+  echo "✗ WordPress container not reachable. Start it with: docker compose up -d wordpress db" >&2
+  exit 2
+fi
+
+# --- 1. Scaffold ---
+step "Scaffold $FQ_NAME (dynamic) into plugins/"
+rm -rf "$PROJECT_ROOT/plugins/$BLOCK"
+bash scripts/scaffold-block.sh "$BLOCK" \
+  --namespace "$NAMESPACE" \
+  --title "Smoke Callout" \
+  --attributes "message:string:Hello from the scaffolder,highlight:boolean:true" \
+  --dynamic --force >/dev/null
+[ -f "$PROJECT_ROOT/plugins/$BLOCK/$BLOCK.php" ] && ok "plugin scaffolded" || bad "plugin file missing"
+
+# --- 2. "Build" (no build step — validate the no-build assets are coherent) ---
+step "Validate assets (no build step required)"
+node -e "JSON.parse(require('fs').readFileSync('plugins/$BLOCK/blocks/$BLOCK/block.json','utf8'))" \
+  && ok "block.json is valid JSON" || bad "block.json invalid"
+node --check "plugins/$BLOCK/blocks/$BLOCK/index.js" >/dev/null 2>&1 \
+  && ok "index.js parses" || bad "index.js syntax error"
+
+# --- 3. Activate ---
+step "Activate plugin in WordPress"
+if wp plugin activate "$BLOCK" >/dev/null 2>&1; then ok "plugin activated"; else bad "activation failed"; fi
+
+registered="$(wp eval "echo WP_Block_Type_Registry::get_instance()->is_registered( '$FQ_NAME' ) ? 'yes' : 'no';" 2>/dev/null || echo 'no')"
+[ "$registered" = "yes" ] && ok "block '$FQ_NAME' is registered" || bad "block not registered"
+
+# --- 4. Render on a test page ---
+step "Render the block on a test page"
+BLOCK_MARKUP="<!-- wp:${FQ_NAME} {\"message\":\"Hello from the scaffolder\",\"highlight\":true} /-->"
+PAGE_ID="$(wp post create --post_type=page --post_status=publish \
+  --post_title='Block Smoke Test' --post_content="$BLOCK_MARKUP" --porcelain 2>/dev/null || echo '')"
+[ -n "$PAGE_ID" ] && ok "created test page (ID $PAGE_ID)" || bad "could not create test page"
+
+if [ -n "$PAGE_ID" ]; then
+  rendered="$(wp eval "echo apply_filters( 'the_content', get_post( $PAGE_ID )->post_content );" 2>/dev/null || echo '')"
+  printf '  rendered HTML: %s\n' "$(printf '%s' "$rendered" | tr -d '\n' | sed -E 's/\s+/ /g' | cut -c1-200)"
+  if printf '%s' "$rendered" | grep -q "wp-block-${NAMESPACE}-${BLOCK}"; then
+    ok "front-end render contains the block wrapper class"
+  else
+    bad "rendered output missing block wrapper class"
+  fi
+  if printf '%s' "$rendered" | grep -q "Hello from the scaffolder"; then
+    ok "front-end render contains the attribute value"
+  else
+    bad "rendered output missing attribute value"
+  fi
+fi
+
+# --- Summary ---
+printf '\n\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80 Smoke summary: %d passed, %d failed \xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\n' "$PASS" "$FAIL"
+[ "$FAIL" -eq 0 ]

--- a/tests/unit/scaffold-block.bats
+++ b/tests/unit/scaffold-block.bats
@@ -1,0 +1,146 @@
+#!/usr/bin/env bats
+# Structural tests for scripts/scaffold-block.sh — the Gutenberg custom block
+# scaffolder (v2.0.0 milestone). These exercise the generator's output without
+# Docker or a WordPress install; the full activate/render path lives in
+# scripts/smoke-block.sh.
+
+load '../test_helper'
+
+SCRIPT="${PROJECT_ROOT}/scripts/scaffold-block.sh"
+
+# Scaffold into the per-test temp dir. Usage: scaffold <name> [extra args...]
+scaffold() {
+    local name="$1"; shift
+    bash "$SCRIPT" "$name" --dest "$TEST_TEMP_DIR" "$@"
+}
+
+# --- Generator sanity ---
+
+@test "scaffold-block.sh exists and is executable-ish (parses)" {
+    [ -f "$SCRIPT" ]
+    run bash -n "$SCRIPT"
+    [ "$status" -eq 0 ]
+}
+
+@test "no positional block name → usage error (exit 2)" {
+    run bash "$SCRIPT"
+    [ "$status" -eq 2 ]
+}
+
+@test "invalid block name is rejected" {
+    run scaffold "Bad_Name"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"Invalid block name"* ]]
+}
+
+@test "invalid attribute type is rejected" {
+    run scaffold "thing" --attributes "x:notatype"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"Invalid attribute type"* ]]
+}
+
+@test "--dry-run writes nothing" {
+    run scaffold "ghost" --attributes "a:string" --dry-run
+    [ "$status" -eq 0 ]
+    [ ! -d "${TEST_TEMP_DIR}/ghost" ]
+    [[ "$output" == *"Dry run"* ]]
+}
+
+# --- Dynamic block ---
+
+@test "dynamic: generates the full file set including render.php" {
+    run scaffold "pricing-table" --namespace acme \
+        --attributes "heading:string:Plans,count:number:3,featured:boolean" --dynamic
+    [ "$status" -eq 0 ]
+    local b="${TEST_TEMP_DIR}/pricing-table"
+    [ -f "${b}/pricing-table.php" ]
+    [ -f "${b}/blocks/pricing-table/block.json" ]
+    [ -f "${b}/blocks/pricing-table/index.js" ]
+    [ -f "${b}/blocks/pricing-table/index.asset.php" ]
+    [ -f "${b}/blocks/pricing-table/editor.css" ]
+    [ -f "${b}/blocks/pricing-table/style.css" ]
+    [ -f "${b}/blocks/pricing-table/render.php" ]
+    [ -f "${b}/tests/PricingTableTest.php" ]
+    [ -f "${b}/tests/bootstrap.php" ]
+    [ -f "${b}/phpunit.xml.dist" ]
+    [ -f "${b}/README.md" ]
+}
+
+@test "dynamic: block.json is valid JSON with namespaced name and attributes" {
+    scaffold "pricing-table" --namespace acme \
+        --attributes "heading:string:Plans,count:number:3,featured:boolean" --dynamic
+    local json="${TEST_TEMP_DIR}/pricing-table/blocks/pricing-table/block.json"
+    run node -e "
+        const d = JSON.parse(require('fs').readFileSync('${json}','utf8'));
+        if (d.name !== 'acme/pricing-table') { console.error('bad name', d.name); process.exit(1); }
+        for (const k of ['heading','count','featured']) {
+            if (!d.attributes || !(k in d.attributes)) { console.error('missing attr', k); process.exit(1); }
+        }
+        if (d.render !== 'file:./render.php') { console.error('missing render field'); process.exit(1); }
+        if (d.attributes.count.type !== 'number') { console.error('bad type'); process.exit(1); }
+        if (d.attributes.heading.default !== 'Plans') { console.error('bad default'); process.exit(1); }
+        console.log('ok');
+    "
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"ok"* ]]
+}
+
+@test "dynamic: index.js parses and save() returns null" {
+    scaffold "pricing-table" --namespace acme --attributes "heading:string" --dynamic
+    local js="${TEST_TEMP_DIR}/pricing-table/blocks/pricing-table/index.js"
+    run node --check "$js"
+    [ "$status" -eq 0 ]
+    grep -q "registerBlockType( 'acme/pricing-table'" "$js"
+    grep -Eq "save:[[:space:]]*function[[:space:]]*\(\)" "$js"
+}
+
+@test "dynamic: render.php references attributes and plugin registers the block dir" {
+    scaffold "pricing-table" --namespace acme --attributes "heading:string" --dynamic
+    local b="${TEST_TEMP_DIR}/pricing-table"
+    grep -q "get_block_wrapper_attributes" "${b}/blocks/pricing-table/render.php"
+    grep -q "\$attributes\['heading'\]" "${b}/blocks/pricing-table/render.php"
+    grep -q "register_block_type( __DIR__ . '/blocks/pricing-table' )" "${b}/pricing-table.php"
+}
+
+@test "dynamic: PHPUnit stub declares a render test" {
+    scaffold "pricing-table" --namespace acme --attributes "heading:string" --dynamic
+    grep -q "function test_render_emits_wrapper_markup" \
+        "${TEST_TEMP_DIR}/pricing-table/tests/PricingTableTest.php"
+}
+
+# --- Static block ---
+
+@test "static: omits render.php and serializes attributes in save()" {
+    run scaffold "callout" --namespace flavian --attributes "message:string:Hi,dismissible:boolean"
+    [ "$status" -eq 0 ]
+    local b="${TEST_TEMP_DIR}/callout"
+    [ ! -f "${b}/blocks/callout/render.php" ]
+    # block.json must not declare a render field
+    run node -e "
+        const d = JSON.parse(require('fs').readFileSync('${b}/blocks/callout/block.json','utf8'));
+        process.exit(d.render === undefined ? 0 : 1);
+    "
+    [ "$status" -eq 0 ]
+    # save() must emit markup, not null
+    grep -q "useBlockProps.save()" "${b}/blocks/callout/index.js"
+    grep -q "wp-block-flavian-callout__message" "${b}/blocks/callout/index.js"
+}
+
+@test "no attributes: still valid, empty attributes object" {
+    run scaffold "plain"
+    [ "$status" -eq 0 ]
+    run node -e "
+        const d = JSON.parse(require('fs').readFileSync('${TEST_TEMP_DIR}/plain/blocks/plain/block.json','utf8'));
+        process.exit(typeof d.attributes === 'object' ? 0 : 1);
+    "
+    [ "$status" -eq 0 ]
+}
+
+@test "--force overwrites an existing block, without it errors" {
+    scaffold "dup" --attributes "a:string"
+    run scaffold "dup" --attributes "a:string"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"already exists"* ]]
+    run scaffold "dup" --attributes "a:string" --force
+    [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
## Summary

Ships the **v2.0.0 "Gutenberg custom block scaffolding"** milestone: a generator that turns a block name + namespace + attribute spec into a complete, **immediately activatable** custom block plugin — with **no build step** required.

`scripts/scaffold-block.sh` emits a self-contained plugin under `plugins/<name>/`. The generated `index.js` uses the WordPress runtime globals and `index.asset.php` declares the package dependencies, mirroring the existing `featured-event` reference block.

## Acceptance criteria

- [x] **Slash command `/scaffold-block` (or `pnpm run scaffold:block`)** accepts: block name, namespace, supported attributes
- [x] **Generates `block.json`, edit + save JS, optional dynamic render callback** (`--dynamic` → `render.php` + `"render"` field)
- [x] **Generates a PHPUnit test stub** (+ `tests/bootstrap.php`, `phpunit.xml.dist`)
- [x] **Documented under `docs/blocks/`**
- [x] **Smoke test: scaffold a block, build, activate, render on a test page** (`scripts/smoke-block.sh`)

## Inputs

| Input | Flag | Notes |
|-------|------|-------|
| Block name | positional | kebab-case; becomes plugin dir + block slug |
| Namespace | `--namespace` | block.json `name` = `<namespace>/<block-name>` |
| Attributes | `--attributes "name:type[:default]"` | types: string, number, boolean, array, object |
| Render mode | `--dynamic` / `--static` | dynamic adds `render.php` |

Plus `--title/--description/--category/--icon/--keywords/--text-domain/--php-namespace/--version/--dest/--force/--dry-run`.

## Outputs

```
plugins/<block-name>/
├── <block-name>.php              # plugin header + register_block_type()
├── blocks/<block-name>/
│   ├── block.json                # metadata, attributes, supports
│   ├── index.js                  # edit() + save() — no build step
│   ├── index.asset.php           # script dependencies + version
│   ├── editor.css / style.css
│   └── render.php                # dynamic only
├── tests/<Class>Test.php + bootstrap.php
├── phpunit.xml.dist
└── README.md
```

## Verification (actually run)

- **Full WP E2E smoke test: 8/8 passed** against the live Docker stack — block registered (`flavian/smoke-callout`) and rendered on a real page with the correct wrapper class + attribute value, then cleaned up.
- **PHPUnit**: dynamic stub 3 tests/10 assertions ✓; static stub 2 tests/7 assertions ✓ (render template executes via bootstrap stubs).
- **bats: 13/13 passed** (run on Linux; local Windows bats has an unrelated CRLF/`load` quirk that doesn't affect CI).
- `php -l`, `node --check`, and JSON validation clean.

## Also included

- `/scaffold-block` slash command + `pnpm run scaffold:block` / `pnpm run smoke:block`
- `.github/workflows/block-validation.yml` — bats job + PHP lint/PHPUnit job (static & dynamic)
- CLAUDE.md quick-reference entry

## Test plan

```bash
# Structural tests
./tests/libs/bats-core/bin/bats tests/unit/scaffold-block.bats

# Full E2E
docker compose up -d wordpress db
pnpm run smoke:block
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)