### PR TITLE
feat(init): add --multisite flag to the project init wizard

### DIFF
--- a/docs/CLI-WIZARD.md
+++ b/docs/CLI-WIZARD.md
@@ -27,6 +27,7 @@ node scripts/init.mjs
 | Site title | Title-cased slug | Human-readable, used in `.env` and `theme.json` |
 | Theme starter | (you pick) | See below |
 | WooCommerce support | `no` | Hidden when starter = `flavian-shop` (auto-enabled) |
+| Multisite network | `no` | When `yes`, also asks for the mode (subdirectory / subdomain) |
 | Local dev port | `8080` | 1024–65535 |
 | Admin email | `git config user.email` | Falls back to `admin@example.com` |
 
@@ -46,6 +47,8 @@ node scripts/init.mjs
 --name <slug>        Project slug
 --theme <starter>    blank | flavian-shop | figma | indesign
 --woo                Enable WooCommerce (auto-true for flavian-shop)
+--multisite          Configure a WordPress multisite network
+--multisite-mode <m> subdirectory | subdomain (default subdirectory; requires --multisite)
 --port <n>           Local dev port (default 8080)
 --email <addr>       Admin email
 --no-git             Skip git init
@@ -63,7 +66,54 @@ node scripts/init.mjs --yes --name=acme-shop --theme=flavian-shop
 
 # Stage a Figma-driven project
 node scripts/init.mjs --yes --name=marketing-site --theme=figma
+
+# Configure a multisite network (subdirectory mode)
+pnpm run init -- --yes --multisite --name=my-network
+
+# …or subdomain mode
+pnpm run init -- --yes --multisite --multisite-mode=subdomain --name=my-network
 ```
+
+## Multisite
+
+`--multisite` doesn't convert WordPress on its own — consistent with the rest of the
+wizard, it only writes configuration. The conversion runs later, against a booted
+container. What the flag adds to `.env`:
+
+| Key | Value | Notes |
+|---|---|---|
+| `WP_MULTISITE` | `true` | `false` on non-multisite runs |
+| `WP_MULTISITE_MODE` | `subdirectory` \| `subdomain` | From `--multisite-mode` (default `subdirectory`) |
+| `MS_NETWORK_TITLE` | your site title | e.g. `--name=my-network` → `My Network` |
+
+The existing `MS_SECOND_SITE_*` defaults in `.env.example` (used by the sample
+sub-site) are left untouched.
+
+### Building the network
+
+Once the config is written, `./wordpress-local.sh install` is multisite-aware: it
+reads `WP_MULTISITE` / `WP_MULTISITE_MODE` from `.env` and runs
+`wp core multisite-install` (adding `--subdomains` for subdomain mode) instead of a
+single-site install. It also writes the mode-specific multisite `.htaccess` (so
+sub-site URLs resolve on the Apache image) and honours `WP_PORT` for the admin URL.
+
+```bash
+docker compose up -d            # boot WordPress + db
+./wordpress-local.sh install    # builds the network from .env
+open http://localhost:8080/wp-admin/network/
+```
+
+The `docker compose --profile multisite up multisite-installer` profile is an
+alternative path that converts an already-installed single site (subdirectory mode
+only — see `docs/multisite/README.md`).
+
+### Subdomain mode caveat
+
+Subdomain multisite (`blog2.localhost`) needs the request to reach WordPress with the
+right `Host` header, which means wildcard DNS for `*.localhost` (a per-site
+`/etc/hosts` entry, or `dnsmasq`). The wizard writes the config and
+`wordpress-local.sh install` passes `--subdomains`, but you must set up local DNS
+yourself. See [docs/multisite/README.md](multisite/README.md#why-subdomain-mode-isnt-shipped).
 
 ## What gets written
 
@@ -72,6 +122,7 @@ A successful run produces:
 ```
 <project>/
 ├── .env                  ← from .env.example, with your values
+│                            (includes WP_MULTISITE / WP_MULTISITE_MODE when --multisite)
 ├── themes/<slug>/        ← scaffolded theme (skipped for figma/indesign)
 ├── docs/NEXT-STEPS.md    ← only for figma/indesign starters
 └── .git/                 ← fresh repo, one commit (unless --no-git)

--- a/scripts/init.mjs
+++ b/scripts/init.mjs
@@ -15,6 +15,8 @@ Options:
   --name <slug>         Project slug
   --theme <starter>     blank | flavian-shop | figma | indesign
   --woo                 Enable WooCommerce
+  --multisite           Configure a WordPress multisite network
+  --multisite-mode <m>  subdirectory | subdomain (default subdirectory)
   --port <n>            Local dev port (default 8080)
   --email <addr>        Admin email
   --no-git              Skip git init
@@ -38,6 +40,8 @@ async function main() {
         name:   { type: 'string' },
         theme:  { type: 'string' },
         woo:    { type: 'boolean' },
+        multisite: { type: 'boolean' },
+        'multisite-mode': { type: 'string' },
         port:   { type: 'string' },
         email:  { type: 'string' },
         'no-git': { type: 'boolean' },
@@ -59,19 +63,31 @@ async function main() {
     process.exit(2);
   }
 
+  if (parsed.values['multisite-mode'] != null && !parsed.values.multisite) {
+    console.error('Error: --multisite-mode requires --multisite');
+    process.exit(2);
+  }
+
   const targetDir = process.cwd();
   const env = { cwdBasename: basename(targetDir), gitEmail: await getGitEmail() };
 
   let config;
   if (parsed.values.yes) {
-    config = resolveDefaults({
-      name: parsed.values.name,
-      theme: parsed.values.theme,
-      woo: parsed.values.woo,
-      port: flagPort,
-      email: parsed.values.email,
-      noGit: parsed.values['no-git'],
-    }, env);
+    try {
+      config = resolveDefaults({
+        name: parsed.values.name,
+        theme: parsed.values.theme,
+        woo: parsed.values.woo,
+        multisite: parsed.values.multisite,
+        multisiteMode: parsed.values['multisite-mode'],
+        port: flagPort,
+        email: parsed.values.email,
+        noGit: parsed.values['no-git'],
+      }, env);
+    } catch (err) {
+      console.error(`Error: ${err.message}`);
+      process.exit(2);
+    }
   } else {
     const { runPrompts } = await import('./init/prompts.mjs');
     config = await runPrompts(env);
@@ -85,6 +101,13 @@ async function main() {
     process.exit(1);
   }
 
+  const multisiteSteps = config.multisite ? `
+Multisite (${config.multisiteMode}) is configured in .env. To build the network:
+  ./wordpress-local.sh install   # runs wp core multisite-install in ${config.multisiteMode} mode
+  open http://localhost:${config.port}/wp-admin/network/${config.multisiteMode === 'subdomain' ? `
+  ⚠ subdomain mode needs wildcard DNS for *.localhost — see docs/multisite/README.md` : ''}
+` : '';
+
   console.log(`
 ✓ Project ready at ${targetDir}
 
@@ -93,10 +116,10 @@ Next steps:
   cp .env.example .env       # already done — review values
   docker compose up -d        # boot WordPress at http://localhost:${config.port}
   open http://localhost:${config.port}/wp-admin
-
+${multisiteSteps}
 Resources:
   - Theme:   themes/${config.projectName}/
-  - Docs:    CLAUDE.md, docs/QUICK-START.md
+  - Docs:    CLAUDE.md, docs/QUICK-START.md, docs/CLI-WIZARD.md
   - Skills:  .claude/skills/README.md
 `);
 }

--- a/scripts/init/default-resolver.mjs
+++ b/scripts/init/default-resolver.mjs
@@ -1,6 +1,7 @@
 import { slugify, titleCase } from './slugify.mjs';
 
 const VALID_THEMES = ['blank', 'flavian-shop', 'figma', 'indesign'];
+const VALID_MULTISITE_MODES = ['subdirectory', 'subdomain'];
 
 export function resolveDefaults(flags, env) {
   const projectName = flags.name
@@ -14,11 +15,19 @@ export function resolveDefaults(flags, env) {
 
   const woocommerce = themeStarter === 'flavian-shop' ? true : Boolean(flags.woo);
 
+  const multisite = Boolean(flags.multisite);
+  const multisiteMode = flags.multisiteMode ?? 'subdirectory';
+  if (!VALID_MULTISITE_MODES.includes(multisiteMode)) {
+    throw new Error(`Unknown multisite mode: ${multisiteMode} (expected one of ${VALID_MULTISITE_MODES.join(', ')})`);
+  }
+
   return {
     projectName,
     siteTitle: flags.title ?? titleCase(projectName),
     themeStarter,
     woocommerce,
+    multisite,
+    multisiteMode,
     port: Number.isInteger(flags.port) ? flags.port : 8080,
     adminEmail: flags.email ?? env.gitEmail ?? 'admin@example.com',
     initGit: !flags.noGit,

--- a/scripts/init/generators/env.mjs
+++ b/scripts/init/generators/env.mjs
@@ -17,7 +17,15 @@ export async function writeEnv(targetDir, config) {
     WP_SITE_TITLE: config.siteTitle,
     WP_PORT: String(config.port),
     WC_DEFAULT_THEME: config.projectName,
+    WP_MULTISITE: String(Boolean(config.multisite)),
   };
+
+  // Only commit a multisite mode and network title when multisite is enabled;
+  // otherwise leave the .env.example defaults (e.g. MS_NETWORK_TITLE) untouched.
+  if (config.multisite) {
+    overrides.WP_MULTISITE_MODE = config.multisiteMode ?? 'subdirectory';
+    overrides.MS_NETWORK_TITLE = config.siteTitle;
+  }
 
   const seen = new Set();
   const out = lines.map(line => {

--- a/scripts/init/prompts.mjs
+++ b/scripts/init/prompts.mjs
@@ -44,6 +44,23 @@ export async function runPrompts({ cwdBasename, gitEmail }) {
     }));
   }
 
+  const multisite = abortIfCancelled(await confirm({
+    message: 'Configure a WordPress multisite network?',
+    initialValue: false,
+  }));
+
+  let multisiteMode = 'subdirectory';
+  if (multisite) {
+    multisiteMode = abortIfCancelled(await select({
+      message: 'Multisite mode',
+      options: [
+        { value: 'subdirectory', label: 'Subdirectory (site.test/blog2) — works out of the box' },
+        { value: 'subdomain',    label: 'Subdomain (blog2.site.test) — needs wildcard DNS locally' },
+      ],
+      initialValue: 'subdirectory',
+    }));
+  }
+
   const port = abortIfCancelled(await text({
     message: 'Local dev port',
     placeholder: '8080',
@@ -73,6 +90,8 @@ export async function runPrompts({ cwdBasename, gitEmail }) {
     siteTitle,
     themeStarter,
     woocommerce,
+    multisite,
+    multisiteMode,
     port: Number(port),
     adminEmail,
     initGit: true,

--- a/tests/init/integration/smoke.test.mjs
+++ b/tests/init/integration/smoke.test.mjs
@@ -47,6 +47,58 @@ test('flavian-shop theme — copies shop and rewrites headers', async (t) => {
   assert.match(style, /Text Domain: smoke-shop/);
 });
 
+test('multisite — --yes --multisite --name=my-network produces a multisite .env', async (t) => {
+  const dir = await stageFixture();
+  t.after(() => rm(dir, { recursive: true, force: true }));
+
+  const { stdout } = await exec('node', ['scripts/init.mjs', '--yes', '--no-git',
+    '--multisite', '--name=my-network', '--theme=blank'], { cwd: dir });
+
+  assert.match(stdout, /Multisite \(subdirectory\) is configured/);
+
+  const env = await readFile(join(dir, '.env'), 'utf8');
+  assert.match(env, /WP_MULTISITE=true/);
+  assert.match(env, /WP_MULTISITE_MODE=subdirectory/);
+  assert.match(env, /MS_NETWORK_TITLE=My Network/);
+
+  // The theme is still scaffolded alongside the multisite config.
+  await access(join(dir, 'themes/my-network/style.css'), constants.F_OK);
+});
+
+test('multisite — subdomain mode writes .env and warns about wildcard DNS', async (t) => {
+  const dir = await stageFixture();
+  t.after(() => rm(dir, { recursive: true, force: true }));
+
+  const { stdout } = await exec('node', ['scripts/init.mjs', '--yes', '--no-git', '--multisite',
+    '--multisite-mode=subdomain', '--name=net-sub', '--theme=blank'], { cwd: dir });
+
+  const env = await readFile(join(dir, '.env'), 'utf8');
+  assert.match(env, /WP_MULTISITE_MODE=subdomain/);
+  assert.match(stdout, /wildcard DNS for \*\.localhost/);
+});
+
+test('multisite — --multisite-mode without --multisite is rejected (exit 2)', async (t) => {
+  const dir = await stageFixture();
+  t.after(() => rm(dir, { recursive: true, force: true }));
+
+  await assert.rejects(
+    () => exec('node', ['scripts/init.mjs', '--yes', '--no-git',
+      '--multisite-mode=subdomain', '--name=x'], { cwd: dir }),
+    { code: 2 }
+  );
+});
+
+test('multisite — an unknown --multisite-mode value exits cleanly (exit 2)', async (t) => {
+  const dir = await stageFixture();
+  t.after(() => rm(dir, { recursive: true, force: true }));
+
+  await assert.rejects(
+    () => exec('node', ['scripts/init.mjs', '--yes', '--no-git',
+      '--multisite', '--multisite-mode=sideways', '--name=x'], { cwd: dir }),
+    (err) => err.code === 2 && /multisite mode/i.test(err.stderr)
+  );
+});
+
 test('figma placeholder — writes NEXT-STEPS.md, no theme dir', async (t) => {
   const dir = await stageFixture();
   t.after(() => rm(dir, { recursive: true, force: true }));

--- a/tests/init/unit/default-resolver.test.mjs
+++ b/tests/init/unit/default-resolver.test.mjs
@@ -47,3 +47,32 @@ test('invalid theme value throws', () => {
     /unknown theme/i
   );
 });
+
+test('multisite defaults to false', () => {
+  const cfg = resolveDefaults({}, { cwdBasename: 'x', gitEmail: null });
+  assert.equal(cfg.multisite, false);
+});
+
+test('--multisite enables multisite in subdirectory mode by default', () => {
+  const cfg = resolveDefaults({ multisite: true }, { cwdBasename: 'x', gitEmail: null });
+  assert.equal(cfg.multisite, true);
+  assert.equal(cfg.multisiteMode, 'subdirectory');
+});
+
+test('--multisite-mode=subdomain is honoured', () => {
+  const cfg = resolveDefaults(
+    { multisite: true, multisiteMode: 'subdomain' },
+    { cwdBasename: 'x', gitEmail: null }
+  );
+  assert.equal(cfg.multisiteMode, 'subdomain');
+});
+
+test('invalid multisite mode throws', () => {
+  assert.throws(
+    () => resolveDefaults(
+      { multisite: true, multisiteMode: 'sideways' },
+      { cwdBasename: 'x', gitEmail: null }
+    ),
+    /multisite mode/i
+  );
+});

--- a/tests/init/unit/env-generator.test.mjs
+++ b/tests/init/unit/env-generator.test.mjs
@@ -31,6 +31,61 @@ test('writes .env with substituted values', async (t) => {
   assert.match(env, /WP_SITE_TITLE=My Shop/);
 });
 
+test('non-multisite run writes WP_MULTISITE=false and leaves MS_NETWORK_TITLE default', async (t) => {
+  const dir = await mkdtemp(join(tmpdir(), 'env-'));
+  t.after(() => rm(dir, { recursive: true, force: true }));
+
+  await writeFile(join(dir, '.env.example'), [
+    'WORDPRESS_DB_NAME=wordpress',
+    'MS_NETWORK_TITLE=Flavian Network',
+  ].join('\n'));
+
+  await writeEnv(dir, {
+    projectName: 'plain', siteTitle: 'Plain', adminEmail: 'a@b.c',
+    port: 8080, themeStarter: 'blank', multisite: false, multisiteMode: 'subdirectory',
+  });
+
+  const env = await readFile(join(dir, '.env'), 'utf8');
+  assert.match(env, /WP_MULTISITE=false/);
+  assert.doesNotMatch(env, /WP_MULTISITE_MODE=/);
+  assert.match(env, /MS_NETWORK_TITLE=Flavian Network/);
+});
+
+test('multisite run writes WP_MULTISITE, mode, and network title from siteTitle', async (t) => {
+  const dir = await mkdtemp(join(tmpdir(), 'env-'));
+  t.after(() => rm(dir, { recursive: true, force: true }));
+
+  await writeFile(join(dir, '.env.example'), [
+    'WORDPRESS_DB_NAME=wordpress',
+    'MS_NETWORK_TITLE=Flavian Network',
+  ].join('\n'));
+
+  await writeEnv(dir, {
+    projectName: 'my-network', siteTitle: 'My Network', adminEmail: 'a@b.c',
+    port: 8080, themeStarter: 'blank', multisite: true, multisiteMode: 'subdirectory',
+  });
+
+  const env = await readFile(join(dir, '.env'), 'utf8');
+  assert.match(env, /WP_MULTISITE=true/);
+  assert.match(env, /WP_MULTISITE_MODE=subdirectory/);
+  assert.match(env, /MS_NETWORK_TITLE=My Network/);
+});
+
+test('multisite subdomain mode is recorded', async (t) => {
+  const dir = await mkdtemp(join(tmpdir(), 'env-'));
+  t.after(() => rm(dir, { recursive: true, force: true }));
+
+  await writeFile(join(dir, '.env.example'), 'WORDPRESS_DB_NAME=wordpress\n');
+
+  await writeEnv(dir, {
+    projectName: 'net', siteTitle: 'Net', adminEmail: 'a@b.c',
+    port: 8080, themeStarter: 'blank', multisite: true, multisiteMode: 'subdomain',
+  });
+
+  const env = await readFile(join(dir, '.env'), 'utf8');
+  assert.match(env, /WP_MULTISITE_MODE=subdomain/);
+});
+
 test('throws if .env.example missing', async (t) => {
   const dir = await mkdtemp(join(tmpdir(), 'env-'));
   t.after(() => rm(dir, { recursive: true, force: true }));

--- a/wordpress-local.sh
+++ b/wordpress-local.sh
@@ -7,6 +7,28 @@ set -e
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "$SCRIPT_DIR"
 
+# --- .env-aware configuration -------------------------------------------------
+# This script runs on the host, so it reads settings straight from .env. We parse
+# line-by-line rather than `source`-ing the file: generated .env values (e.g.
+# WP_SITE_TITLE=My Network) are unquoted and may contain spaces, which would break
+# a naive `source`.
+ENV_FILE="$SCRIPT_DIR/.env"
+
+read_env() {
+    # read_env KEY [default] — echo KEY's value from .env, else the default.
+    local key="$1" default="${2:-}" val=""
+    if [ -f "$ENV_FILE" ]; then
+        val="$(grep -E "^${key}=" "$ENV_FILE" | tail -n 1 | cut -d= -f2-)"
+        val="${val%$'\r'}"   # strip trailing CR from CRLF-encoded files
+    fi
+    printf '%s' "${val:-$default}"
+}
+
+WP_PORT="$(read_env WP_PORT 8080)"
+SITE_URL="http://localhost:${WP_PORT}"
+WP_MULTISITE="$(read_env WP_MULTISITE false)"
+WP_MULTISITE_MODE="$(read_env WP_MULTISITE_MODE subdirectory)"
+
 # Colors for output
 GREEN='\033[0;32m'
 BLUE='\033[0;34m'
@@ -157,7 +179,7 @@ start() {
     print_success "WordPress is starting..."
     echo ""
     echo "Services will be available at:"
-    echo "  • WordPress:   http://localhost:8080"
+    echo "  • WordPress:   $SITE_URL"
     echo "  • phpMyAdmin:  http://localhost:8081"
     echo ""
     echo "Database credentials: (see .env file)"
@@ -221,15 +243,24 @@ install() {
     echo "Waiting for WordPress to be ready..."
     sleep 5
 
-    # Admin credentials (override via environment variables or .env)
-    local admin_user="${WP_ADMIN_USER:-admin}"
-    local admin_password="${WP_ADMIN_PASSWORD:-admin}"
-    local admin_email="${WP_ADMIN_EMAIL:-admin@example.com}"
+    # Admin credentials (override via environment variables, else .env, else defaults)
+    local admin_user="${WP_ADMIN_USER:-$(read_env WP_ADMIN_USER admin)}"
+    local admin_password="${WP_ADMIN_PASSWORD:-$(read_env WP_ADMIN_PASSWORD admin)}"
+    local admin_email="${WP_ADMIN_EMAIL:-$(read_env WP_ADMIN_EMAIL admin@example.com)}"
 
-    # Install WordPress
+    # Multisite is configured by the init wizard via WP_MULTISITE in .env.
+    if [ "$WP_MULTISITE" = "true" ]; then
+        install_multisite "$admin_user" "$admin_password" "$admin_email"
+        return
+    fi
+
+    local site_title
+    site_title="$(read_env WP_SITE_TITLE 'FSE Dev Site')"
+
+    # Install WordPress (single site)
     docker-compose exec wordpress wp core install \
-        --url="http://localhost:8080" \
-        --title="FSE Dev Site" \
+        --url="$SITE_URL" \
+        --title="$site_title" \
         --admin_user="$admin_user" \
         --admin_password="$admin_password" \
         --admin_email="$admin_email" \
@@ -239,9 +270,106 @@ install() {
     print_success "WordPress installed!"
     echo ""
     echo "Admin Login:"
-    echo "  • URL:      http://localhost:8080/wp-admin"
+    echo "  • URL:      $SITE_URL/wp-admin"
     echo "  • Username: $admin_user"
     echo "  • Password: $admin_password"
+}
+
+# Write the multisite-aware .htaccess into the container.
+# `wp core multisite-install` writes the network constants to wp-config.php but
+# never touches .htaccess — without the rewrite block, sub-site URLs 404 on the
+# Apache image. The two rule sets differ between subdirectory and subdomain mode.
+write_multisite_htaccess() {
+    print_header "Writing multisite .htaccess ($WP_MULTISITE_MODE)"
+
+    local htaccess
+    if [ "$WP_MULTISITE_MODE" = "subdomain" ]; then
+        htaccess="$(cat <<'HTACCESS'
+# BEGIN WordPress Multisite
+RewriteEngine On
+RewriteRule .* - [E=HTTP_AUTHORIZATION:%{HTTP:Authorization}]
+RewriteBase /
+RewriteRule ^index\.php$ - [L]
+
+# add a trailing slash to /wp-admin
+RewriteRule ^wp-admin$ wp-admin/ [R=301,L]
+
+RewriteCond %{REQUEST_FILENAME} -f [OR]
+RewriteCond %{REQUEST_FILENAME} -d
+RewriteRule ^ - [L]
+RewriteRule ^(wp-(content|admin|includes).*) $1 [L]
+RewriteRule ^(.*\.php)$ $1 [L]
+RewriteRule . index.php [L]
+# END WordPress Multisite
+HTACCESS
+)"
+    else
+        htaccess="$(cat <<'HTACCESS'
+# BEGIN WordPress Multisite
+RewriteEngine On
+RewriteRule .* - [E=HTTP_AUTHORIZATION:%{HTTP:Authorization}]
+RewriteBase /
+RewriteRule ^index\.php$ - [L]
+
+# add a trailing slash to /wp-admin
+RewriteRule ^([_0-9a-zA-Z-]+/)?wp-admin$ $1wp-admin/ [R=301,L]
+
+RewriteCond %{REQUEST_FILENAME} -f [OR]
+RewriteCond %{REQUEST_FILENAME} -d
+RewriteRule ^ - [L]
+RewriteRule ^([_0-9a-zA-Z-]+/)?(wp-(content|admin|includes).*) $2 [L]
+RewriteRule ^([_0-9a-zA-Z-]+/)?(.*\.php)$ $2 [L]
+RewriteRule . index.php [L]
+# END WordPress Multisite
+HTACCESS
+)"
+    fi
+
+    printf '%s\n' "$htaccess" | docker-compose exec -T wordpress tee /var/www/html/.htaccess >/dev/null
+    docker-compose exec -T wordpress chown www-data:www-data /var/www/html/.htaccess
+}
+
+# Install WordPress as a multisite network.
+# Mode (subdirectory|subdomain) comes from WP_MULTISITE_MODE in .env.
+install_multisite() {
+    local admin_user="$1" admin_password="$2" admin_email="$3"
+    local network_title subdomains_flag=""
+    network_title="$(read_env MS_NETWORK_TITLE "$(read_env WP_SITE_TITLE 'Flavian Network')")"
+
+    if [ "$WP_MULTISITE_MODE" = "subdomain" ]; then
+        subdomains_flag="--subdomains"
+    fi
+
+    print_header "Installing WordPress Multisite ($WP_MULTISITE_MODE)"
+
+    # `wp core multisite-install` installs WordPress and converts it to a network
+    # in one step. --subdomains selects subdomain mode; omitting it = subdirectory.
+    docker-compose exec wordpress wp core multisite-install \
+        --url="$SITE_URL" \
+        --title="$network_title" \
+        --admin_user="$admin_user" \
+        --admin_password="$admin_password" \
+        --admin_email="$admin_email" \
+        $subdomains_flag \
+        --skip-email \
+        --allow-root
+
+    write_multisite_htaccess
+
+    print_success "Multisite network installed!"
+    echo ""
+    echo "Network Admin:"
+    echo "  • URL:      $SITE_URL/wp-admin/network/"
+    echo "  • Username: $admin_user"
+    echo "  • Password: $admin_password"
+    echo ""
+    if [ "$WP_MULTISITE_MODE" = "subdomain" ]; then
+        print_warning "Subdomain mode needs wildcard DNS for *.localhost."
+        echo "  Add a hosts entry per sub-site (e.g. 127.0.0.1 site2.localhost) or use dnsmasq."
+        echo "  See docs/multisite/README.md."
+    else
+        echo "  Create sub-sites at: $SITE_URL/wp-admin/network/sites.php"
+    fi
 }
 
 # Activate a theme
@@ -269,7 +397,7 @@ activate_theme() {
     docker-compose exec wordpress wp theme activate "$theme_slug" --allow-root
 
     print_success "Theme '$theme_slug' activated!"
-    echo "View at: http://localhost:8080"
+    echo "View at: $SITE_URL"
 }
 
 # List themes
@@ -296,7 +424,7 @@ help() {
     echo "  restart            Restart WordPress"
     echo "  logs               Show WordPress logs (Ctrl+C to exit)"
     echo "  status             Show container status"
-    echo "  install            Install WordPress (first-time setup)"
+    echo "  install            Install WordPress (first-time setup; multisite-aware)"
     echo "  activate-theme     Activate a theme"
     echo "  list-themes        List all themes"
     echo "  shell              Open shell in WordPress container"
@@ -313,7 +441,11 @@ help() {
     echo "  2. ./wordpress-local.sh start"
     echo "  3. ./wordpress-local.sh install"
     echo "  4. ./wordpress-local.sh activate-theme your-theme"
-    echo "  5. Open http://localhost:8080"
+    echo "  5. Open $SITE_URL"
+    echo ""
+    echo "Multisite:"
+    echo "  Set WP_MULTISITE=true (and WP_MULTISITE_MODE=subdirectory|subdomain) in .env"
+    echo "  — 'pnpm run init -- --multisite' does this — then run 'install' to build the network."
 }
 
 # Main command router


### PR DESCRIPTION
## What & why

Gives v2.0.0's multi-site scaffolding goal a concrete entry point: `pnpm run init` can now configure a WordPress multisite network up front.

Consistent with the rest of the wizard, `--multisite` only writes configuration — it never boots Docker. The actual network conversion runs later against a running container via the now multisite-aware `wordpress-local.sh install`.

## Acceptance criteria

- [x] `pnpm run init -- --yes --multisite --name=my-network` produces a working WP multisite config (`.env` carries `WP_MULTISITE=true`, `WP_MULTISITE_MODE`, and `MS_NETWORK_TITLE` from the site title)
- [x] `wordpress-local.sh` understands multisite (subdomain vs subdir) — `install` runs `wp core multisite-install` (+`--subdomains` for subdomain mode) and writes the matching multisite `.htaccess` so sub-sites resolve on the Apache image
- [x] Docs added to `docs/CLI-WIZARD.md`
- [x] Init wizard test covers the multisite branch

## CLI surface

```
--multisite           Configure a WordPress multisite network
--multisite-mode <m>  subdirectory | subdomain (default subdirectory; requires --multisite)
```

Interactive mode gains a matching "Configure a multisite network?" confirm + mode select.

## Notable design points

- **Config-only init** keeps the wizard hermetic (no Docker in tests), matching its existing architecture.
- **`wordpress-local.sh` now reads `.env`** via a line-based `read_env` helper (generated `.env` values are unquoted and contain spaces, so `source` would break) and finally honours `WP_PORT` for all user-facing URLs.
- **Mode-aware `.htaccess`** — `wp core multisite-install` writes wp-config constants but not `.htaccess`; without the rewrite block, subdirectory sub-sites 404. The install step now writes the subdirectory/subdomain rule set (subdirectory block matches `scripts/wordpress-install/setup-multisite.sh`).
- **Subdomain mode** still needs wildcard DNS for `*.localhost`; documented with a pointer to `docs/multisite/README.md`.

## Test plan

```
pnpm run test:init        # 50/50 pass
bash -n wordpress-local.sh
```

New tests: resolver defaults/enable/mode/invalid-throws; env-generator true/false/subdomain; integration smoke for the exact acceptance command, both flag guards (exit 2), and the subdomain wildcard-DNS warning.

Closes #83

🤖 Generated with [Claude Code](https://claude.com/claude-code)
