### PR TITLE
feat(init): non-interactive Canva flags for the setup wizard

### DIFF
--- a/.github/workflows/init-wizard.yml
+++ b/.github/workflows/init-wizard.yml
@@ -5,7 +5,9 @@ on:
     paths:
       - 'scripts/init.mjs'
       - 'scripts/init/**'
+      - 'scripts/canva-fse/**'
       - 'tests/init/**'
+      - 'tests/fixtures/canva/**'
       - '.claude/templates/theme/**'
       - 'package.json'
       - 'pnpm-lock.yaml'
@@ -14,7 +16,9 @@ on:
     paths:
       - 'scripts/init.mjs'
       - 'scripts/init/**'
+      - 'scripts/canva-fse/**'
       - 'tests/init/**'
+      - 'tests/fixtures/canva/**'
       - '.claude/templates/theme/**'
       - 'package.json'
       - 'pnpm-lock.yaml'

--- a/docs/CLI-WIZARD.md
+++ b/docs/CLI-WIZARD.md
@@ -37,6 +37,7 @@ node scripts/init.mjs
 |---|---|
 | `blank` | Minimal FSE theme copied from `.claude/templates/theme/` with your slug/title substituted |
 | `flavian-shop` | The bundled WooCommerce-ready theme, copied and renamed to your slug |
+| `canva` | A **working** FSE theme converted from a Canva HTML/CSS export (requires `--canva-export`). See [Canva starter](#canva-starter) |
 | `figma` | No theme generated. Writes `docs/NEXT-STEPS.md` pointing at the `figma-to-fse-autonomous-workflow` skill |
 | `indesign` | Placeholder only — the InDesign-to-FSE pipeline is not yet implemented |
 
@@ -45,7 +46,9 @@ node scripts/init.mjs
 ```
 --yes                Skip prompts, use defaults / flag values
 --name <slug>        Project slug
---theme <starter>    blank | flavian-shop | figma | indesign
+--theme <starter>    blank | flavian-shop | canva | figma | indesign
+--canva              Shorthand for --theme=canva (requires --canva-export)
+--canva-export <dir> Canva HTML/CSS export directory (required for the canva starter)
 --woo                Enable WooCommerce (auto-true for flavian-shop)
 --multisite          Configure a WordPress multisite network
 --multisite-mode <m> subdirectory | subdomain (default subdirectory; requires --multisite)
@@ -67,12 +70,54 @@ node scripts/init.mjs --yes --name=acme-shop --theme=flavian-shop
 # Stage a Figma-driven project
 node scripts/init.mjs --yes --name=marketing-site --theme=figma
 
+# Convert a Canva export into a working theme (no prompts)
+pnpm run init -- --yes --canva --canva-export=path/to/export --name=landing
+
 # Configure a multisite network (subdirectory mode)
 pnpm run init -- --yes --multisite --name=my-network
 
 # …or subdomain mode
 pnpm run init -- --yes --multisite --multisite-mode=subdomain --name=my-network
 ```
+
+## Canva starter
+
+Unlike `figma` (which only stages a `NEXT-STEPS.md`), the `canva` starter produces a
+**working FSE theme** from a Canva HTML/CSS export, so CI and scripted setups can run
+it with no prompts:
+
+```bash
+pnpm run init -- --yes --canva --canva-export=path/to/export --name=landing
+```
+
+`--canva` is shorthand for `--theme=canva`; either form works, and both require
+`--canva-export=<dir>`. The export directory must contain at least one `.css` and one
+`.html` file (the wizard prefers `style.css` / `index.html` when present). The path is
+resolved relative to where you run the wizard.
+
+What the wizard generates in `themes/<slug>/`:
+
+1. A valid blank FSE base scaffold (`theme.json`, `style.css`, `templates/`, `parts/`,
+   `functions.php`) with your slug/title substituted.
+2. **Design tokens** — `scripts/canva-fse/parse-canva-export.sh` extracts colors,
+   font families, font sizes, and spacing from the CSS and merges them into
+   `theme.json`. The lightest/darkest extracted colors are wired to the default
+   background/text, and the first font family becomes the body font.
+3. **Content** — `scripts/canva-fse/convert-html-to-blocks.sh` converts the export's
+   HTML to block markup, written to `patterns/canva-content.php` and referenced from
+   `templates/front-page.html`. This keeps the theme **pattern-first**: PHP and images
+   live in the pattern, never in the `.html` template.
+4. Referenced images are copied into `themes/<slug>/assets/`.
+
+This is a **deterministic baseline** — the same pieces the `canva-fse-converter` agent
+starts from. For a production-quality pass (layout, semantics, responsiveness), point
+Claude Code at your export directory ("Convert this Canva export to a WordPress
+theme"), which runs the `canva-to-fse-autonomous-workflow` skill. The generated
+`docs/NEXT-STEPS.md` spells this out.
+
+> **Requires `bash`.** The canva path shells out to the `scripts/canva-fse/*.sh`
+> helpers (the same scripts the agent and the `canva-e2e` CI job use), so `bash` must
+> be on `PATH`. This is the only wizard starter with that requirement.
 
 ## Multisite
 
@@ -124,7 +169,10 @@ A successful run produces:
 ├── .env                  ← from .env.example, with your values
 │                            (includes WP_MULTISITE / WP_MULTISITE_MODE when --multisite)
 ├── themes/<slug>/        ← scaffolded theme (skipped for figma/indesign)
-├── docs/NEXT-STEPS.md    ← only for figma/indesign starters
+│   ├── patterns/canva-content.php      ← canva starter only (converted content)
+│   ├── templates/front-page.html       ← canva starter only (references the pattern)
+│   └── assets/                          ← canva starter only (copied export images)
+├── docs/NEXT-STEPS.md    ← figma / indesign / canva starters
 └── .git/                 ← fresh repo, one commit (unless --no-git)
 ```
 
@@ -142,7 +190,8 @@ After the apply phase, the wizard runs static checks:
 4. `themes/<slug>/templates/index.html` exists
 
 Steps 2–4 are skipped for `figma` and `indesign` starters since they don't
-generate a theme directly.
+generate a theme directly. The `canva` starter *does* generate a theme, so all
+four checks run against it.
 
 A verification failure leaves the scaffold in place so you can fix and re-run.
 

--- a/scripts/init.mjs
+++ b/scripts/init.mjs
@@ -13,7 +13,9 @@ function usage() {
 Options:
   --yes                 Non-interactive mode (uses defaults / flag values)
   --name <slug>         Project slug
-  --theme <starter>     blank | flavian-shop | figma | indesign
+  --theme <starter>     blank | flavian-shop | figma | indesign | canva
+  --canva               Shorthand for --theme=canva (needs --canva-export)
+  --canva-export <dir>  Canva HTML/CSS export directory (required for canva)
   --woo                 Enable WooCommerce
   --multisite           Configure a WordPress multisite network
   --multisite-mode <m>  subdirectory | subdomain (default subdirectory)
@@ -34,11 +36,19 @@ async function getGitEmail() {
 async function main() {
   let parsed;
   try {
+    // pnpm forwards the `--` separator literally on some platforms (notably
+    // Windows), e.g. `node scripts/init.mjs "--" "--yes"`. The wizard takes no
+    // positionals, so drop any bare `--` token — this makes both
+    // `pnpm run init -- --yes …` and `pnpm run init --yes …` work identically.
+    const argv = process.argv.slice(2).filter(a => a !== '--');
     parsed = parseArgs({
+      args: argv,
       options: {
         yes:    { type: 'boolean' },
         name:   { type: 'string' },
         theme:  { type: 'string' },
+        canva:  { type: 'boolean' },
+        'canva-export': { type: 'string' },
         woo:    { type: 'boolean' },
         multisite: { type: 'boolean' },
         'multisite-mode': { type: 'string' },
@@ -68,6 +78,11 @@ async function main() {
     process.exit(2);
   }
 
+  if (parsed.values['canva-export'] != null && !parsed.values.canva && parsed.values.theme !== 'canva') {
+    console.error('Error: --canva-export requires --canva (or --theme=canva)');
+    process.exit(2);
+  }
+
   const targetDir = process.cwd();
   const env = { cwdBasename: basename(targetDir), gitEmail: await getGitEmail() };
 
@@ -77,6 +92,8 @@ async function main() {
       config = resolveDefaults({
         name: parsed.values.name,
         theme: parsed.values.theme,
+        canva: parsed.values.canva,
+        canvaExport: parsed.values['canva-export'],
         woo: parsed.values.woo,
         multisite: parsed.values.multisite,
         multisiteMode: parsed.values['multisite-mode'],
@@ -101,6 +118,12 @@ async function main() {
     process.exit(1);
   }
 
+  const canvaSteps = config.themeStarter === 'canva' ? `
+Canva export converted into themes/${config.projectName}/ (tokens → theme.json,
+content → patterns/canva-content.php → templates/front-page.html). Refine it with
+the canva-fse-converter agent — see docs/NEXT-STEPS.md.
+` : '';
+
   const multisiteSteps = config.multisite ? `
 Multisite (${config.multisiteMode}) is configured in .env. To build the network:
   ./wordpress-local.sh install   # runs wp core multisite-install in ${config.multisiteMode} mode
@@ -116,7 +139,7 @@ Next steps:
   cp .env.example .env       # already done — review values
   docker compose up -d        # boot WordPress at http://localhost:${config.port}
   open http://localhost:${config.port}/wp-admin
-${multisiteSteps}
+${canvaSteps}${multisiteSteps}
 Resources:
   - Theme:   themes/${config.projectName}/
   - Docs:    CLAUDE.md, docs/QUICK-START.md, docs/CLI-WIZARD.md

--- a/scripts/init/default-resolver.mjs
+++ b/scripts/init/default-resolver.mjs
@@ -1,6 +1,6 @@
 import { slugify, titleCase } from './slugify.mjs';
 
-const VALID_THEMES = ['blank', 'flavian-shop', 'figma', 'indesign'];
+const VALID_THEMES = ['blank', 'flavian-shop', 'figma', 'indesign', 'canva'];
 const VALID_MULTISITE_MODES = ['subdirectory', 'subdomain'];
 
 export function resolveDefaults(flags, env) {
@@ -8,9 +8,28 @@ export function resolveDefaults(flags, env) {
     ? slugify(flags.name)
     : slugify(env.cwdBasename || 'flavian-site');
 
-  const themeStarter = flags.theme ?? 'blank';
+  // The --canva shorthand selects the `canva` starter. It must not contradict an
+  // explicit --theme (e.g. `--canva --theme=blank`).
+  let themeStarter;
+  if (flags.canva) {
+    if (flags.theme && flags.theme !== 'canva') {
+      throw new Error(`--canva conflicts with --theme=${flags.theme} (drop one)`);
+    }
+    themeStarter = 'canva';
+  } else {
+    themeStarter = flags.theme ?? 'blank';
+  }
   if (!VALID_THEMES.includes(themeStarter)) {
     throw new Error(`Unknown theme starter: ${themeStarter} (expected one of ${VALID_THEMES.join(', ')})`);
+  }
+
+  // The Canva starter converts a real export, so an export path is mandatory.
+  const canvaExport = flags.canvaExport ?? null;
+  if (themeStarter === 'canva' && !canvaExport) {
+    throw new Error('Canva starter requires an export path: pass --canva-export=<dir>');
+  }
+  if (canvaExport && themeStarter !== 'canva') {
+    throw new Error('--canva-export requires --canva (or --theme=canva)');
   }
 
   const woocommerce = themeStarter === 'flavian-shop' ? true : Boolean(flags.woo);
@@ -25,6 +44,7 @@ export function resolveDefaults(flags, env) {
     projectName,
     siteTitle: flags.title ?? titleCase(projectName),
     themeStarter,
+    canvaExport,
     woocommerce,
     multisite,
     multisiteMode,

--- a/scripts/init/generators/canva.mjs
+++ b/scripts/init/generators/canva.mjs
@@ -1,0 +1,311 @@
+// Canva starter generator.
+//
+// Unlike the `figma` starter (which only stages a NEXT-STEPS.md), the Canva path
+// produces a *working* FSE theme deterministically from an HTML/CSS export so CI
+// and scripted setups can run it with no prompts. It does this by composing the
+// same deterministic helper scripts the canva-fse-converter agent relies on:
+//
+//   1. Copy the blank FSE theme as a valid base scaffold.
+//   2. parse-canva-export.sh  → design tokens merged into theme.json.
+//   3. convert-html-to-blocks.sh → page content written as a pattern, wired into
+//      templates/front-page.html (pattern-first: PHP/images live in the pattern,
+//      never in the .html template).
+//
+// The result is a deterministic baseline. The canva-fse-converter agent / the
+// canva-to-fse-autonomous-workflow skill refine it into production output.
+
+import { readdir, readFile, writeFile, mkdir, copyFile, access } from 'node:fs/promises';
+import { constants } from 'node:fs';
+import { join, dirname, extname, isAbsolute, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { copyBlankBase } from './theme.mjs';
+
+const exec = promisify(execFile);
+
+// The canva-fse helper scripts belong to the wizard's own repo (not the target
+// project), so resolve them relative to this module.
+const SCRIPT = (name) => fileURLToPath(new URL(`../../canva-fse/${name}`, import.meta.url));
+const PARSE_SCRIPT = SCRIPT('parse-canva-export.sh');
+const CONVERT_SCRIPT = SCRIPT('convert-html-to-blocks.sh');
+
+const PATTERN_SLUG = 'canva-content';
+const IMAGE_EXTS = new Set(['.jpg', '.jpeg', '.png', '.gif', '.webp', '.svg', '.avif', '.ico']);
+
+// --- pure helpers (unit-tested) -------------------------------------------
+
+/** Keep the first entry per slug, preserving order. */
+export function dedupeBySlug(items) {
+  const seen = new Set();
+  const out = [];
+  for (const item of items ?? []) {
+    if (!item || seen.has(item.slug)) continue;
+    seen.add(item.slug);
+    out.push(item);
+  }
+  return out;
+}
+
+/** Relative luminance (0–255) of a #rgb / #rrggbb color; null if unparseable. */
+export function luminance(hex) {
+  let h = String(hex).trim().replace(/^#/, '');
+  if (h.length === 3) h = h.split('').map(c => c + c).join('');
+  if (!/^[0-9a-fA-F]{6}$/.test(h)) return null;
+  const r = parseInt(h.slice(0, 2), 16);
+  const g = parseInt(h.slice(2, 4), 16);
+  const b = parseInt(h.slice(4, 6), 16);
+  return 0.299 * r + 0.587 * g + 0.114 * b;
+}
+
+/**
+ * Choose background (lightest) and text (darkest) slugs from a palette so the
+ * theme's default colors reflect the Canva design. Returns null when fewer than
+ * two usable, distinct colors exist (caller falls back gracefully).
+ */
+export function pickContrastColors(palette) {
+  const scored = (palette ?? [])
+    .map(c => ({ slug: c.slug, lum: luminance(c.color) }))
+    .filter(c => c.lum !== null);
+  if (scored.length < 2) return null;
+  let lightest = scored[0];
+  let darkest = scored[0];
+  for (const c of scored) {
+    if (c.lum > lightest.lum) lightest = c;
+    if (c.lum < darkest.lum) darkest = c;
+  }
+  if (lightest.slug === darkest.slug) return null;
+  return { backgroundSlug: lightest.slug, textSlug: darkest.slug };
+}
+
+const presetVar = (kind, slug) => `var(--wp--preset--${kind}--${slug})`;
+
+/**
+ * Merge Canva-extracted tokens into a base theme.json object. Replaces token
+ * arrays where Canva provided values, and rewrites the `styles` references that
+ * would otherwise dangle (the base uses slugs like `surface`/`system` that the
+ * replacement removes). Returns a new object; does not mutate `base`.
+ */
+export function mergeCanvaTokens(base, tokens) {
+  const out = structuredClone(base);
+  out.settings ??= {};
+  const colors = dedupeBySlug(tokens.colors);
+  const fonts = dedupeBySlug(tokens.fonts);
+  const fontSizes = dedupeBySlug(tokens.fontSizes);
+  const spacing = dedupeBySlug(tokens.spacing);
+
+  if (colors.length) {
+    out.settings.color = { ...(out.settings.color ?? {}), palette: colors };
+    out.styles ??= {};
+    const contrast = pickContrastColors(colors);
+    out.styles.color = contrast
+      ? {
+          background: presetVar('color', contrast.backgroundSlug),
+          text: presetVar('color', contrast.textSlug),
+        }
+      : { text: presetVar('color', colors[0].slug) };
+  }
+
+  if (fonts.length) {
+    out.settings.typography = { ...(out.settings.typography ?? {}), fontFamilies: fonts };
+    out.styles ??= {};
+    out.styles.typography = {
+      ...(out.styles.typography ?? {}),
+      fontFamily: presetVar('font-family', fonts[0].slug),
+    };
+  }
+
+  if (fontSizes.length) {
+    out.settings.typography = { ...(out.settings.typography ?? {}), fontSizes };
+  }
+
+  if (spacing.length) {
+    out.settings.spacing = { ...(out.settings.spacing ?? {}), spacingSizes: spacing };
+  }
+
+  return out;
+}
+
+/**
+ * Strip the leading HTML-document chrome (DOCTYPE/head/body…) the converter
+ * echoes verbatim, keeping the block markup from the first `<!-- wp:` onward.
+ */
+export function cleanConvertedBlocks(output) {
+  const lines = String(output).split('\n');
+  const start = lines.findIndex(l => l.trimStart().startsWith('<!-- wp:'));
+  const kept = start >= 0 ? lines.slice(start) : lines;
+  return kept.join('\n').replace(/\s+$/, '');
+}
+
+/**
+ * Rewrite relative `<img src>` values to theme-asset URIs (the reason converted
+ * content must live in a PHP pattern, not an .html template). Absolute URLs,
+ * root-relative and data: srcs are left untouched. Returns the rewritten markup
+ * plus the set of relative asset paths to copy into the theme.
+ */
+export function rewriteImageSrcs(markup) {
+  const assets = new Set();
+  const out = String(markup).replace(/(<img\b[^>]*?\bsrc=")([^"]+)(")/gi, (m, pre, src, post) => {
+    if (/^(https?:)?\/\//i.test(src) || src.startsWith('/') || src.startsWith('data:') || src.includes('<?php')) {
+      return m;
+    }
+    assets.add(src);
+    const safe = src.replace(/'/g, '');
+    return `${pre}<?php echo esc_url( get_theme_file_uri( 'assets/${safe}' ) ); ?>${post}`;
+  });
+  return { markup: out, assets: [...assets] };
+}
+
+/** Slug → PascalCase package name (`my-shop` → `MyShop`). */
+export function packageName(slug) {
+  return String(slug)
+    .split('-')
+    .filter(Boolean)
+    .map(w => w[0].toUpperCase() + w.slice(1))
+    .join('') || 'Theme';
+}
+
+function patternFile(slug, markup) {
+  const pkg = packageName(slug);
+  return `<?php
+/**
+ * Title: Canva Content
+ * Slug: ${slug}/${PATTERN_SLUG}
+ * Categories: featured
+ * Description: Homepage content imported from a Canva export by the Flavian init wizard. Refine with the canva-fse-converter agent for production.
+ *
+ * @package ${pkg}
+ */
+
+?>
+${markup}
+`;
+}
+
+function frontPageTemplate(slug) {
+  return `<!-- wp:template-part {"slug":"header","tagName":"header"} /-->
+
+<!-- wp:pattern {"slug":"${slug}/${PATTERN_SLUG}"} /-->
+
+<!-- wp:template-part {"slug":"footer","tagName":"footer"} /-->
+`;
+}
+
+function nextSteps(slug) {
+  return `# Next Steps — Canva Import
+
+The Flavian init wizard generated a working FSE theme from your Canva export:
+
+- Design tokens (colors, typography, spacing) were extracted from your CSS into \`themes/${slug}/theme.json\`.
+- Your exported page content was converted to WordPress blocks in
+  \`themes/${slug}/patterns/${PATTERN_SLUG}.php\` and wired into \`templates/front-page.html\`.
+- Referenced images were copied into \`themes/${slug}/assets/\`.
+
+This is a deterministic baseline. For a production-quality pass (layout,
+semantics, responsiveness), point Claude Code at your export directory:
+
+> "Convert this Canva export to a WordPress theme"
+
+…which runs the \`canva-fse-converter\` agent / \`canva-to-fse-autonomous-workflow\` skill.
+`;
+}
+
+// --- script bridges -------------------------------------------------------
+
+async function runScript(scriptPath, args) {
+  try {
+    const { stdout } = await exec('bash', [scriptPath, ...args], { maxBuffer: 16 * 1024 * 1024 });
+    return stdout;
+  } catch (err) {
+    if (err.code === 'ENOENT') {
+      throw new Error('The Canva starter needs `bash` on PATH (it runs scripts/canva-fse/*.sh).');
+    }
+    const detail = (err.stderr || err.message || '').trim();
+    throw new Error(`Canva conversion script failed (${scriptPath}): ${detail}`);
+  }
+}
+
+/** Locate the CSS and HTML entry files in an export directory. */
+async function findExportFiles(exportDir) {
+  let entries;
+  try {
+    entries = await readdir(exportDir);
+  } catch {
+    throw new Error(`Canva export directory not found: ${exportDir}`);
+  }
+  const pick = (exts, preferred) => {
+    const matches = entries.filter(f => exts.includes(extname(f).toLowerCase())).sort();
+    return matches.find(f => f.toLowerCase() === preferred) ?? matches[0] ?? null;
+  };
+  const css = pick(['.css'], 'style.css');
+  const html = pick(['.html', '.htm'], 'index.html');
+  if (!css) throw new Error(`No .css file found in Canva export: ${exportDir}`);
+  if (!html) throw new Error(`No .html file found in Canva export: ${exportDir}`);
+  return { cssPath: join(exportDir, css), htmlPath: join(exportDir, html) };
+}
+
+async function pathExists(p) {
+  try { await access(p, constants.F_OK); return true; } catch { return false; }
+}
+
+// --- orchestration --------------------------------------------------------
+
+export async function setupCanvaTheme(targetDir, config) {
+  const { projectName: slug, siteTitle, canvaExport } = config;
+  if (!canvaExport) {
+    throw new Error('Canva starter requires an export path: pass --canva-export=<dir>');
+  }
+  // The user gives --canva-export relative to where they run the wizard (cwd ===
+  // targetDir for real runs); tests pass an absolute path.
+  const exportDir = isAbsolute(canvaExport) ? canvaExport : resolve(targetDir, canvaExport);
+
+  const { cssPath, htmlPath } = await findExportFiles(exportDir);
+
+  // 1. Valid base scaffold (refuses an existing themes/<slug>/, substitutes tokens).
+  await copyBlankBase(targetDir, slug, siteTitle);
+  const themeDir = join(targetDir, 'themes', slug);
+
+  // 2. Merge extracted design tokens into theme.json.
+  const tokenJson = await runScript(PARSE_SCRIPT, ['--theme-json', cssPath]);
+  let tokens;
+  try {
+    const parsed = JSON.parse(tokenJson);
+    const s = parsed.settings ?? {};
+    tokens = {
+      colors: s.color?.palette ?? [],
+      fonts: s.typography?.fontFamilies ?? [],
+      fontSizes: s.typography?.fontSizes ?? [],
+      spacing: s.spacing?.spacingSizes ?? [],
+    };
+  } catch (err) {
+    throw new Error(`parse-canva-export.sh produced invalid JSON: ${err.message}`);
+  }
+  const themeJsonPath = join(themeDir, 'theme.json');
+  const baseThemeJson = JSON.parse(await readFile(themeJsonPath, 'utf8'));
+  const merged = mergeCanvaTokens(baseThemeJson, tokens);
+  await writeFile(themeJsonPath, JSON.stringify(merged, null, 2) + '\n');
+
+  // 3. Convert page content → pattern (PHP) wired into front-page.html.
+  const rawBlocks = await runScript(CONVERT_SCRIPT, [htmlPath]);
+  const blocks = cleanConvertedBlocks(rawBlocks);
+  const { markup, assets } = rewriteImageSrcs(blocks);
+
+  await mkdir(join(themeDir, 'patterns'), { recursive: true });
+  await writeFile(join(themeDir, 'patterns', `${PATTERN_SLUG}.php`), patternFile(slug, markup));
+  await writeFile(join(themeDir, 'templates', 'front-page.html'), frontPageTemplate(slug));
+
+  // 4. Copy referenced images into the theme so they resolve.
+  for (const rel of assets) {
+    if (rel.includes('..')) continue; // never escape the export dir
+    const src = join(exportDir, rel);
+    if (extname(rel) && !IMAGE_EXTS.has(extname(rel).toLowerCase())) continue;
+    if (!await pathExists(src)) continue;
+    const dst = join(themeDir, 'assets', rel);
+    await mkdir(dirname(dst), { recursive: true });
+    await copyFile(src, dst);
+  }
+
+  // 5. Staging note bridging to the agent path.
+  await mkdir(join(targetDir, 'docs'), { recursive: true });
+  await writeFile(join(targetDir, 'docs', 'NEXT-STEPS.md'), nextSteps(slug));
+}

--- a/scripts/init/generators/theme.mjs
+++ b/scripts/init/generators/theme.mjs
@@ -37,6 +37,19 @@ async function copyBlank(targetDir, slug) {
   await cp(src, dst, { recursive: true });
 }
 
+/**
+ * Materialize the blank FSE theme into themes/<slug>/ with tokens substituted.
+ * Shared by the `blank` and `canva` starters (canva builds on this base).
+ */
+export async function copyBlankBase(targetDir, slug, siteTitle) {
+  await copyBlank(targetDir, slug);
+  await substituteTokens(join(targetDir, 'themes', slug), {
+    THEME_NAME: siteTitle,
+    THEME_SLUG: slug,
+    SITE_TITLE: siteTitle,
+  });
+}
+
 async function copyFlavianShop(targetDir, slug) {
   const src = join(targetDir, 'themes/flavian-shop');
   try {
@@ -80,17 +93,19 @@ export async function setupTheme(targetDir, config) {
 
   switch (themeStarter) {
     case 'blank':
-      await copyBlank(targetDir, slug);
-      await substituteTokens(join(targetDir, 'themes', slug), {
-        THEME_NAME: siteTitle,
-        THEME_SLUG: slug,
-        SITE_TITLE: siteTitle,
-      });
+      await copyBlankBase(targetDir, slug, siteTitle);
       break;
     case 'flavian-shop':
       await copyFlavianShop(targetDir, slug);
       await rewriteFlavianShopHeaders(targetDir, slug, siteTitle);
       break;
+    case 'canva': {
+      // Dynamic import keeps the static module graph acyclic (canva.mjs imports
+      // copyBlankBase from here).
+      const { setupCanvaTheme } = await import('./canva.mjs');
+      await setupCanvaTheme(targetDir, config);
+      break;
+    }
     case 'figma':
     case 'indesign':
       await writeNextSteps(targetDir, themeStarter, slug);

--- a/scripts/init/prompts.mjs
+++ b/scripts/init/prompts.mjs
@@ -31,10 +31,20 @@ export async function runPrompts({ cwdBasename, gitEmail }) {
     options: [
       { value: 'blank',        label: 'Blank FSE theme' },
       { value: 'flavian-shop', label: 'flavian-shop (WooCommerce-ready)' },
+      { value: 'canva',        label: 'Canva export → FSE theme' },
       { value: 'figma',        label: 'Figma import placeholder' },
       { value: 'indesign',     label: 'InDesign import placeholder (not yet implemented)' },
     ],
   }));
+
+  let canvaExport = null;
+  if (themeStarter === 'canva') {
+    canvaExport = abortIfCancelled(await text({
+      message: 'Canva export directory (contains HTML + CSS)',
+      placeholder: './canva-export',
+      validate: v => (v && v.trim() !== '' ? undefined : 'An export directory is required'),
+    }));
+  }
 
   let woocommerce = themeStarter === 'flavian-shop';
   if (!woocommerce) {
@@ -89,6 +99,7 @@ export async function runPrompts({ cwdBasename, gitEmail }) {
     projectName,
     siteTitle,
     themeStarter,
+    canvaExport,
     woocommerce,
     multisite,
     multisiteMode,

--- a/tests/init/integration/smoke.test.mjs
+++ b/tests/init/integration/smoke.test.mjs
@@ -111,6 +111,62 @@ test('figma placeholder — writes NEXT-STEPS.md, no theme dir', async (t) => {
   await assert.rejects(() => access(join(dir, 'themes/smoke-figma'), constants.F_OK));
 });
 
+test('canva — --yes --canva --canva-export produces a working theme', async (t) => {
+  const dir = await stageFixture();
+  t.after(() => rm(dir, { recursive: true, force: true }));
+
+  const fixture = join(REPO_ROOT, 'tests/fixtures/canva/landing');
+  const { stdout } = await exec('node', ['scripts/init.mjs', '--yes', '--no-git',
+    '--canva', `--canva-export=${fixture}`, '--name=smoke-canva', '--port=8099'], { cwd: dir });
+
+  // The static verifier ran and passed (valid theme.json, style.css, index.html).
+  assert.match(stdout, /✓ theme/);
+  assert.match(stdout, /✓ verify/);
+
+  // theme.json carries Canva-extracted tokens.
+  const themeJson = JSON.parse(await readFile(join(dir, 'themes/smoke-canva/theme.json'), 'utf8'));
+  assert.ok(themeJson.settings.color.palette.some(c => c.color === '#1f6feb'));
+
+  // Content lives in a pattern referenced by front-page.html (pattern-first).
+  const front = await readFile(join(dir, 'themes/smoke-canva/templates/front-page.html'), 'utf8');
+  assert.match(front, /wp:pattern \{"slug":"smoke-canva\/canva-content"\}/);
+  const pattern = await readFile(join(dir, 'themes/smoke-canva/patterns/canva-content.php'), 'utf8');
+  assert.match(pattern, /Welcome to Acme/);
+  await access(join(dir, 'themes/smoke-canva/assets/images/hero.jpg'), constants.F_OK);
+});
+
+test('canva — --canva without --canva-export exits 2', async (t) => {
+  const dir = await stageFixture();
+  t.after(() => rm(dir, { recursive: true, force: true }));
+
+  await assert.rejects(
+    () => exec('node', ['scripts/init.mjs', '--yes', '--no-git', '--canva', '--name=x'], { cwd: dir }),
+    (err) => err.code === 2 && /export path/i.test(err.stderr)
+  );
+});
+
+test('canva — --canva-export without --canva exits 2', async (t) => {
+  const dir = await stageFixture();
+  t.after(() => rm(dir, { recursive: true, force: true }));
+
+  await assert.rejects(
+    () => exec('node', ['scripts/init.mjs', '--yes', '--no-git',
+      '--canva-export=./somewhere', '--theme=blank', '--name=x'], { cwd: dir }),
+    (err) => err.code === 2 && /requires --canva/i.test(err.stderr)
+  );
+});
+
+test('a leading "--" separator (as pnpm forwards it) is tolerated', async (t) => {
+  const dir = await stageFixture();
+  t.after(() => rm(dir, { recursive: true, force: true }));
+
+  // pnpm on some platforms passes the `--` through to the script literally.
+  const { stdout } = await exec('node', ['scripts/init.mjs', '--', '--yes', '--no-git',
+    '--name=dash-sep', '--theme=blank'], { cwd: dir });
+  assert.match(stdout, /✓ verify/);
+  await access(join(dir, 'themes/dash-sep/style.css'), constants.F_OK);
+});
+
 test('--yes refuses an existing themes/<slug> dir cleanly', async (t) => {
   const dir = await stageFixture();
   t.after(() => rm(dir, { recursive: true, force: true }));

--- a/tests/init/unit/canva-generator.test.mjs
+++ b/tests/init/unit/canva-generator.test.mjs
@@ -1,0 +1,200 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtemp, mkdir, readFile, access, rm, cp } from 'node:fs/promises';
+import { constants } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  setupCanvaTheme,
+  dedupeBySlug,
+  luminance,
+  pickContrastColors,
+  mergeCanvaTokens,
+  cleanConvertedBlocks,
+  rewriteImageSrcs,
+  packageName,
+} from '../../../scripts/init/generators/canva.mjs';
+
+const REPO_ROOT = fileURLToPath(new URL('../../../', import.meta.url));
+const FIXTURE = join(REPO_ROOT, 'tests/fixtures/canva/landing');
+
+// --- pure helpers ---------------------------------------------------------
+
+test('dedupeBySlug keeps the first entry per slug, preserving order', () => {
+  const out = dedupeBySlug([
+    { slug: '40', size: '12px' },
+    { slug: '40', size: '16px' },
+    { slug: '50', size: '24px' },
+  ]);
+  assert.deepEqual(out.map(x => x.size), ['12px', '24px']);
+});
+
+test('luminance ranks black < blue < white and rejects junk', () => {
+  assert.ok(luminance('#000000') < luminance('#1f6feb'));
+  assert.ok(luminance('#1f6feb') < luminance('#ffffff'));
+  assert.equal(luminance('not-a-color'), null);
+  assert.ok(luminance('#fff') > 200); // shorthand expands
+});
+
+test('pickContrastColors maps lightest→background, darkest→text', () => {
+  const c = pickContrastColors([
+    { slug: 'fg', color: '#1d1d1f' },
+    { slug: 'brand', color: '#1f6feb' },
+    { slug: 'bg', color: '#ffffff' },
+  ]);
+  assert.deepEqual(c, { backgroundSlug: 'bg', textSlug: 'fg' });
+});
+
+test('pickContrastColors returns null for <2 usable colors', () => {
+  assert.equal(pickContrastColors([{ slug: 'only', color: '#123456' }]), null);
+  assert.equal(pickContrastColors([]), null);
+});
+
+test('mergeCanvaTokens replaces tokens and rewrites dangling style refs', () => {
+  const base = {
+    version: 3,
+    settings: {
+      color: { palette: [{ slug: 'surface', color: '#fff', name: 'Surface' }] },
+      typography: { fontFamilies: [{ slug: 'system', fontFamily: 'system-ui', name: 'System' }] },
+    },
+    styles: {
+      color: { background: 'var(--wp--preset--color--surface)', text: 'var(--wp--preset--color--primary)' },
+      typography: { fontFamily: 'var(--wp--preset--font-family--system)', lineHeight: '1.6' },
+    },
+  };
+  const out = mergeCanvaTokens(base, {
+    colors: [
+      { slug: 'c-dark', color: '#111111', name: 'C1' },
+      { slug: 'c-light', color: '#fefefe', name: 'C2' },
+    ],
+    fonts: [{ slug: 'inter', fontFamily: 'Inter', name: 'Inter' }],
+    fontSizes: [{ slug: 'base', size: '16px', name: 'base' }],
+    spacing: [{ slug: '40', size: '12px', name: 'Space 40' }],
+  });
+
+  // Tokens replaced.
+  assert.deepEqual(out.settings.color.palette.map(c => c.slug), ['c-dark', 'c-light']);
+  assert.equal(out.settings.typography.fontFamilies[0].slug, 'inter');
+  assert.equal(out.settings.typography.fontSizes[0].slug, 'base');
+  assert.equal(out.settings.spacing.spacingSizes[0].slug, '40');
+
+  // Style refs point only at slugs that now exist (no dangling surface/primary/system).
+  assert.equal(out.styles.color.background, 'var(--wp--preset--color--c-light)');
+  assert.equal(out.styles.color.text, 'var(--wp--preset--color--c-dark)');
+  assert.equal(out.styles.typography.fontFamily, 'var(--wp--preset--font-family--inter)');
+  assert.equal(out.styles.typography.lineHeight, '1.6'); // preserved
+
+  // Input not mutated.
+  assert.equal(base.settings.color.palette[0].slug, 'surface');
+});
+
+test('mergeCanvaTokens leaves base untouched when no tokens extracted', () => {
+  const base = { settings: { color: { palette: [{ slug: 'surface', color: '#fff' }] } }, styles: { color: { text: 'x' } } };
+  const out = mergeCanvaTokens(base, { colors: [], fonts: [], fontSizes: [], spacing: [] });
+  assert.deepEqual(out.settings.color.palette[0].slug, 'surface');
+  assert.deepEqual(out.styles.color, { text: 'x' });
+});
+
+test('cleanConvertedBlocks strips leading HTML-document chrome', () => {
+  const raw = [
+    '<!DOCTYPE html>',
+    '<head>',
+    '<body>',
+    '<!-- wp:heading {"level":1} -->',
+    '<h1 class="wp-block-heading">Hi</h1>',
+    '<!-- /wp:heading -->',
+    '',
+  ].join('\n');
+  const out = cleanConvertedBlocks(raw);
+  assert.ok(out.startsWith('<!-- wp:heading'));
+  assert.doesNotMatch(out, /DOCTYPE|<head>|<body>/);
+});
+
+test('rewriteImageSrcs rewrites relative srcs and records assets, leaving URLs alone', () => {
+  const input =
+    '<img src="images/hero.jpg" alt="a" />\n' +
+    '<img src="https://cdn.example/x.png" alt="b" />\n' +
+    '<img src="/root.png" alt="c" />';
+  const { markup, assets } = rewriteImageSrcs(input);
+  assert.match(markup, /get_theme_file_uri\( 'assets\/images\/hero\.jpg' \)/);
+  assert.match(markup, /src="https:\/\/cdn\.example\/x\.png"/); // untouched
+  assert.match(markup, /src="\/root\.png"/);                    // untouched
+  assert.deepEqual(assets, ['images/hero.jpg']);
+});
+
+test('packageName produces a PascalCase package token', () => {
+  assert.equal(packageName('my-canva-shop'), 'MyCanvaShop');
+  assert.equal(packageName('shop'), 'Shop');
+});
+
+// --- full generator against the committed fixture -------------------------
+
+async function stageTarget() {
+  const dir = await mkdtemp(join(tmpdir(), 'canva-gen-'));
+  await mkdir(join(dir, '.claude/templates'), { recursive: true });
+  await cp(join(REPO_ROOT, '.claude/templates/theme'), join(dir, '.claude/templates/theme'), { recursive: true });
+  return dir;
+}
+
+test('setupCanvaTheme builds a working theme from the fixture export', async (t) => {
+  const dir = await stageTarget();
+  t.after(() => rm(dir, { recursive: true, force: true }));
+
+  await setupCanvaTheme(dir, {
+    projectName: 'acme',
+    siteTitle: 'Acme',
+    canvaExport: FIXTURE,
+  });
+
+  const themeDir = join(dir, 'themes/acme');
+
+  // Base scaffold present → satisfies the wizard verifier.
+  await access(join(themeDir, 'style.css'), constants.F_OK);
+  await access(join(themeDir, 'templates/index.html'), constants.F_OK);
+
+  // theme.json: valid JSON carrying the Canva-extracted tokens.
+  const themeJson = JSON.parse(await readFile(join(themeDir, 'theme.json'), 'utf8'));
+  const hexes = themeJson.settings.color.palette.map(c => c.color);
+  assert.ok(hexes.includes('#1f6feb'), 'extracted Canva brand color present');
+  assert.ok(themeJson.settings.typography.fontFamilies.some(f => f.fontFamily === 'Inter'));
+  assert.ok(themeJson.settings.typography.fontSizes.length >= 3);
+  assert.ok(themeJson.settings.spacing.spacingSizes.length >= 3);
+  // No duplicate spacing slugs survived the merge.
+  const spacingSlugs = themeJson.settings.spacing.spacingSizes.map(s => s.slug);
+  assert.equal(new Set(spacingSlugs).size, spacingSlugs.length);
+  // Style refs resolve to existing palette slugs (lightest=bg, darkest=text).
+  assert.match(themeJson.styles.color.background, /var\(--wp--preset--color--/);
+  const paletteSlugs = new Set(themeJson.settings.color.palette.map(c => c.slug));
+  for (const ref of [themeJson.styles.color.background, themeJson.styles.color.text]) {
+    const slug = ref.match(/color--([^)]+)\)/)[1];
+    assert.ok(paletteSlugs.has(slug), `style ref ${slug} exists in palette`);
+  }
+
+  // Content converted into a pattern, wired into front-page.html (pattern-first).
+  const front = await readFile(join(themeDir, 'templates/front-page.html'), 'utf8');
+  assert.match(front, /wp:pattern \{"slug":"acme\/canva-content"\}/);
+  assert.doesNotMatch(front, /<\?php/, 'no PHP in HTML templates');
+
+  const pattern = await readFile(join(themeDir, 'patterns/canva-content.php'), 'utf8');
+  assert.match(pattern, /Slug:\s*acme\/canva-content/);
+  assert.match(pattern, /Welcome to Acme/);
+  assert.match(pattern, /get_theme_file_uri\( 'assets\/images\/hero\.jpg' \)/);
+
+  // Referenced image copied into the theme.
+  await access(join(themeDir, 'assets/images/hero.jpg'), constants.F_OK);
+
+  // Bridge doc for the agent refinement pass.
+  const next = await readFile(join(dir, 'docs/NEXT-STEPS.md'), 'utf8');
+  assert.match(next, /canva-fse-converter/);
+});
+
+test('setupCanvaTheme fails clearly when the export directory is missing', async (t) => {
+  const dir = await stageTarget();
+  t.after(() => rm(dir, { recursive: true, force: true }));
+
+  await assert.rejects(
+    () => setupCanvaTheme(dir, { projectName: 'x', siteTitle: 'X', canvaExport: join(dir, 'nope') }),
+    /export directory not found/i
+  );
+});

--- a/tests/init/unit/default-resolver.test.mjs
+++ b/tests/init/unit/default-resolver.test.mjs
@@ -76,3 +76,53 @@ test('invalid multisite mode throws', () => {
     /multisite mode/i
   );
 });
+
+test('canvaExport is null for non-canva starters', () => {
+  const cfg = resolveDefaults({ theme: 'blank' }, { cwdBasename: 'x', gitEmail: null });
+  assert.equal(cfg.canvaExport, null);
+});
+
+test('--canva selects the canva starter and keeps the export path', () => {
+  const cfg = resolveDefaults(
+    { canva: true, canvaExport: './export', name: 'shop' },
+    { cwdBasename: 'x', gitEmail: null }
+  );
+  assert.equal(cfg.themeStarter, 'canva');
+  assert.equal(cfg.canvaExport, './export');
+});
+
+test('--theme=canva is equivalent to --canva', () => {
+  const cfg = resolveDefaults(
+    { theme: 'canva', canvaExport: './export' },
+    { cwdBasename: 'x', gitEmail: null }
+  );
+  assert.equal(cfg.themeStarter, 'canva');
+  assert.equal(cfg.canvaExport, './export');
+});
+
+test('canva starter without an export path throws', () => {
+  assert.throws(
+    () => resolveDefaults({ canva: true }, { cwdBasename: 'x', gitEmail: null }),
+    /export path/i
+  );
+});
+
+test('--canva conflicting with --theme=blank throws', () => {
+  assert.throws(
+    () => resolveDefaults(
+      { canva: true, theme: 'blank', canvaExport: './export' },
+      { cwdBasename: 'x', gitEmail: null }
+    ),
+    /conflicts/i
+  );
+});
+
+test('--canva-export without the canva starter throws', () => {
+  assert.throws(
+    () => resolveDefaults(
+      { theme: 'blank', canvaExport: './export' },
+      { cwdBasename: 'x', gitEmail: null }
+    ),
+    /requires --canva/i
+  );
+});


### PR DESCRIPTION
Closes #87.

## What

Adds non-interactive Canva support to `scripts/init.mjs`, mirroring the existing Figma flags so CI and scripted setups can use Canva without prompts:

```bash
pnpm run init -- --yes --canva --canva-export=path/to/export --name=landing
```

`--canva` is shorthand for `--theme=canva`; both require `--canva-export=<dir>` (a directory with at least one `.css` and one `.html`, prefers `style.css`/`index.html`).

Unlike `figma` (which only writes a `NEXT-STEPS.md`), the `canva` starter produces a **real, activatable FSE theme** by composing the deterministic `scripts/canva-fse/*` helpers — the same pieces the `canva-fse-converter` agent relies on — on top of the blank base:

1. **Base** — copies the blank FSE scaffold (guarantees a valid `theme.json` / `style.css` / `templates/index.html`).
2. **Tokens** — `parse-canva-export.sh` extracts colors/fonts/sizes/spacing into `theme.json`; lightest/darkest colors are wired to default background/text and the first font to the body, deduped by slug, with **no dangling `styles` references**.
3. **Content** — `convert-html-to-blocks.sh` output is written to `patterns/canva-content.php` and referenced from `templates/front-page.html` — **pattern-first** (no PHP/images in `.html`).
4. **Assets** — referenced images copied into `assets/`, with `<img src>` rewritten to `get_theme_file_uri()`.

A `docs/NEXT-STEPS.md` bridges to the `canva-to-fse-autonomous-workflow` skill for a production-quality (agent) pass. This wizard output is intentionally a **deterministic baseline** — per the fixture README, the polished converter is an LLM agent that can't run reproducibly in CI.

## Bonus fix

The documented `pnpm run init -- …` form was actually broken: pnpm forwards the `--` separator to the script literally on some platforms (notably Windows), and `parseArgs` then treated everything after it as positionals. The wizard takes no positionals, so we now strip bare `--` from argv — fixing the AC command *and* the latent breakage for **all** starters. Guarded by a regression test.

## Acceptance criteria

- [x] `pnpm run init -- --yes --canva --canva-export=path/to/export` produces a working theme from a Canva export
- [x] Wizard tests cover the Canva non-interactive branch
- [x] Docs updated in `docs/CLI-WIZARD.md`

## Test plan

- `pnpm run test:init` → **71/71 pass** (added: 7 resolver cases, new `tests/init/unit/canva-generator.test.mjs` covering the pure helpers + a full run against `tests/fixtures/canva/landing`, smoke tests for the happy path + `--canva`/`--canva-export` guards + the `--` separator guard).
- `pnpm test:canva-e2e` → still green (the helper-script output contract is unchanged).
- **Exact AC command** run end-to-end → `✓ verify`, all theme files present with Canva tokens + content.
- **Live render** (deployed the generated theme to the Docker WP stack, activated it): front page returns **HTTP 200**, hero heading / features / list items / hero image all render, the `Inter` font is applied, and **0 PHP fatals** (page + `debug.log`). `php -l` clean on the generated pattern + `functions.php`.

## Notes for reviewers

- CI: `.github/workflows/init-wizard.yml` now also watches `scripts/canva-fse/**` and `tests/fixtures/canva/**` (the canva path depends on them), closing a coverage gap.
- The canva path shells out to `bash` (the only wizard starter that does) — documented in `docs/CLI-WIZARD.md`. CI is Linux; consistent with how `canva-e2e` already invokes these scripts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
