### PR TITLE
docs(gui): close Setup wizard doc gaps (#102)

### DIFF
--- a/docs/CLI-WIZARD.md
+++ b/docs/CLI-WIZARD.md
@@ -4,6 +4,12 @@
 optionally stages WooCommerce, and creates an initial git commit. Run it once after
 cloning the template (or after `composer create-project`).
 
+> **Prefer a GUI?** Flavian's desktop app has a **Setup wizard** screen that wraps this
+> exact flow — it collects the same inputs and runs the wizard's `apply()` /
+> `resolveDefaults()` in-process, so the GUI and CLI share one code path (no duplicated
+> setup logic). See **[GUI.md](GUI.md)**. This page remains the reference for the prompts
+> and flags the wizard form maps onto.
+
 ## Running the wizard
 
 ```bash

--- a/docs/GUI.md
+++ b/docs/GUI.md
@@ -60,6 +60,12 @@ Figma `claude` session and `docker logs -f`).
 | **Convert design** | Launches a Figma, Canva, or InDesign conversion and streams progress. | `claude -p` / init canva path / `flavian pipeline indesign` |
 | **Visual QA** | Runs visual-diff + Lighthouse and renders the artifacts (diff triptychs, scores, report). | `pnpm visual:diff` / `pnpm lighthouse:run` |
 
+The **Setup wizard** mirrors `pnpm run init` — the same inputs and flags documented in
+**[CLI-WIZARD.md](CLI-WIZARD.md)** — and runs the wizard's `apply()` / `resolveDefaults()`
+in-process (one shared code path, no duplicated setup logic) rather than spawning the CLI.
+It surfaces each step (`.env` written, theme scaffolded, git commit) as a streamed log with
+success/error states, and validates inputs (via `resolveDefaults`) before running.
+
 ## Commands
 
 From the repo root:


### PR DESCRIPTION
Closes #102. Part of #100. Milestone v3.0.0.

The Setup-wizard UI itself shipped in #129 (form mirroring `pnpm run init`, flag
mapping, streamed `.env`/theme/git output, pre-run validation). The only unmet
acceptance criterion was the **docs cross-link**, addressed here.

- `docs/CLI-WIZARD.md` now points to the GUI's Setup wizard.
- `docs/GUI.md` links back to `CLI-WIZARD.md` and states explicitly that the GUI
  runs the wizard's `apply()` / `resolveDefaults()` **in-process** — one shared
  code path with the CLI, no duplicated setup logic (rather than spawning
  `scripts/init.mjs`, which would be a second code path).

### Criteria
- [x] Form mirrors the `pnpm run init` prompts — #129
- [x] Maps to existing flags; no duplicated setup logic (in-process shared path) — #129
- [x] Wizard output surfaced with success/error states — #129
- [x] Validation before invoking — #129
- [x] Documented in `docs/GUI.md` and cross-linked from `docs/CLI-WIZARD.md` — **this PR**

> Stacked on #133 (`101-…`); base retargets to `main` once #133 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
