### PR TITLE
feat(gui): close Docker-controls gaps (#104)

### DIFF
--- a/docs/GUI.md
+++ b/docs/GUI.md
@@ -56,7 +56,7 @@ Figma `claude` session and `docker logs -f`).
 | --- | --- | --- |
 | **Prerequisites** | Runs the prereq check and shows a pass/fail checklist with actionable guidance. | `scripts/check-prerequisites.sh` |
 | **Setup wizard** | Scaffolds a project (slug, theme starter, Canva/Woo/multisite/port…). | `scripts/init/` `resolveDefaults()` + `apply()` (in-process) |
-| **WordPress (Docker)** | Build/start/stop/restart/install, live container status, theme activation, log streaming. | `wordpress-local.sh` + `docker compose` |
+| **WordPress (Docker)** | Build/start/stop/restart/install, live container status, theme activation, log streaming; quick links to the site / wp-admin / phpMyAdmin, first-run ordering guidance, and actionable error hints (Docker not running, port conflicts) linking to `docs/docker-troubleshooting.md`. | `wordpress-local.sh` + `docker compose` |
 | **Convert design** | Launches a Figma, Canva, or InDesign conversion and streams progress. | `claude -p` / init canva path / `flavian pipeline indesign` |
 | **Visual QA** | Runs visual-diff + Lighthouse and renders the artifacts (diff triptychs, scores, report). | `pnpm visual:diff` / `pnpm lighthouse:run` |
 

--- a/packages/gui/src/main/ipc/register-handlers.ts
+++ b/packages/gui/src/main/ipc/register-handlers.ts
@@ -1,4 +1,5 @@
-import { BrowserWindow, dialog, ipcMain } from 'electron';
+import { BrowserWindow, dialog, ipcMain, shell } from 'electron';
+import { isAbsolute, relative, resolve } from 'node:path';
 import { IPC } from '../../shared/ipc-channels';
 import type { DockerCommand, DockerService } from '../../shared/types/docker';
 import type { InitInput, InitResult } from '../../shared/types/init';
@@ -176,6 +177,20 @@ export function registerHandlers(deps: HandlerDeps): void {
   ipcMain.handle(IPC.qaText, (_event, relPath: string): Promise<string | null> =>
     readTextArtifact(deps.project.current.root, relPath),
   );
+
+  ipcMain.handle(IPC.openExternal, async (_event, url: string): Promise<void> => {
+    if (/^https?:\/\//i.test(url)) await shell.openExternal(url);
+  });
+
+  ipcMain.handle(IPC.openPath, async (_event, relPath: string): Promise<string> => {
+    // Open a project-relative doc; refuse traversal and non-text targets.
+    const target = resolve(deps.project.current.root, relPath);
+    const rel = relative(deps.project.current.root, target).replace(/\\/g, '/');
+    if (rel === '' || rel.startsWith('../') || isAbsolute(rel) || !/\.(md|txt)$/i.test(rel)) {
+      return 'Path not allowed';
+    }
+    return shell.openPath(target);
+  });
 
   ipcMain.handle(IPC.taskSnapshot, (_event, taskId: string): TaskSnapshot | null =>
     deps.taskManager.snapshot(taskId),

--- a/packages/gui/src/preload/index.ts
+++ b/packages/gui/src/preload/index.ts
@@ -26,6 +26,8 @@ const bridge: FlavianBridge = {
   getQaArtifacts: () => ipcRenderer.invoke(IPC.qaArtifacts) as Promise<QaArtifacts>,
   readQaImage: (relPath) => ipcRenderer.invoke(IPC.qaImage, relPath) as Promise<string | null>,
   readQaText: (relPath) => ipcRenderer.invoke(IPC.qaText, relPath) as Promise<string | null>,
+  openExternal: (url) => ipcRenderer.invoke(IPC.openExternal, url) as Promise<void>,
+  openPath: (relPath) => ipcRenderer.invoke(IPC.openPath, relPath) as Promise<string>,
   getTaskSnapshot: (taskId) =>
     ipcRenderer.invoke(IPC.taskSnapshot, taskId) as Promise<TaskSnapshot | null>,
   cancelTask: (taskId) => ipcRenderer.invoke(IPC.taskCancel, taskId) as Promise<void>,

--- a/packages/gui/src/renderer/components/DockerPanel.tsx
+++ b/packages/gui/src/renderer/components/DockerPanel.tsx
@@ -12,6 +12,18 @@ const LIFECYCLE: { command: DockerCommand; label: string }[] = [
   { command: 'install', label: 'Install WP' },
 ];
 
+/** Turn a failed docker run's log into an actionable message (cf. docs/docker-troubleshooting.md). */
+function dockerErrorHint(lines: string[]): string {
+  const text = lines.join('\n').toLowerCase();
+  if (/cannot connect to the docker daemon|docker daemon|daemon running/.test(text)) {
+    return "Docker doesn't appear to be running. Start Docker Desktop, then retry.";
+  }
+  if (/port is already allocated|address already in use|bind for|already in use/.test(text)) {
+    return 'A required port (8080 or 8081) is already in use. Stop the conflicting service or free the port, then retry.';
+  }
+  return 'The command failed — see the log above.';
+}
+
 export function DockerPanel() {
   const [status, setStatus] = useState<DockerService[] | null>(null);
   const [themes, setThemes] = useState<string[]>([]);
@@ -59,6 +71,10 @@ export function DockerPanel() {
   };
 
   const anyRunning = (status ?? []).some((s) => s.state === 'running');
+  const failed = active !== null && stream.state === 'failed';
+  const openExternal = (url: string): void => {
+    void bridge().openExternal(url);
+  };
 
   return (
     <section className="panel">
@@ -71,12 +87,6 @@ export function DockerPanel() {
       <p className="panel-intro">
         Drives the local Docker WordPress lifecycle via <code>wordpress-local.sh</code> and{' '}
         <code>docker compose</code>.
-        {anyRunning && (
-          <>
-            {' '}
-            Site: <span className="prereq-url">http://localhost:8080</span>
-          </>
-        )}
       </p>
 
       <div className="group">
@@ -113,8 +123,29 @@ export function DockerPanel() {
         )}
       </div>
 
+      {anyRunning && (
+        <div className="group">
+          <h2>Open</h2>
+          <div className="button-row">
+            <button type="button" onClick={() => openExternal('http://localhost:8080')}>
+              Site
+            </button>
+            <button type="button" onClick={() => openExternal('http://localhost:8080/wp-admin')}>
+              wp-admin
+            </button>
+            <button type="button" onClick={() => openExternal('http://localhost:8081')}>
+              Database (phpMyAdmin)
+            </button>
+          </div>
+        </div>
+      )}
+
       <div className="group">
         <h2>Lifecycle</h2>
+        <p className="hint-note">
+          First run: <strong>Build → Start → Install</strong> (creates the WordPress site) →{' '}
+          <strong>Activate theme</strong>. After that, just Start / Stop.
+        </p>
         <div className="button-row">
           {LIFECYCLE.map((l) => (
             <button key={l.command} type="button" disabled={busy} onClick={() => run(l.command, l.label)}>
@@ -158,6 +189,19 @@ export function DockerPanel() {
               </button>
             )}
           </div>
+          {failed && (
+            <div className="banner banner-error">
+              <strong>{active.label} failed</strong>
+              <span>{dockerErrorHint(stream.lines)}</span>
+              <button
+                type="button"
+                className="link-btn"
+                onClick={() => void bridge().openPath('docs/docker-troubleshooting.md')}
+              >
+                Open the Docker troubleshooting guide
+              </button>
+            </div>
+          )}
           <LogStream lines={stream.lines} />
         </div>
       )}

--- a/packages/gui/src/shared/ipc-channels.ts
+++ b/packages/gui/src/shared/ipc-channels.ts
@@ -20,6 +20,8 @@ export const IPC = {
   qaArtifacts: 'flavian:qa:artifacts',
   qaImage: 'flavian:qa:image',
   qaText: 'flavian:qa:text',
+  openExternal: 'flavian:shell:open-external',
+  openPath: 'flavian:shell:open-path',
   taskSnapshot: 'flavian:task:snapshot',
   taskCancel: 'flavian:task:cancel',
   // main → renderer push

--- a/packages/gui/src/shared/types/ipc.ts
+++ b/packages/gui/src/shared/types/ipc.ts
@@ -67,6 +67,13 @@ export interface FlavianBridge {
   /** Read a QA text/markdown artifact (sandboxed), or null. */
   readQaText(relPath: string): Promise<string | null>;
 
+  /** Open an http(s) URL in the user's default browser. */
+  openExternal(url: string): Promise<void>;
+
+  /** Open a project-relative doc (e.g. a troubleshooting .md) in the OS default app.
+   *  Returns '' on success or an error message. */
+  openPath(relPath: string): Promise<string>;
+
   /** Snapshot any task (state + bounded log tail). */
   getTaskSnapshot(taskId: string): Promise<TaskSnapshot | null>;
 


### PR DESCRIPTION
Closes #104. Part of #100. Milestone v3.0.0.

Lifecycle controls, live container status, theme activation, and log streaming
shipped in #129. This PR adds the remaining acceptance-criteria items.

- **Quick links** (shown when a container is running): Site, wp-admin, and
  Database/phpMyAdmin (`:8081`) — opened in the default browser via a new
  sandboxed `openExternal` bridge (http/https only).
- **First-run guidance**: Build → Start → Install → Activate ordering, mirroring
  the README quick-start.
- **Actionable errors**: a failure banner detects "Docker daemon not running" and
  port-conflict cases from the log and gives a specific next step, with a button
  that opens `docs/docker-troubleshooting.md` (new sandboxed `openPath` bridge).

### Criteria
- [x] Controls for build/start/stop/install/activate-theme — #129
- [x] Live status indicator + quick links to site / wp-admin / DB UI — **this PR**
- [x] First-run build/install ordering guidance — **this PR**
- [x] Actionable errors (Docker not running, port conflicts) + troubleshooting link — **this PR**
- [x] Shells out to `wordpress-local.sh` (no reimplementation) — #129
- [x] Documented in `docs/GUI.md` — **this PR**

> Stacked on #102 (→ #133 → main); base retargets as each merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
